### PR TITLE
Forms--Add an integer validation rule

### DIFF
--- a/libraries/joomla/form/rules/integer.php
+++ b/libraries/joomla/form/rules/integer.php
@@ -47,30 +47,60 @@ class JFormRuleInteger extends JFormRule
 	 *
 	 */
 	public function test(& $element, $value, $group = null, & $input = null, & $form = null)
-	{
-
-		$regexarray = array(
-			'all' => '/^[\+\-]?[0-9]* $/',
-			'positive'=> '/^[\+]?[0-9]*[1-9]*[0-9]* $/',
-			'negative'=> '/^[-?[0-9]*[1-9]*[0-9]* $/',
-			'nonnegative' => '/^[\+]?[0-9]* $/'
-		);
+	{  
 		// If the field is empty and not required, the field is valid.
 		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
-		if (!$required && empty($value)) {
+		if (!$required && strlen($value) == 0) {
+
 			return true;
 		}
+
+		// Deal with character strings
+		if (!is_numeric($value)) {
+
+			return false;
+		}
+		// Deal with doubles
+
+		if ( (double) $value - floor($value) > 0) {
+
+			return false;
+		}
+		$value = (int) $value; 
+
 		// If no integertype is specified assume that all are permitted.
 		if (!isset($element['integertype'])) {
 			$element['integertype'] = 'all';
 		}
-		$inttype = $element['integertype'];
-		
-		$regex = $regexarray[$inttype];
-		// Test the value against the regular expression.
-		if (preg_match($regex, trim($value)) == false || $value > $element['max'] || $value < $element['min'] ) {
+		$inttype = (string) $element['integertype'];
+		//Simple elimination of false results
+		if ( isset($element['max'])) {
+			$max = (int) $element['max'];
+			if ( $value > $max) {
+
+				return false;
+			}
+		}
+		if ( isset($element['min'])) {
+			$min = (int) $element['min'];
+			if ( $value < $min) { 
+
+				return false;
+			}
+		}
+		if ($inttype == 'positive' &&  $value < 1) {
+
+			return false;
+		} 
+		elseif ($inttype == 'nonnegative' && $value < 0) {
+
+			return false;
+		} 
+		elseif ($inttype == 'negative' && $value >= 0) {
 
 			return false;
 		}
+
+		return true;
 	}
 }

--- a/libraries/joomla/form/rules/integer.php
+++ b/libraries/joomla/form/rules/integer.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Form
+ *
+ * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+jimport('joomla.form.formrule');
+
+
+/**
+ * Form Rule class for the Joomla Framework.
+ *
+ * @package     Joomla.Framework
+ * @subpackage  Form
+ * @since       11.1
+ */
+class JFormRuleInteger extends JFormRule
+{
+	/**
+	 * Method to test for integer input with optional restrictions to positive, non negative
+	 * negative and maximam and minimum values.
+	 *
+	 * The rule for integers is that they must consist only of digits which
+	 * may be preceeded by a + or - but no other characters are permitted.
+	 * This validation will permit a blank to pass.
+	 * Integer type optionally allows restricting values to a specific subset of all integers.
+	 * Non negative refers to all positive numbers and 0.
+	 * All refers to all integers.
+	 *
+	 * @param   object  $element  The JXMLElement object representing the <field /> tag for the
+	 *                            form field object.
+	 * @param   mixed   $value    The form field value to validate.
+	 * @param   string  $group    The field name group control value. This acts as as an array
+	 *                            container for the field. For example if the field has name="foo"
+	 *                            and the group value is set to "bar" then the full field name
+	 *                            would end up being "bar[foo]".
+	 * @param   object  $input    An optional JRegistry object with the entire data set to validate
+	 *                            against the entire form.
+	 * @param   object  $form     The form object for which the field is being tested.
+	 *
+	 * @return  boolean  True if the value is valid, false otherwise.
+	 *
+	 */
+	public function test(& $element, $value, $group = null, & $input = null, & $form = null)
+	{
+
+		$regexarray = array(
+			'all' => '/^[\+\-]?[0-9]* $/',
+			'positive'=> '/^[\+]?[0-9]*[1-9]*[0-9]* $/',
+			'negative'=> '/^[-?[0-9]*[1-9]*[0-9]* $/',
+			'nonnegative' => '/^[\+]?[0-9]* $/'
+		);
+		// If the field is empty and not required, the field is valid.
+		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
+		if (!$required && empty($value)) {
+			return true;
+		}
+		// If no integertype is specified assume that all are permitted.
+		if (!isset($element['integertype'])) {
+			$element['integertype'] = 'all';
+		}
+		$inttype = $element['integertype'];
+		
+		$regex = $regexarray[$inttype];
+		// Test the value against the regular expression.
+		if (preg_match($regex, trim($value)) == false || $value > $element['max'] || $value < $element['min'] ) {
+
+			return false;
+		}
+	}
+}

--- a/libraries/joomla/form/rules/integer.php
+++ b/libraries/joomla/form/rules/integer.php
@@ -17,7 +17,7 @@ jimport('joomla.form.formrule');
  *
  * @package     Joomla.Framework
  * @subpackage  Form
- * @since       11.1
+ * @since       11.3
  */
 class JFormRuleInteger extends JFormRule
 {
@@ -32,94 +32,110 @@ class JFormRuleInteger extends JFormRule
 	 * Non negative refers to all positive numbers and 0.
 	 * All refers to all integers.
 	 *
-	 * @param   object  $element  The JXMLElement object representing the <field /> tag for the
-	 *                            form field object.
-	 * @param   mixed   $value    The form field value to validate.
-	 * @param   string  $group    The field name group control value. This acts as as an array
-	 *                            container for the field. For example if the field has name="foo"
-	 *                            and the group value is set to "bar" then the full field name
-	 *                            would end up being "bar[foo]".
-	 * @param   object  $input    An optional JRegistry object with the entire data set to validate
-	 *                            against the entire form.
-	 * @param   object  $form     The form object for which the field is being tested.
+	 * @param   object   $element  The JXMLElement object representing the <field /> tag for the
+	 *                             form field object.
+	 * @param   mixed    $value    The form field value to validate.
+	 * @param   string   $group    The field name group control value. This acts as as an array
+	 *                             container for the field. For example if the field has name="foo"
+	 *                             and the group value is set to "bar" then the full field name
+	 *                             would end up being "bar[foo]".
+	 * @param   object   $input    An optional JRegistry object with the entire data set to validate
+	 *                             against the entire form.
+	 * @param   object   $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
+	 * @since   11.3
 	 */
 	public function test(& $element, $value, $group = null, & $input = null, & $form = null)
-	{  
+	{
 		// If the field is empty and not required, the field is valid.
 		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
-		if (!$required && strlen($value) == 0) {
+		if (!$required && strlen($value) == 0)
+		{
 
 			return true;
 		}
 
 		// Deal with character strings
-		if (!is_numeric($value)) {
+		if (!is_numeric($value))
+		{
 
 			return false;
 		}
 		// Deal with doubles
 
-		if ( (double) $value - floor($value) > 0) {
+		if ( (double) $value - floor($value) > 0)
+		{
 
 			return false;
 		}
 		$value = (int) $value; 
 
 		// If no integertype is specified assume that all are permitted.
-		if (!isset($element['integertype'])) {
+		if (!isset($element['integertype']))
+		{
 			$element['integertype'] = 'all';
 		}
 		$inttype = (string) $element['integertype'];
 		//Simple elimination of false results
-		if ( isset($element['max'])) {
+		if ( isset($element['max']))
+		{
 			$max = (int) $element['max'];
-			if ( $value > $max) {
+			if ( $value > $max)
+			{
 
 				return false;
 			}
-			if (($max > 0 && $inttype == 'negative') || ($max < 0 && $inttype == 'nonnegative') || ($max < 1 && $inttype == 'positive' )){
+			if (($max > 0 && $inttype == 'negative') || ($max < 0 && $inttype == 'nonnegative') || ($max < 1 && $inttype == 'positive' ))
+			{
 				// Form settings warning.
 				JLog::add('Integer rule is misconfigured.', JLog::WARNING, 'Form');
 
 				return false;
 			}
 		}
-		if ( isset($element['min'])) {
+		if ( isset($element['min']))
+		{
 			$min = (int) $element['min'];
-			if ( $value < $min) {
+			if ( $value < $min)
+			{
 
 				return false;
 			}
 
-			if (($min > 0 && $inttype == 'negative') || ($min < 0 && $inttype == 'nonnegative') || ($min < 1 && $inttype == 'positive' )){
+			if (($min > 0 && $inttype == 'negative') || ($min < 0 && $inttype == 'nonnegative') || ($min < 1 && $inttype == 'positive' ))
+			{
 				// Form settings warning.
 				JLog::add('Integer rule is misconfigured.', JLog::WARNING, 'Form');
 
 				return false;
 			
 			}
-			if ((isset($max) && $min >= $max)){
+			if ((isset($max) && $min >= $max))
+			{
 				// Form settings warning.
 				JLog::add('Integer rule is misconfigured.', JLog::WARNING, 'Form');
 
 				return false;
 			}
 		}
-		if ($inttype == 'positive' &&  $value < 1) {
+		if ($inttype == 'positive' &&  $value < 1)
+		{
 
 			return false;
 		} 
-		elseif ($inttype == 'nonnegative' && $value < 0) {
+		elseif ($inttype == 'nonnegative' && $value < 0)
+		{
 
 			return false;
 		} 
-		elseif ($inttype == 'negative' && $value >= 0) {
+		elseif ($inttype == 'negative' && $value >= 0)
+		{
 
 			return false;
 		}
+
 		return true;
 	}
 }

--- a/libraries/joomla/form/rules/integer.php
+++ b/libraries/joomla/form/rules/integer.php
@@ -80,10 +80,30 @@ class JFormRuleInteger extends JFormRule
 
 				return false;
 			}
+			if (($max > 0 && $inttype == 'negative') || ($max < 0 && $inttype == 'nonnegative') || ($max < 1 && $inttype == 'positive' )){
+				// Form settings warning.
+				JLog::add('Integer rule is misconfigured.', JLog::WARNING, 'Form');
+
+				return false;
+			}
 		}
 		if ( isset($element['min'])) {
 			$min = (int) $element['min'];
-			if ( $value < $min) { 
+			if ( $value < $min) {
+
+				return false;
+			}
+
+			if (($min > 0 && $inttype == 'negative') || ($min < 0 && $inttype == 'nonnegative') || ($min < 1 && $inttype == 'positive' )){
+				// Form settings warning.
+				JLog::add('Integer rule is misconfigured.', JLog::WARNING, 'Form');
+
+				return false;
+			
+			}
+			if ((isset($max) && $min >= $max)){
+				// Form settings warning.
+				JLog::add('Integer rule is misconfigured.', JLog::WARNING, 'Form');
 
 				return false;
 			}
@@ -100,7 +120,6 @@ class JFormRuleInteger extends JFormRule
 
 			return false;
 		}
-
 		return true;
 	}
 }

--- a/tests/suite/joomla/form/rules/JFormRuleIntegerTest.php
+++ b/tests/suite/joomla/form/rules/JFormRuleIntegerTest.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ * @package     Joomla.UnitTest
+ */
+
+/**
+ * Test class for JForm.
+ *
+ * @package		Joomla.UnitTest
+ * @subpackage  Form
+ *
+ */
+class JFormRuleTelTest extends JoomlaTestCase
+{
+	/**
+	 * set up for testing
+	 *
+	 * @return void
+	 */
+		public function setUp()
+	{
+		jimport('joomla.form.formrule');
+		jimport('joomla.utilities.xmlelement');
+		require_once JPATH_PLATFORM.'/joomla/form/rules/integer.php';
+	}
+	
+	/**
+	 * Test the JFormRuleUrl::test method.
+	 *
+	 * @dataProvider provider
+     */
+	public function testInteger($xmlfield,$integer,$expected)
+	{
+		// Initialise variables.
+
+		$rule = new JFormRuleInteger;
+
+		// The field allows you to optionally limit the range of integers in specific ways.
+		// integer tests unrestricted integers.
+		// integerAll tests unrestricted integers with the All attribute.
+		// integerPositive accepts only positive integers.
+		// integerNonNegative accepts positive integers and 0.
+		// integerNegative  accepts only negative integers.
+		// integerMax restricts to values less than or equal to a maximum.
+		// integerMin restricts to values greater than or equal to a minimum.
+		// integerComp_1 uses both a type and a maximum.
+		// integerComp_2 uses both a type and a minimum.
+		// integerComp_3 uses both a type and a maximum that are in conflict.
+		// integerComp_4 uses both a type and a minimum that are in conflict.
+		// integerComp_4 uses a maximum and a minimum that are in conflict.
+		
+		
+		$xml = simplexml_load_string('<form>
+		<field name="integer" />,
+		<field name="integerAll" integertype="all"/>,
+		<field name="integerPositive" integertype="positive"/>,
+		<field name="integerNonnegative" integertype="nonnegative"/>,
+		<field name="integerNegative" integertype="negative"/>,
+		<field name="integerMax" max="100"/>,
+		<field name="integerMin" min="10"/>,
+		<field name="integerComp_1" integertype="positive" max="100"/>,
+		<field name="integerComp_2" integertype="positive" min="10"/>,
+		<field name="integerComp_3" integertype="positive" max="-1"/>,
+		<field name="integerComp_4" integertype="negative" min="10"/>,
+		<field name="integerComp_4" max="1" min="10"/>,
+		
+		</form>', 'JXMLElement');
+		$i = 0;
+		while ($i <= 10) {
+			
+				if ($xmlfield == $i){
+					if ($expected == 'false'){
+						// Test fail conditions.
+						$this->assertThat(
+							$rule->test($xml->field[$i], $integer),
+							$this->isFalse(),
+							'Line:'.__LINE__.' The rule should return'.$expected.'.'
+						);
+					}
+					if ($expected == 'true'){
+						// Test pass conditions.
+						$this->assertThat(
+							$rule->test($xml->field[$i], $integer),
+							$this->isTrue(),
+							'Line:'.__LINE__.' The rule should return'.$expected.'.'
+						);
+				}
+				$i ++;
+			}
+		}
+	}
+	/**
+	 * Test the JFormRuleInteger::test method.
+	 *  @dataProvider provider
+	 */
+	public function provider()
+	{
+		
+		return
+		array(
+			array('Positive'					=> '0','5', 'true'),
+			array('Negative'					=> '0','-7', 'true'),
+			array('0'							=> '0','0', 'true'),
+			array('Blank'						=> '0','', 'true'),
+			array('Characters'					=> '0','aaa', 'false'),
+			array('Decimal'						=> '0','1.5', 'false'),
+			array('Mixed'						=> '0','1aaa', 'false'),
+
+			array('Positive'					=> '1','5', 'true'),
+			array('Negative'					=> '1','-7', 'true'),
+			array('0'							=> '1','0', 'true'),
+			array('Blank'						=> '1','', 'true'),
+			array('Characters'					=> '1','aaa', 'false'),
+			array('Decimal'						=> '1','1.5', 'false'),
+			array('Mixed'						=> '1','1aaa', 'false'),
+			
+			array('Positive'					=> '2','5', 'true'),
+			array('Negative'					=> '2','-7', 'false'),
+			array('0'							=> '2','0', 'false'),
+			array('Blank'						=> '2','', 'true'),
+			array('Characters'					=> '2','aaa', 'false'),
+			array('Decimal'						=> '2','1.5', 'false'),
+			array('Mixed'						=> '2','1aaa', 'false'),
+			
+			array('Positive'					=> '3','5', 'true'),
+			array('Negative'					=> '3','-7', 'false'),
+			array('0'							=> '3','0', 'true'),
+			array('Blank'						=> '3','', 'true'),
+			array('Characters'					=> '3','aaa', 'false'),
+			array('Decimal' 					=> '3','1.5', 'false'),
+			array('Mixed'						=> '3','1aaa', 'false'),
+			
+			
+			array('Positive'					=> '4','5', 'false'),
+			array('Negative'					=> '4','-7', 'true'),
+			array('0'							=> '4','0', 'false'),
+			array('Blank'						=> '4','', 'true'),
+			array('Characters' 					=> '4','aaa', 'false'),
+			array('Decimal' 					=> '4','1.5', 'false'),
+			array('Mixed'						=> '4','1aaa', 'false'),
+			
+			array('Positive'					=> '5','5', 'true'),
+			array('Negative'					=> '5','-7','true'),
+			array('0'							=> '5','0', 'true'),
+			array('Big number'					=> '5','200', 'false'),
+			
+			array('Positive'					=> '6','5', 'false'),
+			array('Negative'					=> '6','-7','false'),
+			array('0'							=> '6','0', 'false'),
+			array('Big number'					=> '6','200', 'true'),
+			
+			array('Positive'					=> '7','5', 'true'),
+			array('Negative'					=> '7','-7','true'),
+			array('0'							=> '7','0', 'true'),
+			array('Big number'					=> '7','200', 'false'),
+
+			array('Positive'					=> '8','5', 'false'),
+			array('Negative'					=> '8','-7','false'),
+			array('0'							=> '8','0', 'false'),
+			array('Blank'						=> '8','', 'true'),
+			
+			array('Positive'					=> '9','5', 'false'),
+			array('Negative'					=> '9','-7','false'),
+			array('0'							=> '9','0', 'false'),
+			array('Blank'						=> '9','', 'true'),
+			
+			array('Positive'					=> '9','5', 'false'),
+			array('Negative'					=> '9','-7','false'),
+			array('0'							=> '9','0', 'false'),
+			array('Blank'						=> '9','', 'true'),
+			
+		);
+	}	
+}

--- a/tests/suite/joomla/form/rules/JFormRuleIntegerTest.php
+++ b/tests/suite/joomla/form/rules/JFormRuleIntegerTest.php
@@ -12,7 +12,7 @@
  * @subpackage  Form
  *
  */
-class JFormRuleTelTest extends JoomlaTestCase
+class JFormRuleIntegerTest extends JoomlaTestCase
 {
 	/**
 	 * set up for testing
@@ -71,105 +71,107 @@ class JFormRuleTelTest extends JoomlaTestCase
 		while ($i <= 10) {
 			
 				if ($xmlfield == $i){
-					if ($expected == 'false'){
+					if ($expected == false){
 						// Test fail conditions.
 						$this->assertThat(
 							$rule->test($xml->field[$i], $integer),
 							$this->isFalse(),
-							'Line:'.__LINE__.' The rule should return'.$expected.'.'
+							'Line:'.__LINE__.' The rule should return '.$expected.'.'
 						);
 					}
-					if ($expected == 'true'){
+					if ($expected == true){
 						// Test pass conditions.
 						$this->assertThat(
 							$rule->test($xml->field[$i], $integer),
 							$this->isTrue(),
-							'Line:'.__LINE__.' The rule should return'.$expected.'.'
+							'Line:'.__LINE__.' The rule should return '.$expected.'.'
 						);
 				}
-				$i ++;
+
 			}
+			$i++;
 		}
 	}
 	/**
 	 * Test the JFormRuleInteger::test method.
-	 *  @dataProvider provider
+	 *
 	 */
 	public function provider()
 	{
 		
 		return
-		array(
-			array('Positive'					=> '0','5', 'true'),
-			array('Negative'					=> '0','-7', 'true'),
-			array('0'							=> '0','0', 'true'),
-			array('Blank'						=> '0','', 'true'),
-			array('Characters'					=> '0','aaa', 'false'),
-			array('Decimal'						=> '0','1.5', 'false'),
-			array('Mixed'						=> '0','1aaa', 'false'),
+		array(					// Value, field, expected
+			'Positive integer'			=> array('0', '5', true),
+			'+ sign integer'			=> array('0', '+5', true),
+			'Negative integer'			=> array('0', '-7', true),
+			'0 integer'					=> array('0', '0', true),
+			'Blank integer'				=> array('0', '', true),
+			'Characters integer'		=> array('0', 'aaa', false),
+			'Decimal integer'			=> array('0', '1.5', false),
+			'Mixed integer'				=> array('0', '1aaa', false),
 
-			array('Positive'					=> '1','5', 'true'),
-			array('Negative'					=> '1','-7', 'true'),
-			array('0'							=> '1','0', 'true'),
-			array('Blank'						=> '1','', 'true'),
-			array('Characters'					=> '1','aaa', 'false'),
-			array('Decimal'						=> '1','1.5', 'false'),
-			array('Mixed'						=> '1','1aaa', 'false'),
+			'Positive integerAll'			=> array('1', '5', true),
+			'Negative integerAll'			=> array('1', '-7', true),
+			'0 integerAll'					=> array('1', '0', true),
+			'Blank integerAll'				=> array('1', '', true),
+			'Characters integerAll'			=> array('1', 'aaa', false),
+			'Decimal integerAll'			=> array('1', '1.5', false),
+			'Mixed integerAll'				=> array('1', '1aaa', false),
 			
-			array('Positive'					=> '2','5', 'true'),
-			array('Negative'					=> '2','-7', 'false'),
-			array('0'							=> '2','0', 'false'),
-			array('Blank'						=> '2','', 'true'),
-			array('Characters'					=> '2','aaa', 'false'),
-			array('Decimal'						=> '2','1.5', 'false'),
-			array('Mixed'						=> '2','1aaa', 'false'),
+			'Positive integerAll'			=> array('2', '5', true),
+			'Negative integerPositive'			=> array('2', '-7', false),
+			'0 integerPositive'					=> array('2', '0', false),
+			'Blank integerPositive'				=> array('2', '', true),
+			'Characters integerPositive'		=> array('2','aaa', false),
+			'Decimal integerPositive'			=> array('2','1.5', false),
+			'Mixed integerPositive'				=> array('2','1aaa', false),
 			
-			array('Positive'					=> '3','5', 'true'),
-			array('Negative'					=> '3','-7', 'false'),
-			array('0'							=> '3','0', 'true'),
-			array('Blank'						=> '3','', 'true'),
-			array('Characters'					=> '3','aaa', 'false'),
-			array('Decimal' 					=> '3','1.5', 'false'),
-			array('Mixed'						=> '3','1aaa', 'false'),
+			'Positive integerNonnegative'			=> array('3','5', true),
+			'Negative integerNonnegative'			=> array('3','-7', false),
+			'0 integerNonnegative'					=> array('3','0', true),
+			'Blank integerNonnegative'				=> array('3','', true),
+			'Characters integerNonnegative'			=> array('3','aaa', false),
+			'Decimal integerNonnegative' 			=> array('3','1.5', false),
+			'Mixed integerNonnegative'				=> array('3','1aaa', false),
 			
 			
-			array('Positive'					=> '4','5', 'false'),
-			array('Negative'					=> '4','-7', 'true'),
-			array('0'							=> '4','0', 'false'),
-			array('Blank'						=> '4','', 'true'),
-			array('Characters' 					=> '4','aaa', 'false'),
-			array('Decimal' 					=> '4','1.5', 'false'),
-			array('Mixed'						=> '4','1aaa', 'false'),
+			'Positive integerNegative'			=> array('4','5', false),
+			'Negative integerNegative'			=> array('4','-7', true),
+			'0 integerNegative'					=> array('4','0', false),
+			'Blank integerNegative'				=> array('4','', true),
+			'Characters integerNegative' 		=> array('4','aaa', false),
+			'Decimal integerNegative' 			=> array('4','1.5', false),
+			'Mixed integerNegative'				=> array('4','1aaa', false),
+	
+			'Positive integerMax'			=> array('5','5', true),
+			'Negative integerMax'			=> array('5','-7',true),
+			'0 integerMax'					=> array('5','0', true),
+			'Big number integerMax'			=> array('5','200', false),
 			
-			array('Positive'					=> '5','5', 'true'),
-			array('Negative'					=> '5','-7','true'),
-			array('0'							=> '5','0', 'true'),
-			array('Big number'					=> '5','200', 'false'),
-			
-			array('Positive'					=> '6','5', 'false'),
-			array('Negative'					=> '6','-7','false'),
-			array('0'							=> '6','0', 'false'),
-			array('Big number'					=> '6','200', 'true'),
-			
-			array('Positive'					=> '7','5', 'true'),
-			array('Negative'					=> '7','-7','true'),
-			array('0'							=> '7','0', 'true'),
-			array('Big number'					=> '7','200', 'false'),
+			'Positive integerMin'			=> array('6','5', false),
+			'Negative integerMin'			=> array('6','-7',false),
+			'0 integerMin'					=> array('6','0', false),
+			'Big number integerMin'			=> array('6','200', true),
+	
+			'Positive integerComp_1'			=> array('7','5', true),
+			'Negative integerComp_1'			=> array('7','-7',false),
+			'0 integerComp_1'					=> array('7','0', false),
+			'Big number integerComp_1'			=> array('7','200', false),
 
-			array('Positive'					=> '8','5', 'false'),
-			array('Negative'					=> '8','-7','false'),
-			array('0'							=> '8','0', 'false'),
-			array('Blank'						=> '8','', 'true'),
-			
-			array('Positive'					=> '9','5', 'false'),
-			array('Negative'					=> '9','-7','false'),
-			array('0'							=> '9','0', 'false'),
-			array('Blank'						=> '9','', 'true'),
-			
-			array('Positive'					=> '9','5', 'false'),
-			array('Negative'					=> '9','-7','false'),
-			array('0'							=> '9','0', 'false'),
-			array('Blank'						=> '9','', 'true'),
+			'Positive integerComp_2'			=> array('8','5', false),
+			'Negative integerComp_2'			=> array('8','-7',false),
+			'0 integerComp_2'					=> array('8','0', false),
+			'Blank integerComp_2'				=> array('8','', true),
+	
+			'Positive integerComp_3'			=> array('9','5', false),
+			'Negative integerComp_3'			=> array('9','-7',false),
+			'0  integerComp_3'					=> array('9','0', false),
+			'Blank  integerComp_3'				=> array('9','', true),
+	
+			'Positive integerComp_4'			=> array('10','5', false),
+			'Negative integerComp_4'			=> array('10','-7',false),
+			'0  integerComp_4'					=> array('10','0', false),
+			'Blank  integerComp_4'				=> array('10','', true)
 			
 		);
 	}	


### PR DESCRIPTION
This is a rule we need in the CMS for leading/intro/links/columns and some modules, but I think there are a lot of use cases. Can also be used to validate the integer field type.

Tests included
