### PR TITLE
Restoring memory limit after daemon test

### DIFF
--- a/tests/suite/joomla/application/cli/JDaemonTest.php
+++ b/tests/suite/joomla/application/cli/JDaemonTest.php
@@ -36,6 +36,16 @@ class JDaemonTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Restore memory limit after tests
+	 * 
+	 */
+	 public static function tearDownAfterClass()
+	 {
+		 ini_restore('memory_limit');
+		 parent::tearDownAfterClass();
+	 }
+
+	/**
 	 * Test the JDaemon::writeProcessIdFile method.
 	 */
 	public function testWriteProcessIdFile()


### PR DESCRIPTION
The daemon class sets the maximum memory to 256M which causes the code coverage report to fail.  This change will restore the default value after the test is run.
