### PR TITLE
Allow removal of admin menu entries

### DIFF
--- a/docs/manual/appendices/changelog.xml
+++ b/docs/manual/appendices/changelog.xml
@@ -40,6 +40,10 @@
 				<para>Implemented graceful failure when update manifest is not available</para>
 			</listitem>
 			<listitem>
+				<para>Allow components to remove the admin menu entry in their postflight script, and not 
+				throw errors during uninstall if the menu entries are not there.</para>
+			</listitem>
+			<listitem>
 				<para></para>
 			</listitem>
 			<listitem>

--- a/libraries/joomla/installer/adapters/component.php
+++ b/libraries/joomla/installer/adapters/component.php
@@ -1595,7 +1595,7 @@ class JInstallerComponent extends JAdapterInstance
 		$ids = $db->loadColumn();
 
 		// Check for error
-		if ($error = $db->getErrorMsg() || empty($ids))
+		if ($error = $db->getErrorMsg())
 		{
 			JError::raiseWarning('', JText::_('JLIB_INSTALLER_ERROR_COMP_REMOVING_ADMIN_MENUS_FAILED'));
 
@@ -1606,7 +1606,7 @@ class JInstallerComponent extends JAdapterInstance
 
 			return false;
 		}
-		else
+		else if (!empty($ids))
 		{
 			// Iterate the items to delete each one.
 			foreach ($ids as $menuid)


### PR DESCRIPTION
This will allow developers to remove the backend entry in the components menu using for example the postflight() hook in the installer without throwing errors about missing menu entries when the component is uninstalled.
