### PR TITLE
2 platform changes that will enable Joomfish to interact with database queries more effectively (redux)

### DIFF
--- a/libraries/joomla/application/component/modellist.php
+++ b/libraries/joomla/application/component/modellist.php
@@ -212,7 +212,7 @@ class JModelList extends JModel
 
 		// Load the total.
 		$query = $this->_getListQuery();
-		$total = (int) $this->_getListCount((string) $query);
+		$total = (int) $this->_getListCount( $query);
 
 		// Check for a database error.
 		if ($this->_db->getErrorNum()) {

--- a/libraries/joomla/database/databasequery.php
+++ b/libraries/joomla/database/databasequery.php
@@ -73,6 +73,20 @@ class JDatabaseQueryElement
 		}
 	}
 
+
+	/**
+	 * Magic function to convert the query element to a string.
+	 *
+	 * @param   String
+	 * @return  mixed
+	 *
+	 * @since   11.1
+	 */
+	public function __get($name)
+	{
+		return isset($this->$name) ? $this->$name : null;
+        }
+
 	/**
 	 * Appends element parts to the internal list.
 	 *

--- a/libraries/joomla/database/databasequery.php
+++ b/libraries/joomla/database/databasequery.php
@@ -73,20 +73,6 @@ class JDatabaseQueryElement
 		}
 	}
 
-
-	/**
-	 * Magic function to convert the query element to a string.
-	 *
-	 * @param   String
-	 * @return  mixed
-	 *
-	 * @since   11.1
-	 */
-	public function __get($name)
-	{
-		return isset($this->$name) ? $this->$name : null;
-        }
-
 	/**
 	 * Appends element parts to the internal list.
 	 *

--- a/libraries/joomla/database/databasequery.php
+++ b/libraries/joomla/database/databasequery.php
@@ -367,6 +367,19 @@ abstract class JDatabaseQuery
 	}
 
 	/**
+	 * Magic function to get protected variable value
+	 *
+	 * @param   String
+	 * @return  mixed
+	 *
+	 * @since   11.1
+	 */
+	public function __get($name)
+	{
+		return isset($this->$name) ? $this->$name : null;
+        }
+	
+	/**
 	 * Casts a value to a char.
 	 *
 	 * Ensure that the value is properly quoted before passing to the method.


### PR DESCRIPTION
Sorry - closed pull request 44 by mistake (I'm new to github).   This new request has the getter added to the correct class (I'd cut and pasted it in the wrong class last time :( ).  To avoid  confusion I'll repeat my comment about setters:

A setter is a good idea (but not essential) but it would allow for unforeseen eventualities. The only problem with the setter is how it would interact with JDatabaseQueryElement - i.e. which one of the elements would it be setting?

You can always simulate a setter by getting the separate element groups, calling clear and then resetting the relevant element. e.g. in pseudo code:
$elements = $query->where;
// do something to elements
$query->clear('where');
foreach ($elements as $elem){
$query->where($elem);
}

Perhaps the last 4 lines would be the code for the __set method?
