### PR TITLE
Make getTable fill in the prefix like JController::getView

### DIFF
--- a/libraries/joomla/application/component/model.php
+++ b/libraries/joomla/application/component/model.php
@@ -385,10 +385,14 @@ abstract class JModel extends JObject
 	 * @return  JTable  A JTable object
 	 * @since   11.1
 	 */
-	public function getTable($name = '', $prefix = 'Table', $options = array())
+	public function getTable($name = '', $prefix = '', $options = array())
 	{
 		if (empty($name)) {
 			$name = $this->getName();
+		}
+
+		if(empty($prefix)) {
+			$prefix = $this->getName() . 'Table';
 		}
 
 		if ($table = $this->_createTable($name, $prefix, $options)) {

--- a/libraries/joomla/application/component/model.php
+++ b/libraries/joomla/application/component/model.php
@@ -399,6 +399,10 @@ abstract class JModel extends JObject
 			return $table;
 		}
 
+		if ($table = $this->_createTable($name, 'Table', $options)) {
+			return $table;
+		}
+
 		JError::raiseError(0, JText::sprintf('JLIB_APPLICATION_ERROR_TABLE_NAME_NOT_SUPPORTED', $name));
 
 		return null;


### PR DESCRIPTION
When using tables in extensions, the default JModel::getTable() method does not automatically include the extension name, instead it uses the prefix 'Table' to for the table to automatically load using getTable it has to be named TableHelloworld and not HelloworldTableHelloworld.
