### PR TITLE
Graceful return when update manifest cannot be parsed

### DIFF
--- a/docs/manual/appendices/changelog.xml
+++ b/docs/manual/appendices/changelog.xml
@@ -29,6 +29,9 @@
 					validation.</para>
 			</listitem>
 			<listitem>
+				<para>Implemented graceful failure when update manifest is not available</para>
+			</listitem>
+			<listitem>
 				<para></para>
 			</listitem>
 			<listitem>

--- a/libraries/joomla/updater/adapters/collection.php
+++ b/libraries/joomla/updater/adapters/collection.php
@@ -226,7 +226,7 @@ class JUpdaterCollection extends JUpdateAdapter
 			
 			JLog::add("Error parsing url: ".$url, JLog::WARNING, 'updater');
 			$app = JFactory::getApplication();
-			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_OPEN_URL', $url));
+			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_OPEN_URL', $url), 'warning');
 			return false;
 		}
 
@@ -240,7 +240,7 @@ class JUpdaterCollection extends JUpdateAdapter
 			{
 				JLog::add("Error parsing url: ".$url, JLog::WARNING, 'updater');
 				$app = JFactory::getApplication();
-				$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_PARSE_URL', $url));
+				$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_PARSE_URL', $url), 'warning');
 				return false;
 			}
 		}

--- a/libraries/joomla/updater/adapters/collection.php
+++ b/libraries/joomla/updater/adapters/collection.php
@@ -223,7 +223,10 @@ class JUpdaterCollection extends JUpdateAdapter
 			$query->where('update_site_id = ' . $this->_update_site_id);
 			$dbo->setQuery($query);
 			$dbo->Query();
-			JError::raiseWarning('101', JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_OPEN_URL', $url));
+			
+			JLog::add("Error parsing url: ".$url, JLog::WARNING);
+			$app = JFactory::getApplication();
+			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_OPEN_URL', $url));
 			return false;
 		}
 
@@ -235,7 +238,9 @@ class JUpdaterCollection extends JUpdateAdapter
 		{
 			if (!xml_parse($this->xml_parser, $data, feof($fp)))
 			{
-				JError::raiseWarning('101', JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_PARSE_URL', $url));
+				JLog::add("Error parsing url: ".$url, JLog::WARNING);
+				$app = JFactory::getApplication();
+				$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_PARSE_URL', $url));
 				return false;
 			}
 		}

--- a/libraries/joomla/updater/adapters/collection.php
+++ b/libraries/joomla/updater/adapters/collection.php
@@ -235,9 +235,8 @@ class JUpdaterCollection extends JUpdateAdapter
 		{
 			if (!xml_parse($this->xml_parser, $data, feof($fp)))
 			{
-				die(
-					sprintf("XML error: %s at line %d", xml_error_string(xml_get_error_code($this->xml_parser)),
-						xml_get_current_line_number($this->xml_parser)));
+				JError::raiseWarning('101', JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_PARSE_URL', $url));
+				return false;
 			}
 		}
 		// TODO: Decrement the bad counter if non-zero

--- a/libraries/joomla/updater/adapters/collection.php
+++ b/libraries/joomla/updater/adapters/collection.php
@@ -224,7 +224,7 @@ class JUpdaterCollection extends JUpdateAdapter
 			$dbo->setQuery($query);
 			$dbo->Query();
 			
-			JLog::add("Error parsing url: ".$url, JLog::WARNING);
+			JLog::add("Error parsing url: ".$url, JLog::WARNING, 'updater');
 			$app = JFactory::getApplication();
 			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_OPEN_URL', $url));
 			return false;
@@ -238,7 +238,7 @@ class JUpdaterCollection extends JUpdateAdapter
 		{
 			if (!xml_parse($this->xml_parser, $data, feof($fp)))
 			{
-				JLog::add("Error parsing url: ".$url, JLog::WARNING);
+				JLog::add("Error parsing url: ".$url, JLog::WARNING, 'updater');
 				$app = JFactory::getApplication();
 				$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_PARSE_URL', $url));
 				return false;

--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -162,7 +162,10 @@ class JUpdaterExtension extends JUpdateAdapter
 			$query->where('update_site_id = ' . $this->_update_site_id);
 			$dbo->setQuery($query);
 			$dbo->Query();
-			JError::raiseWarning('101', JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_OPEN_URL', $url));
+			
+			JLog::add("Error opening url: ".$url, JLog::WARNING);
+			$app = JFactory::getApplication();
+			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_OPEN_URL', $url));
 			return false;
 		}
 
@@ -175,7 +178,9 @@ class JUpdaterExtension extends JUpdateAdapter
 		{
 			if (!xml_parse($this->xml_parser, $data, feof($fp)))
 			{
-				JError::raiseWarning('101', JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_PARSE_URL', $url));
+				JLog::add("Error parsing url: ".$url, JLog::WARNING);
+				$app = JFactory::getApplication();
+				$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_PARSE_URL', $url));
 				return false;
 			}
 		}

--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -163,7 +163,7 @@ class JUpdaterExtension extends JUpdateAdapter
 			$dbo->setQuery($query);
 			$dbo->Query();
 			
-			JLog::add("Error opening url: ".$url, JLog::WARNING);
+			JLog::add("Error opening url: ".$url, JLog::WARNING, 'updater');
 			$app = JFactory::getApplication();
 			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_OPEN_URL', $url));
 			return false;
@@ -178,7 +178,7 @@ class JUpdaterExtension extends JUpdateAdapter
 		{
 			if (!xml_parse($this->xml_parser, $data, feof($fp)))
 			{
-				JLog::add("Error parsing url: ".$url, JLog::WARNING);
+				JLog::add("Error parsing url: ".$url, JLog::WARNING, 'updater');
 				$app = JFactory::getApplication();
 				$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_PARSE_URL', $url));
 				return false;

--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -165,7 +165,7 @@ class JUpdaterExtension extends JUpdateAdapter
 			
 			JLog::add("Error opening url: ".$url, JLog::WARNING, 'updater');
 			$app = JFactory::getApplication();
-			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_OPEN_URL', $url));
+			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_OPEN_URL', $url), 'warning');
 			return false;
 		}
 
@@ -180,7 +180,7 @@ class JUpdaterExtension extends JUpdateAdapter
 			{
 				JLog::add("Error parsing url: ".$url, JLog::WARNING, 'updater');
 				$app = JFactory::getApplication();
-				$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_PARSE_URL', $url));
+				$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_PARSE_URL', $url), 'warning');
 				return false;
 			}
 		}

--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -175,13 +175,8 @@ class JUpdaterExtension extends JUpdateAdapter
 		{
 			if (!xml_parse($this->xml_parser, $data, feof($fp)))
 			{
-				die(
-					sprintf(
-						'XML error: %s at line %d',
-						xml_error_string(xml_get_error_code($this->xml_parser)),
-						xml_get_current_line_number($this->xml_parser)
-					)
-				);
+				JError::raiseWarning('101', JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_PARSE_URL', $url));
+				return false;
 			}
 		}
 		xml_parser_free($this->xml_parser);


### PR DESCRIPTION
Instead of just dying when the update manifest cannot be parsed, give a warning and move on.
