### PR TITLE
System test failure fix

### DIFF
--- a/libraries/joomla/application/categories.php
+++ b/libraries/joomla/application/categories.php
@@ -281,7 +281,7 @@ class JCategories
 					$this->_nodes[$result->id] = new JCategoryNode($result, $this);
 
 					// If this is not root and if the current node's parent is in the list or the current node parent is 0
-					if ($result->id != 'root' && (isset($this->_nodes[$result->parent_id]) || $result->parent_id == 0)) {
+					if ($result->id != 'root' && (isset($this->_nodes[$result->parent_id]) || $result->parent_id == 1)) {
 						// Compute relationship between node and its parent - set the parent in the _nodes field
 						$this->_nodes[$result->id]->setParent($this->_nodes[$result->parent_id]);
 					}
@@ -648,7 +648,9 @@ class JCategoryNode extends JObject
 			$this->_parent = & $parent;
 
 			if ($this->id != 'root') {
-				$this->_path = $parent->getPath();
+			if ($this->parent_id != 1 ) {
+					$this->_path = $parent->getPath();
+				}
 				$this->_path[] = $this->id.':'.$this->alias;
 			}
 


### PR DESCRIPTION
Correct fatal error when a category id of 0 is passed in; this was
exposed as a problem with system test failurs on the CMS whem there
was a failure to get the module params correctly. With this hange fall
back to default works. 
