### PR TITLE
This is a cms catchup commit for issues 25696 and 26284  

### DIFF
--- a/libraries/joomla/application/cli/daemon.php
+++ b/libraries/joomla/application/cli/daemon.php
@@ -88,7 +88,7 @@ class JDaemon extends JCli
 		parent::__construct();
 
 		// Set some system limits.
-		set_time_limit($this->config->get('max_execution_time', 0));
+		@set_time_limit($this->config->get('max_execution_time', 0));
 		if ($this->config->get('max_memory_limit') !== null) {
 			ini_set('memory_limit', $this->config->get('max_memory_limit', '256M'));
 		}

--- a/libraries/joomla/filesystem/archive/zip.php
+++ b/libraries/joomla/filesystem/archive/zip.php
@@ -382,7 +382,7 @@ class JArchiveZip extends JObject
 			$entries[$name]['_dataStart'] = $lfhStart +30 + $info['Length'] + $info['ExtraLength'];
 
 			// Bump the max execution time because not using the built in php zip libs makes this process slow.
-			set_time_limit(ini_get('max_execution_time'));
+			@set_time_limit(ini_get('max_execution_time'));
 		}
 		while ((($fhStart = strpos($data, $this->_ctrlDirHeader, $fhStart +46)) !== false));
 

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -322,7 +322,7 @@ class JFile
 	 */
 	public static function write($file, &$buffer, $use_streams=false)
 	{
-		set_time_limit(ini_get('max_execution_time'));
+		@set_time_limit(ini_get('max_execution_time'));
 
 		// If the destination directory doesn't exist we need to create it
 		if (!file_exists(dirname($file))) {

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -33,7 +33,7 @@ abstract class JFolder
 	 */
 	public static function copy($src, $dest, $path = '', $force = false, $use_streams=false)
 	{
-		set_time_limit(ini_get('max_execution_time'));
+		@set_time_limit(ini_get('max_execution_time'));
 
 		// Initialise variables.
 		jimport('joomla.client.helper');
@@ -280,7 +280,7 @@ abstract class JFolder
 	 */
 	public static function delete($path)
 	{
-		set_time_limit(ini_get('max_execution_time'));
+		@set_time_limit(ini_get('max_execution_time'));
 
 		// Sanity check
 		if (!$path)
@@ -552,7 +552,7 @@ abstract class JFolder
 	 */
 	protected static function _items($path, $filter, $recurse, $full, $exclude, $excludefilter_string, $findfiles)
 	{
-		set_time_limit(ini_get('max_execution_time'));
+		@set_time_limit(ini_get('max_execution_time'));
 
 		// Initialise variables.
 		$arr = array();

--- a/libraries/joomla/installer/helper.php
+++ b/libraries/joomla/installer/helper.php
@@ -93,7 +93,9 @@ abstract class JInstallerHelper
 
 		// Restore error tracking to what it was before
 		ini_set('track_errors',$track_errors);
-
+ 		// bump the max execution time because not using built in php zip libs are slow
+ 		@set_time_limit(ini_get('max_execution_time'));
+		
 		// Return the name of the downloaded package
 		return basename($target);
 	}


### PR DESCRIPTION
As part of solving a problem with updating the maximum time was bumped up for
zip. However some shared hosting does not permit this and that can
cause warnings. Therefore @ is added to supress warnings when this
option is not available. Original report and patch for 26284from Brian
Towles.
