### PR TITLE
Add batch processing to framework (Feature Request #22590)

### DIFF
--- a/libraries/joomla/application/component/controllerform.php
+++ b/libraries/joomla/application/component/controllerform.php
@@ -210,6 +210,33 @@ class JControllerForm extends JController
 	}
 
 	/**
+	 * Method to run batch operations.
+	 *
+	 * Extended classes can override this if necessary.
+	 *
+	 * @param   object   $model  The model of the component being processed.
+	 *
+	 * @return	void
+	 * @since	11.1
+	 */
+	public function batch($model)
+	{
+		// Initialise variables.
+		$app	= JFactory::getApplication();
+		$vars	= JRequest::getVar('batch', array(), 'post', 'array');
+		$cid	= JRequest::getVar('cid', array(), 'post', 'array');
+
+		// Attempt to run the batch operation.
+		if ($model->batch($vars, $cid)) {
+			$this->setMessage(JText::_('JLIB_APPLICATION_SUCCESS_BATCH'));
+			return true;
+		} else {
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_BATCH_FAILED', $model->getError()));
+			return false;
+		}
+	}
+
+	/**
 	 * Method to cancel an edit.
 	 *
 	 * @param   string  $key  The name of the primary key of the URL variable.

--- a/libraries/joomla/application/component/controllerform.php
+++ b/libraries/joomla/application/component/controllerform.php
@@ -212,11 +212,9 @@ class JControllerForm extends JController
 	/**
 	 * Method to run batch operations.
 	 *
-	 * Extended classes can override this if necessary.
+	 * @param   object	$model  The model of the component being processed.
 	 *
-	 * @param   object   $model  The model of the component being processed.
-	 *
-	 * @return	void
+	 * @return	boolean	True if successful, false otherwise and internal error is set.
 	 * @since	11.1
 	 */
 	public function batch($model)

--- a/libraries/joomla/application/component/modeladmin.php
+++ b/libraries/joomla/application/component/modeladmin.php
@@ -107,6 +107,285 @@ abstract class JModelAdmin extends JModelForm
 	}
 
 	/**
+	 * Method to perform batch operations on an item or a set of items.
+	 *
+	 * @param	array	$commands	An array of commands to perform.
+	 * @param	array	$pks		An array of item ids.
+	 *
+	 * @return	boolean	Returns true on success, false on failure.
+	 * @since	11.1
+	 */
+	public function batch($commands, $pks)
+	{
+		// Sanitize user ids.
+		$pks = array_unique($pks);
+		JArrayHelper::toInteger($pks);
+
+		// Remove any values of zero.
+		if (array_search(0, $pks, true)) {
+			unset($pks[array_search(0, $pks, true)]);
+		}
+
+		if (empty($pks)) {
+			$this->setError(JText::_('JGLOBAL_NO_ITEM_SELECTED'));
+			return false;
+		}
+
+		$done = false;
+
+		if (!empty($commands['assetgroup_id'])) {
+			if (!$this->batchAccess($commands['assetgroup_id'], $pks)) {
+				return false;
+			}
+
+			$done = true;
+		}
+
+		if (!empty($commands['category_id'])) {
+			$cmd = JArrayHelper::getValue($commands, 'move_copy', 'c');
+
+			if ($cmd == 'c' && !$this->batchCopy($commands['category_id'], $pks)) {
+				return false;
+			} else if ($cmd == 'm' && !$this->batchMove($commands['category_id'], $pks)) {
+				return false;
+			}
+			$done = true;
+		}
+
+		if (!$done) {
+			$this->setError(JText::_('JLIB_APPLICATION_ERROR_INSUFFICIENT_BATCH_INFORMATION'));
+			return false;
+		}
+
+		// Clear the cache
+		$this->cleanCache();
+
+		return true;
+	}
+
+	/**
+	 * Batch access level changes for a group of rows.
+	 *
+	 * @param	integer	$value	The new value matching an Asset Group ID.
+	 * @param	array	$pks	An array of row IDs.
+	 *
+	 * @return	booelan	True if successful, false otherwise and internal error is set.
+	 * @since	11.1
+	 */
+	protected function batchAccess($value, $pks)
+	{
+		// Check that user has edit permission for items
+		$extension = JRequest::getCmd('option');
+		$user	= JFactory::getUser();
+		if (!$user->authorise('core.edit', $extension)) {
+			$this->setError(JText::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
+			return false;
+		}
+
+		$table = $this->getTable();
+
+		foreach ($pks as $pk) {
+			$table->reset();
+			$table->load($pk);
+			$table->access = (int) $value;
+
+			if (!$table->store()) {
+				$this->setError($table->getError());
+				return false;
+			}
+		}
+
+		// Clean the cache
+		$this->cleanCache();
+
+		return true;
+	}
+
+	/**
+	 * Batch copy items to a new category or current.
+	 *
+	 * @param	integer	$value	The new category.
+	 * @param	array	$pks	An array of row IDs.
+	 *
+	 * @return	boolean	True if successful, false otherwise and internal error is set.
+	 * @since	11.1
+	 */
+	protected function batchCopy($value, $pks)
+	{
+		$categoryId	= (int) $value;
+
+		$table	= $this->getTable();
+		$db		= $this->getDbo();
+
+		// Check that the category exists
+		if ($categoryId) {
+			$categoryTable = JTable::getInstance('Category');
+			if (!$categoryTable->load($categoryId)) {
+				if ($error = $categoryTable->getError()) {
+					// Fatal error
+					$this->setError($error);
+					return false;
+				} else {
+					$this->setError(JText::_('JLIB_APPLICATION_ERROR_BATCH_MOVE_CATEGORY_NOT_FOUND'));
+					return false;
+				}
+			}
+		}
+
+		if (empty($categoryId)) {
+			$this->setError(JText::_('JLIB_APPLICATION_ERROR_BATCH_MOVE_CATEGORY_NOT_FOUND'));
+			return false;
+		}
+
+		// Check that the user has create permission for the component
+		$extension	= JRequest::getCmd('option');
+		$user		= JFactory::getUser();
+		if (!$user->authorise('core.create', $extension)) {
+			$this->setError(JText::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_CREATE'));
+			return false;
+		}
+
+		// Parent exists so we let's proceed
+		while (!empty($pks))
+		{
+			// Pop the first ID off the stack
+			$pk = array_shift($pks);
+
+			$table->reset();
+
+			// Check that the row actually exists
+			if (!$table->load($pk)) {
+				if ($error = $table->getError()) {
+					// Fatal error
+					$this->setError($error);
+					return false;
+				} else {
+					// Not fatal error
+					$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_BATCH_MOVE_ROW_NOT_FOUND', $pk));
+					continue;
+				}
+			}
+
+			// Alter the title & alias
+			$data = $this->generateNewTitle($categoryId, $table->alias, $table->title);
+			$table->title   = $data['0'];
+			$table->alias   = $data['1'];
+
+			// Reset the ID because we are making a copy
+			$table->id		= 0;
+
+			// New category ID
+			$table->catid	= $categoryId;
+
+			// TODO: Deal with ordering?
+			//$table->ordering	= 1;
+
+			// Check the row
+			if (!$table->check()) {
+				$this->setError($table->getError());
+				return false;
+			}
+
+			// Store the row
+			if (!$table->store()) {
+				$this->setError($table->getError());
+				return false;
+			}
+		}
+
+		// Clean the cache
+		$this->cleanCache();
+
+		return true;
+	}
+
+	/**
+	 * Batch move articles to a new category
+	 *
+	 * @param	integer	$value	The new category ID.
+	 * @param	array	$pks	An array of row IDs.
+	 *
+	 * @return	booelan	True if successful, false otherwise and internal error is set.
+	 * @since	11.1
+	 */
+	protected function batchMove($value, $pks)
+	{
+		$categoryId	= (int) $value;
+
+		$table	= $this->getTable();
+		$db		= $this->getDbo();
+
+		// Check that the category exists
+		if ($categoryId) {
+			$categoryTable = JTable::getInstance('Category');
+			if (!$categoryTable->load($categoryId)) {
+				if ($error = $categoryTable->getError()) {
+					// Fatal error
+					$this->setError($error);
+					return false;
+				} else {
+					$this->setError(JText::_('JLIB_APPLICATION_ERROR_BATCH_MOVE_CATEGORY_NOT_FOUND'));
+					return false;
+				}
+			}
+		}
+
+		if (empty($categoryId)) {
+			$this->setError(JText::_('JLIB_APPLICATION_ERROR_BATCH_MOVE_CATEGORY_NOT_FOUND'));
+			return false;
+		}
+
+		// Check that user has create and edit permission for the component
+		$extension	= JRequest::getCmd('option');
+		$user		= JFactory::getUser();
+		if (!$user->authorise('core.create', $extension)) {
+			$this->setError(JText::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_CREATE'));
+			return false;
+		}
+
+		if (!$user->authorise('core.edit', $extension)) {
+			$this->setError(JText::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
+			return false;
+		}
+
+		// Parent exists so we let's proceed
+		foreach ($pks as $pk) {
+			// Check that the row actually exists
+			if (!$table->load($pk)) {
+				if ($error = $table->getError()) {
+					// Fatal error
+					$this->setError($error);
+					return false;
+				} else {
+					// Not fatal error
+					$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_BATCH_MOVE_ROW_NOT_FOUND', $pk));
+					continue;
+				}
+			}
+
+			// Set the new category ID
+			$table->catid = $categoryId;
+
+			// Check the row
+			if (!$table->check()) {
+				$this->setError($table->getError());
+				return false;
+			}
+
+			// Store the row
+			if (!$table->store()) {
+				$this->setError($table->getError());
+				return false;
+			}
+		}
+
+		// Clean the cache
+		$this->cleanCache();
+
+		return true;
+	}
+
+	/**
 	 * Method to test whether a record can be deleted.
 	 *
 	 * @param   object   $record	A record object.
@@ -258,6 +537,37 @@ abstract class JModelAdmin extends JModelForm
 		$this->cleanCache();
 
 		return true;
+	}
+
+	/**
+	 * Method to change the title & alias.
+	 *
+	 * @param	integer	$category_id	The id of the category.
+	 * @param   string	$alias			The alias.
+	 * @param   string	$title			The title.
+	 *
+	 * @return	array   Contains the modified title and alias.
+	 * @since	11.1
+	 */
+	protected function generateNewTitle($category_id, $alias, $title)
+	{
+		// Alter the title & alias
+		$table = $this->getTable();
+		while ($table->load(array('alias'=>$alias, 'catid'=>$category_id))) {
+			$m = null;
+			if (preg_match('#-(\d+)$#', $alias, $m)) {
+				$alias = preg_replace('#-(\d+)$#', '-'.($m[1] + 1).'', $alias);
+			} else {
+				$alias .= '-2';
+			}
+			if (preg_match('#\((\d+)\)$#', $title, $m)) {
+				$title = preg_replace('#\(\d+\)$#', '('.($m[1] + 1).')', $title);
+			} else {
+				$title .= ' (2)';
+			}
+		}
+
+		return array($title, $alias);
 	}
 
 	/**

--- a/libraries/joomla/html/html/batch.php
+++ b/libraries/joomla/html/html/batch.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  HTML
+ *
+ * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Extended Utility class for batch processing widgets.
+ *
+ * @package		Joomla.Platform
+ * @subpackage	HTML
+ * @since		11.1
+ */
+abstract class JHtmlBatch
+{
+	/**
+	 * Display a batch widget for the access level selector.
+	 *
+	 * @return	string	The necessary HTML for the widget.
+	 * @since	11.1
+	 */
+	public static function access()
+	{
+		// Create the batch selector to change an access level on a selection list.
+		$lines = array(
+			'<label id="batch-access-lbl" for="batch-access" class="hasTip" title="'.JText::_('JLIB_HTML_BATCH_ACCESS_LABEL').'::'.JText::_('JLIB_HTML_BATCH_ACCESS_LABEL_DESC').'">',
+			JText::_('JLIB_HTML_BATCH_ACCESS_LABEL'),
+			'</label>',
+			JHtml::_('access.assetgrouplist', 'batch[assetgroup_id]', '', 'class="inputbox"', array('title' => JText::_('JLIB_HTML_BATCH_NOCHANGE'), 'id' => 'batch-access'))
+		);
+
+		return implode("\n", $lines);
+	}
+
+	/**
+	 * Displays a batch widget for moving or copying items.
+	 *
+	 * @param	string	$extension	The extension that owns the category.
+	 * @param	string	$published	The published state of categories to be shown in the list.
+	 *
+	 * @return	string	The necessary HTML for the widget.
+	 * @since	11.1
+	 */
+	public static function item($extension, $published)
+	{
+		// Create the copy/move options.
+		$options = array(
+			JHtml::_('select.option', 'c', JText::_('JLIB_HTML_BATCH_COPY')),
+			JHtml::_('select.option', 'm', JText::_('JLIB_HTML_BATCH_MOVE'))
+		);
+
+		// Create the batch selector to change select the category by which to move or copy.
+		$lines = array(
+			'<label id="batch-choose-action-lbl" for="batch-choose-action">',
+			JText::_('JLIB_HTML_BATCH_MENU_LABEL'),
+			'</label>',
+			'<fieldset id="batch-choose-action" class="combo">',
+				'<select name="batch[category_id]" class="inputbox" id="batch-category-id">',
+					'<option value="">'.JText::_('JSELECT').'</option>',
+					JHtml::_('select.options',	JHtml::_('category.options', $extension, array('published' => (int) $published))),
+				'</select>',
+				JHTML::_( 'select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'),
+			'</fieldset>'
+		);
+
+		return implode("\n", $lines);
+	}
+}


### PR DESCRIPTION
Consistent with http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=22590...

This pull request focuses only on the framework changes for this feature request.  Between the 1.6.3 release and the platform merge, batch processing was added to com_content.  Upon my own review and testing, the code used here was applied in a manner that it could be reused throughout components that follow a category->item structure.

Specific to the framework are the following changes:
- JControllerForm: Function batch added
- JModelAdmin: Functions batch, batchAccess, batchCopy, batchMove, and generateNewTitle added
- JHtmlBatch added

If implemented, changes to the CMS can be made as demonstrated via my SVN branch (mbabker).
