### PR TITLE
Don't render meta elements without content

### DIFF
--- a/libraries/joomla/document/html/renderer/head.php
+++ b/libraries/joomla/document/html/renderer/head.php
@@ -66,7 +66,7 @@ class JDocumentRendererHead extends JDocumentRenderer
 					$content.= '; charset=' . $document->getCharset();
 					$buffer .= $tab.'<meta http-equiv="'.$name.'" content="'.htmlspecialchars($content).'"'.$tagEnd.$lnEnd;
 				}
-				else if ($type == 'standard') {
+				else if ($type == 'standard' && !empty($content)) {
 					$buffer .= $tab.'<meta name="'.$name.'" content="'.htmlspecialchars($content).'"'.$tagEnd.$lnEnd;
 				}
 			}


### PR DESCRIPTION
CMS Issue: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=26184

Just a little markup saver. Also helps a little with some meta elements not valid in HTML5.
