### PR TITLE
PHP Strict Errors

### DIFF
--- a/libraries/joomla/html/toolbar/button.php
+++ b/libraries/joomla/html/toolbar/button.php
@@ -91,18 +91,6 @@ abstract class JButton extends JObject
 	}
 
 	/**
-	 * Get the button id
-	 *
-	 * Can be redefined in the final button class
-	 *
-	 * @since       11.1
-	 */
-	public function fetchId()
-	{
-		return;
-	}
-
-	/**
 	 * Get the button
 	 *
 	 * Defined in the final button class

--- a/libraries/joomla/utilities/date.php
+++ b/libraries/joomla/utilities/date.php
@@ -411,7 +411,7 @@ class JDate extends DateTime
 	 *
 	 * @since   11.1
 	 */
-	public function setTimezone(DateTimeZone $tz)
+	public function setTimezone($tz)
 	{
 		$this->_tz = $tz;
 		return parent::setTimezone($tz);


### PR DESCRIPTION
Commit 1 - Minor change made to JDate::setTimezone to correct PHP Strict Error

Commit 2 - Remove JButton::fetchID parent class - child classes are not consistent with parameters so there is no easy way to make the parent class consistent. Since it is not used and since it only returns when executed, removing it will at least get rid of the Strict eror.
