### PR TITLE
Use require_once instead of include in JLoader

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -87,7 +87,7 @@ abstract class JLoader
 
 				// If the file exists attempt to include it.
 				if (is_file($base.DS.$path.'.php')) {
-					$success = (bool) include $base.DS.$path.'.php';
+					$success = (bool) include_once $base.DS.$path.'.php' ;
 				}
 			}
 
@@ -198,7 +198,7 @@ abstract class JLoader
 
 		// If the class is registered include the file.
 		if (isset(self::$_classes[$class])) {
-			include self::$_classes[$class];
+			include_once self::$_classes[$class] ;
 			return true;
 		}
 


### PR DESCRIPTION
I do not know if there is a good reason for using include over require_once, if there is, please disregard this commit. All unit tests ran fine with this change.
