### PR TITLE
Make JUpdate also use regular expression for targetplatform

### DIFF
--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -209,7 +209,7 @@ class JUpdate extends JObject
 			case 'UPDATE':
 				$ver = new JVersion;
 				$product = strtolower(JFilterInput::getInstance()->clean($ver->PRODUCT, 'cmd'));
-				if($product == $this->_current_update->targetplatform->name && $ver->RELEASE == $this->_current_update->targetplatform->version)
+				if($product == $this->_current_update->targetplatform->name && preg_match('/'.$this->_current_update->targetplatform->version.'/', $ver->RELEASE))
 				{
 					if(isset($this->_latest))
 					{


### PR DESCRIPTION
When using collections in the updater, the tag allows you to specify a targetplatformversion using regular expressions, however the tag does not.
