### PR TITLE
Move the rendering of HTML link elements to JDocumentRendererHead.

### DIFF
--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -188,9 +188,9 @@ class JDocumentHTML extends JDocument
 	 */
 	public function addHeadLink($href, $relation, $relType = 'rel', $attribs = array())
 	{
-		$attribs = JArrayHelper::toString($attribs);
-		$generatedTag = '<link href="'.$href.'" '.$relType.'="'.$relation.'" '.$attribs;
-		$this->_links[] = $generatedTag;
+		$this->_links[$href]['relation']	= $relation;
+		$this->_links[$href]['relType']		= $relType;
+		$this->_links[$href]['attribs']		= $attribs;
 	}
 
 	/**
@@ -207,7 +207,7 @@ class JDocumentHTML extends JDocument
 	public function addFavicon($href, $type = 'image/vnd.microsoft.icon', $relation = 'shortcut icon')
 	{
 		$href = str_replace('\\', '/', $href);
-		$this->_links[] = '<link href="'.$href.'" rel="'.$relation.'" type="'.$type.'"';
+		$this->addHeadLink($href, $relation, 'rel', array('type' => $type));
 	}
 
 	/**

--- a/libraries/joomla/document/html/renderer/head.php
+++ b/libraries/joomla/document/html/renderer/head.php
@@ -82,8 +82,13 @@ class JDocumentRendererHead extends JDocumentRenderer
 		$buffer .= $tab.'<title>'.htmlspecialchars($document->getTitle(), ENT_COMPAT, 'UTF-8').'</title>'.$lnEnd;
 
 		// Generate link declarations
-		foreach ($document->_links as $link) {
-			$buffer .= $tab.$link.$tagEnd.$lnEnd;
+		foreach ($document->_links as $link => $linkAtrr)
+		{
+			$buffer .= $tab.'<link href="'.$link.'" '.$linkAtrr['relType'].'="'.$linkAtrr['relation'].'"';
+			if ($temp = JArrayHelper::toString($linkAtrr['attribs'])) {
+				$buffer .= ' '.$temp;
+			}
+			$buffer .= ' />'.$lnEnd;
 		}
 
 		// Generate stylesheet links


### PR DESCRIPTION
Previously discussed here: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=25251

Note: This has some small backwards compatibility consequences (e.g. if somebody chose to override either of the two classes involved) but it makes JDocument more consistent and opens up future use (head links in other types of documents).
