### PR TITLE
Add optional context to JHtmlContent::prepare

### DIFF
--- a/libraries/joomla/html/html/content.php
+++ b/libraries/joomla/html/html/content.php
@@ -22,11 +22,11 @@ abstract class JHtmlContent
 	 * Fire onContentPrepare for content that isn't part of an article.
 	 *
 	 * @param   string   The content to be transformed.
-	 * @param   string   The context of the content to be transformed.
 	 * @param   array    The content params.
+	 * @param   string   The context of the content to be transformed.
 	 * @return  string   The content after transformation.
 	 */
-	public static function prepare($text, $context = 'text', $params = null)
+	public static function prepare($text, $params = null, $context = 'text')
 	{
 		if ($params === null) {
 			$params = new JObject;

--- a/libraries/joomla/html/html/content.php
+++ b/libraries/joomla/html/html/content.php
@@ -22,10 +22,11 @@ abstract class JHtmlContent
 	 * Fire onContentPrepare for content that isn't part of an article.
 	 *
 	 * @param   string   The content to be transformed.
+	 * @param   string   The context of the content to be transformed.
 	 * @param   array    The content params.
 	 * @return  string   The content after transformation.
 	 */
-	public static function prepare($text, $params = null)
+	public static function prepare($text, $context = 'text', $params = null)
 	{
 		if ($params === null) {
 			$params = new JObject;
@@ -35,7 +36,7 @@ abstract class JHtmlContent
 		JPluginHelper::importPlugin('content');
 		$dispatcher = JDispatcher::getInstance();
 		$results = $dispatcher->trigger(
-			'onContentPrepare', array ('text', &$article, &$params, 0)
+			'onContentPrepare', array ($context, &$article, &$params, 0)
 		);
 
 		return $article->text;


### PR DESCRIPTION
See CMS Bug Tracker -> http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=26421

This adds an optional context to JHtmlContent::prepare so that in all instances where this method is used to run the onContentPrepare event, a non-generic context can be passed to the event.  This will allow developers to better check the data their plugin's event has received to verify they are not accidentally processing data they do not intend to handle.  There are no backward compatibility issues as this variable is optional and defaults to the already hard coded context.
