### PR TITLE
Check return value of opendir against NULL and not FALSE

### DIFF
--- a/libraries/joomla/cache/storage/file.php
+++ b/libraries/joomla/cache/storage/file.php
@@ -544,7 +544,11 @@ class JCacheStorageFile extends JCacheStorage
 		}
 
 		// Read the source directory.
-		$handle = opendir($path);
+		if (!($handle = @opendir($path)))
+		{
+			return $arr;
+		}
+
 		if (count($excludefilter))
 		{
 			$excludefilter = '/(' . implode('|', $excludefilter) . ')/';
@@ -629,8 +633,11 @@ class JCacheStorageFile extends JCacheStorage
 		}
 
 		// read the source directory
-		$handle = opendir($path);
-
+		if (!($handle = @opendir($path)))
+		{
+			return $arr;
+		}
+		
 		if (count($excludefilter))
 		{
 			$excludefilter_string = '/(' . implode('|', $excludefilter) . ')/';

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -563,7 +563,11 @@ abstract class JFolder
 		$arr = array();
 
 		// Read the source directory
-		$handle = opendir($path);
+		if (!($handle = @opendir($path)))
+		{
+			return $arr;
+		}
+
 		while (($file = readdir($handle)) !== false)
 		{
 			if ($file != '.' && $file != '..' && !in_array($file, $exclude) &&


### PR DESCRIPTION
We need to check the return value of opendir before it is passed to readdir, readdir does not seem to handle non-valid resources like expected. The following PHP statement will result in an infinite loop of stack traces.

php -r 'while(readdir(1) !== false){ echo "hello"; };

From the php documentation:

The newer internal parameter parsing API has been applied across all the extensions bundled with PHP 5.3.x. This parameter parsing API causes functions to return NULL when passed incompatible parameters. There are some exceptions to this rule, such as the get_class() function, which will continue to return FALSE on error.

So we either have to check the return value of opendir against NULL, or remove the type-specific comparison and simply use != instead of !==.
