### PR TITLE
Consistent phpdoc subpackage in updater

### DIFF
--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -13,7 +13,7 @@ defined('JPATH_PLATFORM') or die;
  * Update class.
  *
  * @package     Joomla.Platform
- * @subpackage  Update
+ * @subpackage  Updater
  * @since       11.1
  */
 class JUpdate extends JObject

--- a/libraries/joomla/updater/updateadapter.php
+++ b/libraries/joomla/updater/updateadapter.php
@@ -15,7 +15,7 @@ jimport('joomla.base.adapterinstance');
  * UpdateAdapter class.
  *
  * @package     Joomla.Platform
- * @subpackage  Update
+ * @subpackage  Updater
  * @since       11.1
  */
 

--- a/libraries/joomla/updater/updater.php
+++ b/libraries/joomla/updater/updater.php
@@ -20,7 +20,7 @@ jimport('joomla.log.log');
 /**
  * Updater Class
  * @package     Joomla.Platform
- * @subpackage  Update
+ * @subpackage  Updater
  * @since       11.1
  */
 class JUpdater extends JAdapter {


### PR DESCRIPTION
Some files in the Updater subpackage are tagged with "@subpackage Update", this makes phpdoc create two different packages for the updater.

This patch makes consistent use of "@subpackage Updater"
