### PR TITLE
Initial documentation and version 11.2 changelog

### DIFF
--- a/docs/coding-standards/book.xml
+++ b/docs/coding-standards/book.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE book [
+<!ENTITY pref SYSTEM "chapters/preface.xml">
+<!ENTITY chap1 SYSTEM "chapters/source-code-management.xml">
+<!ENTITY chap2 SYSTEM "chapters/basic-guidelines.xml">
+<!ENTITY chap3 SYSTEM "chapters/php.xml">
+]>
+
+<book xmlns="http://docbook.org/ns/docbook" version="5.0">
+	<title>Joomla! Platform Coding Standards</title>
+&pref;
+&chap1;
+&chap2;
+&chap3;
+</book>

--- a/docs/coding-standards/chapters/basic-guidelines.xml
+++ b/docs/coding-standards/chapters/basic-guidelines.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<chapter xml:id="ch2">
+  <title>Basic Guidelines</title>
+
+  <section>
+    <title></title>
+
+    <para>This chapter outlines the basic guidelines that cover and
+    files.</para>
+  </section>
+
+  <section>
+    <title>File Format</title>
+
+    <para>All files contributed to Joomla must be stored as ASCII text, use
+    UTF-8 character encoding and ne Unix formatted. Lines must end only with a
+    line feed (LF). Line feeds are represented as ordinal 10, octal 012 and
+    hex 0A. Do not use carriage returns (CR) like Macintosh computers do or
+    the carriage return/line feed combination (CRLF) like Windows computers
+    do.</para>
+  </section>
+
+  <section>
+    <title>Spelling</title>
+
+    <para>The spelling of words and terms used in code comments and in the
+    naming of class, functions, variables and constant should generally be in
+    accordance with British English rules (en_GB). However, some exceptions
+    are permitted, for example where common programming names are used that
+    align with the PHP API or other established conven-tions such as for
+    “color” where is it common practice to maintain US English
+    spelling.</para>
+  </section>
+
+  <section>
+    <title>Indenting</title>
+
+    <para>Tabs are used for indenting code (not spaces as required by the PEAR
+    standard). Source code editors or Integrated Development Environments
+    (IDE’s) such as Eclipse must have the tab-stops for indenting measuring
+    four (4) spaces in length.</para>
+  </section>
+
+  <section>
+    <title>Line Length</title>
+
+    <para>There is no maximum limit for line lengths in files, however, a
+    notional value of about 150 characters is recommend to achieve a good
+    level of readability without horizontal scrolling. Longer lines are
+    permitted if the nature of the code for individual lines requires it and
+    line breaks would have an adverse affect on the final output (such as for
+    mixed PHP/HTML layout files).</para>
+  </section>
+
+  <section>
+    <title>Best Practices</title>
+
+    <para>TODO Any words of wisdom about PHP best practice, maybe even
+    references for design patterns? Can/should we link out to the JRD, Doc
+    wiki and Developer site for additional resources?</para>
+  </section>
+</chapter>

--- a/docs/coding-standards/chapters/php.xml
+++ b/docs/coding-standards/chapters/php.xml
@@ -3,94 +3,371 @@
 <chapter xml:id="ch3">
 	<title>PHP</title>
 
-	<section>
+	<sect1>
 		<title></title>
 
 		<para>This chapter is about</para>
-	</section>
+	</sect1>
 
-	<section>
+	<sect1>
 		<title>Language Constructs</title>
 
-		<section>
+		<sect1>
 			<title>PHP Code Tags</title>
 
-			<para>Always use the full &lt;?php ?&gt; to delimit PHP code, not the
-				&lt;? ?&gt; shorthand. This is the most portable way to include PHP
-				code
-				on differing operating systems and setups.
+			<para>Always use the full &lt;?php ?&gt; to delimit PHP code, not the &lt;? ?&gt; shorthand. This
+				is the most portable way to include PHP code on differing operating systems and setups.
 			</para>
 
-			<para>For files that contain only PHP code, the closing tag (?&gt;)
-				should not be included. It is not required by PHP. Leaving this out
-				prevents trailing white space from being accidentally injected into
-				the
-				output that can introduce errors in the Joomla session (see the PHP
-				manual on instruction separation at
-				http://php.net/basic-syntax.instruction-separation).
+			<para>For files that contain only PHP code, the closing tag (?&gt;) should not be included. It is
+				not required by PHP. Leaving this out prevents trailing white space from being accidentally
+				injected into the output that can introduce errors in the Joomla session (see the PHP manual on
+				instruction separation at http://php.net/basic-syntax.instruction-separation).
 			</para>
 
 			<para>TODO Example</para>
-		</section>
+		</sect1>
 
-		<section>
+		<sect1>
 			<title>Including Code</title>
 
-			<para>Anywhere you are unconditionally including a file, use
-				require_once. Anywhere you are conditionally including a file (for
-				example, factory methods), use include_once. Either of these will
-				ensure
-				that files are included only once. They share the same file list, so you
-				don't need to worry about mixing them. A file included with
-				require_once
-				will not be included again by include_once.
+			<para>Anywhere you are unconditionally including a file, use require_once. Anywhere you are
+				conditionally including a file (for example, factory methods), use include_once. Either of these
+				will ensure that files are included only once. They share the same file list, so you don't need
+				to worry about mixing them. A file included with require_once will not be included again by
+				include_once.
 			</para>
 
 			<note>
-				<para>include_once and require_once are PHP language statements, not
-					functions. The correct formatting is:
+				<para>include_once and require_once are PHP language statements, not functions. The correct
+					formatting is:
 				</para>
 
 				<para>require_once JPATH_COMPONENT.’/helpers/helper.php’;</para>
 			</note>
 
 			<para>You should not enclose the filename in parentheses. </para>
-		</section>
+		</sect1>
 
-		<section>
-			<title></title>
+		<sect1>
+			<title>E_STRICT Compatible PHP Code</title>
 
-			<para></para>
-		</section>
-	</section>
+			<para>As of Joomla version 1.6 and for all versions of the Joomla Platform, adhering to object
+				oriented programming practice as supported by PHP 5.2 is required. Joomla is commit-ted to
+				progressively making the source code E_STRICT.
+			</para>
+		</sect1>
+	</sect1>
 
-	<section>
+	<sect1>
+		<title>GLobal Variables</title>
+
+		<para>TODO Usage should be kept to a minimum. Use OOP and factory patterns instead.</para>
+	</sect1>
+
+	<sect1>
+		<title>Control Structures</title>
+
+		<para>For all control structures, there is a space between the keyword and an opening
+			parenthe-sis, then no space either after the opening parenthesis or before the closing bracket.
+			This is done to distinguish control keywords from function names. All control structures must
+			contain their logic within braces.
+		</para>
+		<para>Where the control structure is an if, the if and else keywords are put on newlines and the
+			control logic is indented. The opening brace is included on the same line as the if or else and
+			the closing brace is on a new line.
+		</para>
+		<para>For all other control structures, such as do, for, foreach, try, catch, switch and while,
+			both the keyword starts a newline and the opening and closing braces are each put on a new line.
+		</para>
+		<sect2>
+			<title>An if-else Example</title>
+			<programlisting><![CDATA[
+if ($test) {
+	echo 'True';
+}
+// Comments can go here.
+else if ($test === false) {
+	echo 'Really false';
+else {
+	echo 'A white lie';
+}
+			]]>
+			</programlisting>
+		</sect2>
+
+		<sect2>
+			<title>A do-while Example</title>
+			<programlisting><![CDATA[
+do
+{
+    $i++;
+}
+while ($i < 10);
+			]]>
+			</programlisting>
+		</sect2>
+
+		<sect2>
+			<title>A for Example</title>
+			<programlisting><![CDATA[
+for ($i = 0; $i < $n; $i++)
+{
+    echo 'Increment = '.$i;
+}
+			]]>
+			</programlisting>
+		</sect2>
+
+		<sect2>
+			<title>A foreach Example</title>
+			<programlisting><![CDATA[
+foreach ($rows as $index => $row)
+{
+    echo 'Index = '.$id.', Value = '.$row;
+}
+			]]>
+			</programlisting>
+		</sect2>
+
+		<sect2>
+			<title>A while Example</title>
+			<programlisting><![CDATA[
+while (!$done)
+{
+    $done = true;
+}
+			]]>
+			</programlisting>
+		</sect2>
+
+		<sect2>
+			<title>A switch example</title>
+			<para>When using a switch statement, the case keywords are indented. The break statement starts
+				on a newline assuming the indent of the code within the case.
+			</para>
+			<programlisting><![CDATA[
+switch ($value)
+{
+    case 'a':
+        echo 'A';
+        break;
+
+    default:
+        echo 'I give up';
+        break;
+}
+			]]>
+			</programlisting>
+		</sect2>
+
+		<sect2>
+			<title>References</title>
+			<para>When using references, there should be a space before the reference operator and no space
+				between it and the function or variable name.
+			</para>
+			<para>For example:</para>
+			<programlisting><![CDATA[
+<?php
+$ref1  = &$this->_sql;
+			]]>
+			</programlisting>
+			<note>
+				<para>In PHP 5, reference operators are not required for objects. All objects are handled by
+					reference.
+				</para>
+			</note>
+		</sect2>
+
+		<sect2>
+			<title>Arrays</title>
+			<para>Assignments (the =&gt; operator) in arrays may be aligned with tabs. When splitting array
+				definitions onto several lines, the last value may also have a trailing comma. This is val-id
+				PHP syntax and helps to keep code diffs minimal.
+			</para>
+			<para>For example:</para>
+			<programlisting><![CDATA[
+$options = array(
+    'foo'  => 'foo',
+    'spam' => 'spam',
+);
+			]]>
+			</programlisting>
+		</sect2>
+	</sect1>
+
+	<sect1>
+		<title>Code Commenting</title>
+
+		<para>Inline comments to explain code follow the convention for C (/* … */) and C++ single line
+			(// ...) comments. C-style blocks are generally restricted to documentation headers for files,
+			classes and functions. The C++ style is generally used for making code notes. Code notes are
+			strongly encouraged to help other people, including your future-self, follow the purpose of the
+			code. Always provide notes where the code is performing particularly complex operations.
+		</para>
+		<para>Perl/shell style comments (#) are not permitted in PHP files but are permitted in INI
+			language files.
+		</para>
+		<para>Blocks of code may, of course, be commented out for debugging purposes using any appropriate
+			format, but should be removed before submitting patches for contribution back to the core code.
+		</para>
+		<para>For example, do not include feature submissions like:</para>
+		<programlisting><![CDATA[
+<?php 
+// Must fix this code up one day.
+//$code = broken($fixme);
+			]]>
+		</programlisting>
+
+		<sect2>
+			<title>Comment Docblocks</title>
+
+			<para>Documentation headers for PHP and Javascript code in files, classes, class properties,
+				methods and functions, called the docblocks, follow a convention similar to JavaDoc or phpDOC.
+			</para>
+			<para>These &quot;DocBlocks&quot; borrow from the PEAR standard but have some variations specific
+				for
+				Joomla and the Joomla Platform.
+			</para>
+			<para>Whereas normal code indenting uses real tabs, all whitespace in a Docblock uses real
+				spaces. This provides better readability in source code browsers. The minimum whitespace between
+				any text elements, such as tags, variable types, variable names and tag descriptions, is two
+				real spaces. Variable types and tag descriptions should be aligned according to the longest
+				Docblock tag and type-plus-variable respectively.
+			</para>
+			<para>If the @package tag is used, it will be &quot;Joomla.Platform&quot;.</para>
+			<para>If the @subpackage tag is used, it is the name of the top level folder under the /joomla/
+				folder. For example: Application, Database, Html, and so on.
+			</para>
+			<para>Code contributed to the Joomla project that will become the copyright of the project is not
+				allowed to include @author tags. You should update the contribution log in CREDITS.php.
+				Joomla's
+				philosophy is that the code is written "all together" and there is no notion of any one
+				person
+				&quot;owning&quot; any section of code. The @author tags are permitted in third-party
+				libraries
+				that are included in the core libraries.
+			</para>
+			<para>Files included from third party sources must leave DocBlocks intact. Layout files use the
+				same DocBlocks as other PHP files.</para>
+		</sect2>
+
+		<sect2>
+			<title>File DocBlock Headers</title>
+
+			<para>The file header DocBlock consists of the following required and optional elements in the
+				following order:</para>
+
+			<itemizedlist>
+				<listitem>
+					<para>Short description (optional unless the file contains more than two classes or functions),
+						followed by a blank line).</para>
+				</listitem>
+				<listitem>
+					<para>Long description (optional, followed by a blank line).</para>
+				</listitem>
+				<listitem>
+					<para>@category (optional and rarely used)</para>
+				</listitem>
+				<listitem>
+					<para>@package (generally optional but required when files contain only procedural code)</para>
+				</listitem>
+				<listitem>
+					<para>@subpackage (optional)</para>
+				</listitem>
+				<listitem>
+					<para>@author (optional but only permitted in non-Joomla source files, for example, included
+						third-party libraries like Geshi)</para>
+				</listitem>
+				<listitem>
+					<para>@copyright (required)</para>
+				</listitem>
+				<listitem>
+					<para>@license (required and must be compatible with the Joomla license)</para>
+				</listitem>
+				<listitem>
+					<para>@deprecated (optional)</para>
+				</listitem>
+				<listitem>
+					<para>@link (optional)</para>
+				</listitem>
+				<listitem>
+					<para>@see (optional)</para>
+				</listitem>
+				<listitem>
+					<para>@since (generally optional but required when files contain only procedural code)</para>
+				</listitem>
+			</itemizedlist>
+
+			<example>
+				<title>Example Joomla Platform file header </title>
+				<programlisting><![CDATA[
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Database
+ * @copyright   Copyright 2005 - 2010 Open Source Matters. All rights re-served.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+			]]>
+				</programlisting>
+
+			</example>
+		</sect2>
+
+
+	</sect1>
+
+	<sect1>
+		<title>Function Calls</title>
+
+		<para>Functions should be called with no spaces between the function name and the opening parenthesis, and no space between this and the first parameter; a space after the comma between each parameter (if they are present), and no space between the last parameter and the closing parenthesis. There should be space before and exactly one space after the equals sign. Tab alignment over multiple lines is permitted.</para>
+			<example>
+				<title>Example function call</title>
+				<programlisting><![CDATA[
+<?php
+// An isolated function call.
+$foo = bar($var1, $var2);
+
+// Multiple aligned function calls.
+$short   = bar('short');
+$medium  = bar('medium');
+$long    = bar('long');
+				]]>
+				</programlisting>
+			</example>
+
+
+		<para></para>
+		<para></para>
+		<para></para>
+		<para></para>
+		<para></para>
+		<para></para>
+		<para></para>
+	</sect1>
+
+	<sect1>
 		<title></title>
 
 		<para></para>
-	</section>
+	</sect1>
 
-	<section>
+	<sect1>
 		<title></title>
 
 		<para></para>
-	</section>
+	</sect1>
 
-	<section>
+	<sect1>
 		<title></title>
 
 		<para></para>
-	</section>
+	</sect1>
 
-	<section>
+	<sect1>
 		<title></title>
 
 		<para></para>
-	</section>
-
-	<section>
-		<title></title>
-
-		<para></para>
-	</section>
+	</sect1>
 </chapter>

--- a/docs/coding-standards/chapters/php.xml
+++ b/docs/coding-standards/chapters/php.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<chapter xml:id="ch3">
+	<title>PHP</title>
+
+	<section>
+		<title></title>
+
+		<para>This chapter is about</para>
+	</section>
+
+	<section>
+		<title>Language Constructs</title>
+
+		<section>
+			<title>PHP Code Tags</title>
+
+			<para>Always use the full &lt;?php ?&gt; to delimit PHP code, not the
+				&lt;? ?&gt; shorthand. This is the most portable way to include PHP
+				code
+				on differing operating systems and setups.
+			</para>
+
+			<para>For files that contain only PHP code, the closing tag (?&gt;)
+				should not be included. It is not required by PHP. Leaving this out
+				prevents trailing white space from being accidentally injected into
+				the
+				output that can introduce errors in the Joomla session (see the PHP
+				manual on instruction separation at
+				http://php.net/basic-syntax.instruction-separation).
+			</para>
+
+			<para>TODO Example</para>
+		</section>
+
+		<section>
+			<title>Including Code</title>
+
+			<para>Anywhere you are unconditionally including a file, use
+				require_once. Anywhere you are conditionally including a file (for
+				example, factory methods), use include_once. Either of these will
+				ensure
+				that files are included only once. They share the same file list, so you
+				don't need to worry about mixing them. A file included with
+				require_once
+				will not be included again by include_once.
+			</para>
+
+			<note>
+				<para>include_once and require_once are PHP language statements, not
+					functions. The correct formatting is:
+				</para>
+
+				<para>require_once JPATH_COMPONENT.’/helpers/helper.php’;</para>
+			</note>
+
+			<para>You should not enclose the filename in parentheses. </para>
+		</section>
+
+		<section>
+			<title></title>
+
+			<para></para>
+		</section>
+	</section>
+
+	<section>
+		<title></title>
+
+		<para></para>
+	</section>
+
+	<section>
+		<title></title>
+
+		<para></para>
+	</section>
+
+	<section>
+		<title></title>
+
+		<para></para>
+	</section>
+
+	<section>
+		<title></title>
+
+		<para></para>
+	</section>
+
+	<section>
+		<title></title>
+
+		<para></para>
+	</section>
+</chapter>

--- a/docs/coding-standards/chapters/preface.xml
+++ b/docs/coding-standards/chapters/preface.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<preface xml:id="preface">
+  <title>Preface</title>
+
+  <para>One of the things that sets good software apart from great software is
+  not the features or the actual function the software performs, but it more
+  often than not balances on the quality of the source code. In order to
+  perform in the highly competitive Open Source and propriety software
+  industries, the source code not only needs to be beautifully de-signed, it
+  also needs to be beautiful and elegant to look at.</para>
+
+  <para>Readable code is maintainable code and the compass guides us in
+  achieving that goal is by developing and adhering to a set of well thought
+  out coding standards for the different software languages that are employed
+  in a software project. Joomla has a solid heritage of striving to support a
+  great looking product with great looking code. This document compiles the
+  collective wisdom of past and present contributors to the project to form
+  the definitive standard for coding in Joomla, whether that is for the core
+  Joomla Platform or an extension that forms part of the stack of the Joomla
+  CMS. It also serves as a lighthouse to the Joomla developer community, to
+  safely guide developers around the pitfalls of becoming lackadaisical with
+  respect to writing clean, beautiful code.</para>
+
+  <para>The Joomla Coding Standards borrows heavily from the PEAR coding
+  standard for PHP files, augmenting and diverging where it is deemed sensible
+  to do so</para>
+</preface>

--- a/docs/coding-standards/chapters/source-code-management.xml
+++ b/docs/coding-standards/chapters/source-code-management.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<chapter xml:id="ch1">
+  <title>Source Code Management</title>
+
+  <section>
+    <title></title>
+
+    <para>Before we start talking about what code should look list, it is
+    appropriate to look at how and where the source code is stored. All
+    serious software projects, whether driven by an Open Source community or
+    developed within a company for proprietary purposes will manage the source
+    code is some sort of source or version management system. Joomla currently
+    employs two different systems. One system is for the files that form the
+    product distributed as the Joomla CMS, and the other is for the files that
+    are distributed as the Joomla Platform. Each system is described
+    below.</para>
+  </section>
+
+  <section>
+    <title>The Joomla Platform</title>
+
+    <para>In April 2011 the Joomla project decided to formally split off the
+    core engine that drives the Joomla CMS into a separate project with a
+    separate development path called the Joomla Platform. The Joomla Platform
+    is a PHP framework that is designed to serve as a foundation for not only
+    web applications (like a CMS) but other types of software such as command
+    line applications. The files that form the Joomla Platform are stored in a
+    Distributed Version Control System (DVCS) called Mercurial hosted at
+    bitbucket.org</para>
+
+    <para>You can learn about how to get the Joomla Platform source code from
+    the Mercurial repository from the following page: &lt;permalink to
+    developer.joomla.org staging page&gt;</para>
+
+    <para>Because Mercurial treats the concepts of file revision numbers
+    differently than Subversion, the repository revision number is not
+    required in files (that is, the @version tag is not necessary).</para>
+  </section>
+
+  <section>
+    <title>Compliance Tool</title>
+
+    <para>TODO Mention something about CodeSniffer and the custom Joomla sniff
+    standard for PHP files. The Sniff is based on the standard outlined in
+    this document.</para>
+  </section>
+</chapter>

--- a/docs/manual/appendices/changelog.xml
+++ b/docs/manual/appendices/changelog.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appendix xml:id="app1">
+	<title>Changelog</title>
+
+	<sect1>
+		<title>Version 11.3</title>
+
+		<para>Version 11.3 is currently under development.</para>
+
+		<itemizedlist>
+			<listitem>
+				<para>This manual was added.</para>
+			</listitem>
+			<listitem>
+				<para>The coding standards document was added.</para>
+			</listitem>
+			<listitem>
+				<para>The Joomla codesniffer was added to the tree and the build process.</para>
+			</listitem>
+			<listitem>
+				<para></para>
+			</listitem>
+			<listitem>
+				<para></para>
+			</listitem>
+			<listitem>
+				<para></para>
+			</listitem>
+			<listitem>
+				<para></para>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
+	<sect1>
+		<title>Version 11.2</title>
+
+		<para>Version 11.2 was tagged on 26 July 2011.</para>
+
+		<itemizedlist>
+			<listitem>
+				<para></para>
+			</listitem>
+			<listitem>
+				<para></para>
+			</listitem>
+			<listitem>
+				<para></para>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
+	<sect1>
+		<title>Version 11.1</title>
+
+		<para>Version 11.1 was tagged on DD July 2011. This was the inaugral release of the platform
+			following its separation from the Joomla CMS trunk. It includes the following significant
+			changes:
+		</para>
+
+		<itemizedlist>
+			<listitem>
+				<para>New JDaemon class.</para>
+			</listitem>
+			<listitem>
+				<para>New application/input sub-package that includes JInputCli, JInputCookie and JInputFiles (extended from JInput).</para>
+			</listitem>
+			<listitem>
+				<para>New ApplicationException class.</para>
+			</listitem>
+			<listitem>
+				<para>New JCli class.</para>
+			</listitem>
+			<listitem>
+				<para>New JInput class.</para>
+			</listitem>
+			<listitem>
+				<para>JApplication::getUserState now takes a second 'default' argument that is returned if the 'key' is not found.</para>
+			</listitem>
+			<listitem>
+				<para>New JHttp class.</para>
+			</listitem>
+			<listitem>
+				<para></para>
+			</listitem>
+			<listitem>
+				<para></para>
+			</listitem>
+			<listitem>
+				<para></para>
+			</listitem>
+			<listitem>
+				<para></para>
+			</listitem>
+			<listitem>
+				<para></para>
+			</listitem>
+			<listitem>
+				<para></para>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+</appendix>

--- a/docs/manual/book.xml
+++ b/docs/manual/book.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE book [
+<!ENTITY pref SYSTEM "chapters/preface.xml">
+<!ENTITY app1 SYSTEM "appendices/changelog.xml">
+]>
+
+<book xmlns="http://docbook.org/ns/docbook" version="5.0">
+	<title>The Joomla! Platform Manual</title>
+&pref;
+&app1;
+</book>

--- a/docs/manual/chapters/preface.xml
+++ b/docs/manual/chapters/preface.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<preface xml:id="preface">
+  <title>Preface</title>
+
+  <para>This document compliments the Joomla Platform API reference.</para>
+</preface>


### PR DESCRIPTION
Adds a documentation sections to the tree with two books in Docbook format (which can be ultimately used to push to ePub, PDF and a variety of other formats). First is the platform manual which, at the moment, only holds the changelog appendix (up to date for version 11.2, version 11.1 needs a lot of work).  With this appendix added, other developers doing pull requests can also make synchronous additions to at least the changelog (usually the explanation they put in the pull request, like this one) or notes about the feature changes in the body of the manual (when that is fleshed out more).

The other book is the coding standards manual work in progress from other material that several people have been working on.
