### PR TITLE
Docblock fix

### DIFF
--- a/libraries/joomla/user/authentication.php
+++ b/libraries/joomla/user/authentication.php
@@ -198,10 +198,10 @@ class JAuthentication extends JObservable
 	 * Authorises that a particular user should be able to login
 	 * 
 	 * @access public
-	 * @param JAuthenticationResponse username of the user to authorise
-	 * @param Array list of options 
-	 * @return Array[JAuthenticationResponse] results of authorisation
-	 * @since  11.1
+	 * @param  JAuthenticationResponse $response response including username of the user to authorise
+	 * @param  array                   $options  list of options 
+	 * @return array[JAuthenticationResponse] results of authorisation
+	 * @since  11.2
 	 */
 	public static function authorise($response, $options=Array())
 	{


### PR DESCRIPTION
Noticed a formatting issue, not sure what the return should be set to and fixed the incorrectly marked authorise function from 11.1 to 11.2
