### PR TITLE
Cleaning up after JDocument changes

### DIFF
--- a/tests/suite/joomla/document/JDocumentTest.php
+++ b/tests/suite/joomla/document/JDocumentTest.php
@@ -181,24 +181,6 @@ class JDocumentTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * This is an empty test for code coverage reasons (the method is empty)
-	 */
-	public function testGetHeadData()
-	{
-		$this->object = new JDocument;
-		$this->object->getHeadData();
-	}
-
-	/**
-	 * This is an empty test for code coverage reasons (the method is empty)
-	 */
-	public function testSetHeadData()
-	{
-		$this->object = new JDocument;
-		$this->object->setHeadData(array());
-	}
-
-	/**
 	 * Test getBuffer
 	 */
 	public function testGetBuffer()

--- a/tests/suite/joomla/document/json/JDocumentJSONTest.php
+++ b/tests/suite/joomla/document/json/JDocumentJSONTest.php
@@ -92,22 +92,6 @@ class JDocumentJSONTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * This method does nothing.
-	 */
-	public function testGetHeadData()
-	{
-		$this->object->getHeadData();
-	}
-
-	/**
-	 * This method does nothing.
-	 */
-	public function testSetHeadData()
-	{
-		$this->object->setHeadData('Head Data');
-	}
-
-	/**
 	 * We test both at once
 	 */
 	public function testGetAndSetName()


### PR DESCRIPTION
Removing methods under test while ignoring the tests
caused a mess that needed cleaned up.
