### PR TITLE
Fixes for #22587 and #24285

### DIFF
--- a/libraries/joomla/application/module/helper.php
+++ b/libraries/joomla/application/module/helper.php
@@ -389,7 +389,8 @@ abstract class JModuleHelper
 			$cache->setCaching(false);
 		}
 
-		$cache->setLifeTime($moduleparams->get('cache_time', $conf->get('cachetime') * 60));
+		// module cache is set in seconds, global cache in minutes, setLifeTime works in minutes
+		$cache->setLifeTime($moduleparams->get('cache_time', $conf->get('cachetime') * 60) / 60);
 
 		$wrkaroundoptions = array (
 			'nopathway' 	=> 1,

--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -389,11 +389,16 @@ class JCache extends JObject
 	 * @since   11.1
 	 */
 	public function &_getStorage()
-	{
-		if (!isset($this->_handler)) {
-			$this->_handler = JCacheStorage::getInstance($this->_options['storage'], $this->_options);
-		}
-		return $this->_handler;
+	{	
+		$hash = md5(serialize($this->_options));
+	
+		if (isset(self::$_handler[$hash])) {
+			return self::$_handler[$hash];
+ 		}
+		
+		self::$_handler[$hash] = JCacheStorage::getInstance($this->_options['storage'], $this->_options);
+		
+		return self::$_handler[$hash];
 	}
 
 	/**

--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -504,14 +504,30 @@ class JCache extends JObject
 
 		// Document head data
 		if ($loptions['nohead'] != 1) {
-			$cached['head'] = $document->getHeadData();
 
 			if ($loptions['modulemode'] == 1) {
-					unset($cached['head']['title']);
-					unset($cached['head']['description']);
-					unset($cached['head']['link']);
-					unset($cached['head']['metaTags']);
+					$headnow = $document->getHeadData();
+					$unset = array('title', 'description', 'link', 'metaTags');
+					
+					foreach ($unset AS $un) {
+						unset($headnow[$un]);
+						unset($options['headerbefore'][$un]);
+					}
+					
+					$cached['head'] = array();
+					
+					// only store what this module has added 
+					foreach ($headnow AS $now=>$value) {
+						$newvalue = array_diff_assoc($headnow[$now], isset($options['headerbefore'][$now]) ? $options['headerbefore'][$now] : array() );
+						if (!empty($newvalue)) {
+							$cached['head'][$now] = $newvalue;
+						}
+					}
+
+			} else {
+					$cached['head'] = $document->getHeadData();
 			}
+			
 		}
 
 		// Pathway data

--- a/libraries/joomla/cache/controller/callback.php
+++ b/libraries/joomla/cache/controller/callback.php
@@ -120,6 +120,15 @@ class JCacheControllerCallback extends JCacheController
 			}
 
 			if ($locktest->locked == false) $locktest = $this->cache->lock($id);
+			
+			if (isset($woptions['modulemode'])) {
+				$document	= JFactory::getDocument();
+				$coptions['modulemode'] =  $woptions['modulemode'];
+				$coptions['headerbefore'] = $document->getHeadData();
+			} else {
+				$coptions['modulemode'] = 0;
+			}
+			
 			ob_start();
 			ob_implicit_flush(false);
 
@@ -133,7 +142,6 @@ class JCacheControllerCallback extends JCacheController
 			$coptions['nopathway'] = isset($woptions['nopathway']) ? $woptions['nopathway'] : 1;
 			$coptions['nohead'] = isset($woptions['nohead']) ? $woptions['nohead'] : 1;
 			$coptions['nomodules'] = isset($woptions['nomodules']) ? $woptions['nomodules'] : 1;
-			$coptions['modulemode'] = isset($woptions['modulemode']) ? $woptions['modulemode'] : 0;
 
 			$cached['output'] = ($wrkarounds == false) ? $output : JCache::setWorkarounds($output, $coptions);
 			$cached['result'] = $result;


### PR DESCRIPTION
Issue 22587
- Change modules cache lifetime to be set as intended (seconds must be converted to minutes)
- Cache handler needs to use all parameters for static variable caching

Also $_handler is a static variable and so can't be referenced as $this->_handler  (this bug was introduced after #22587 report) - change back to self::$_handler

Issue 24285

Fix changes module caching to store only headers that changed after module was executed. Headers before and after callback are compared.
