### PR TITLE
Fixed JStringTest

### DIFF
--- a/tests/suite/joomla/utilities/JStringTest.php
+++ b/tests/suite/joomla/utilities/JStringTest.php
@@ -222,7 +222,10 @@ class JStringTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testStrcasecmp($string1, $string2, $locale, $expect)
 	{
-		if (substr(php_uname(), 0, 6) != 'Darwin') {
+		if (substr(php_uname(), 0, 6) == 'Darwin' &&
+		      $locale != false) {
+		    $this->markTestSkipped('Darwin bug prevents foreign conversion from working properly');
+		} else {
 			$actual = JString::strcasecmp ($string1, $string2, $locale);
 			if ($actual != 0) {
 				$actual = $actual/abs($actual);
@@ -238,11 +241,16 @@ class JStringTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testStrcmp($string1, $string2, $locale, $expect)
 	{
-		$actual = JString::strcmp ($string1, $string2, $locale);
-		if ($actual != 0) {
-			$actual = $actual/abs($actual);
+		if (substr(php_uname(), 0, 6) == 'Darwin' &&
+		      $locale != false) {
+		    $this->markTestSkipped('Darwin bug prevents foreign conversion from working properly');
+		} else {
+			$actual = JString::strcmp ($string1, $string2, $locale);
+			if ($actual != 0) {
+				$actual = $actual/abs($actual);
+			}
+			$this->assertEquals($expect, $actual);
 		}
-		$this->assertEquals($expect, $actual);
 	}
 
 	/**


### PR DESCRIPTION
Darwin bug was causing tests to fail. Added test for Darwin, and if
tests are running under Darwin, it marks the international string
tests as skipped, and gives the reason why.
