### PR TITLE
Cleared Fatal crash if JTestConfig not found

### DIFF
--- a/tests/suite/joomla/database/database/JDatabaseMySQLTest.php
+++ b/tests/suite/joomla/database/database/JDatabaseMySQLTest.php
@@ -59,7 +59,12 @@ class JDatabaseMySQLTest extends JoomlaDatabaseTestCase
 	 */
 	protected function setUp()
 	{
-		$config = new JTestConfig;
+		@include_once JPATH_TESTS . '/config_mysql.php';
+		if (class_exists('JMySQLTestConfig')) {
+			$config = new JMySQLTestConfig;
+		} else {
+			$this->markTestSkipped('There is no mysql test config file present.');
+		}
 		$this->object = JDatabase::getInstance(
 			array(
 				'driver' => $config->dbtype,


### PR DESCRIPTION
Added different config file to JDatabaseMySQLTest to allow an independent decision
by the tester on whether these tests should be run. It now requires
config_mysql.php to contain the JMySQLTestConfig class to be present or the tests
will be skipped.
