### PR TITLE
Fixed JDaemonTest

### DIFF
--- a/tests/suite/joomla/application/cli/JDaemonTest.php
+++ b/tests/suite/joomla/application/cli/JDaemonTest.php
@@ -33,6 +33,9 @@ class JDaemonTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testWriteProcessIdFile()
 	{
+		if (!defined('SIGHUP')) {
+			$this->markTestSkipped( 'Test skipped because the PCNTL extension is not loaded.' );
+		}
 		// Get a new JDaemonInspector instance.
 		$daemon = new JDaemonInspector();
 

--- a/tests/suite/joomla/database/database/JDatabaseMySQLTest.php
+++ b/tests/suite/joomla/database/database/JDatabaseMySQLTest.php
@@ -59,7 +59,10 @@ class JDatabaseMySQLTest extends JoomlaDatabaseTestCase
 	 */
 	protected function setUp()
 	{
-		$config = new JTestConfig;
+		@include_once JPATH_TESTS . '/config.php';
+		if (class_exists('JTestConfig')) {
+			$config = new JTestConfig;
+		}
 		$this->object = JDatabase::getInstance(
 			array(
 				'driver' => $config->dbtype,


### PR DESCRIPTION
There was a bug in JDaemonTest that crashed the tests if the PCNTL extension wasn't available.
Test code now marks the test as skipped if the extension isn't there.
