### PR TITLE
If given id is ourselves, behave like no id was given

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -162,20 +162,22 @@ abstract class JFactory
 	public static function getUser($id = null)
 	{
 		jimport('joomla.user.user');
-
-		if (is_null($id))
-		{
+	
+		if (is_null($id)) {
 			$instance = self::getSession()->get('user');
-			if (!($instance instanceof JUser))
-			{
+			if (!($instance instanceof JUser)) {
 				$instance = JUser::getInstance();
 			}
 		}
-		else
-		{
-			$instance = JUser::getInstance($id);
+		else {
+			$current = self::getSession()->get('user');
+			if($current->id != $id){
+				$instance = JUser::getInstance($id);
+			} else {
+				$instance = self::getSession()->get('user');
+			}
 		}
-
+	
 		return $instance;
 	}
 

--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -163,17 +163,23 @@ abstract class JFactory
 	{
 		jimport('joomla.user.user');
 	
-		if (is_null($id)) {
+		if (is_null($id)) 
+		{
 			$instance = self::getSession()->get('user');
-			if (!($instance instanceof JUser)) {
+			if (!($instance instanceof JUser)) 
+			{
 				$instance = JUser::getInstance();
 			}
 		}
-		else {
+		else 
+		{
 			$current = self::getSession()->get('user');
-			if($current->id != $id){
+			if($current->id != $id)
+			{
 				$instance = JUser::getInstance($id);
-			} else {
+			} 
+			else 
+			{
 				$instance = self::getSession()->get('user');
 			}
 		}


### PR DESCRIPTION
JFactory::getUser() and JFactory::getUser($id) does not behave the same even if $id is the same number as the currently logged in user, so that if a plugin has used JUser::bind() to change the user object, JFactory will not give back the correct object if given an id. This patch will make getUser() check if the given id matches the currently logged in user and behave like no id was given if that is the case.
