### PR TITLE
Fix JForm::load() not replacing form field in same location

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -661,13 +661,7 @@ class JForm
 				if ($current = $this->findField((string) $field['name'], implode('.', $groups))) {
 
 					// If set to replace found fields remove it from the current definition.
-					if ($replace) {
-						$dom = dom_import_simplexml($current);
-						$dom->parentNode->removeChild($dom);
-					}
-
-					// Else remove it from the incoming definition so it isn't replaced.
-					else {
+					if (!$replace) {
 						unset($field);
 					}
 				}


### PR DESCRIPTION
When loading another form xml definition on a JForm object, and the new xml definition contains field names which overlap, the fields should be replaced in the same location.

In the current implementation, the old field is removed, and then the new field is added to the end of the form, changing the ordering.

This patch fixes the problem with reordering, but I am not sure if it has any other adverse effects, I will leave that up to someone who knows more about the workings of JForm.
