### PR TITLE
JDocument fluent interface

### DIFF
--- a/docs/manual/appendices/changelog.xml
+++ b/docs/manual/appendices/changelog.xml
@@ -40,8 +40,21 @@
 				<para>Implemented graceful failure when update manifest is not available</para>
 			</listitem>
 			<listitem>
-				<para>Allow components to remove the admin menu entry in their postflight script, and not 
+				<para>Allow components to remove the admin menu entry in their postflight script, and not
 				throw errors during uninstall if the menu entries are not there.</para>
+			</listitem>
+			<listitem>
+				<para>Implemented fluid interface for setter and mutator methods in document package.
+					JDocument: parse(), addScript(), addScriptDeclaration(), addStyleSheet(),
+						addStyleDeclaration(), setBase(), setBuffer(), setCharset(), setDescription(),
+						setDirection(), setGenerator(), setLanguage(), setLineEnd(), setLink(), setMetaData(),
+						setMimeEncoding(), setModifiedDate(), setTab(), setTitle(), setType().
+					JDocumentFeed: addItem(), setEnclosure().
+					JDocumentHTML: addCustomTag(), addFavicon(), addHeadLink(), mergeHeadData(),
+						setBuffer(), setHeadData(), _fetchTemplate(), _parseTemplate().
+					JDocumentJSON: setName().
+					JDocumentOpensearch: addImage(), addUrl(), setShortName().
+					JDocumentXml: setName().</para>
 			</listitem>
 			<listitem>
 				<para></para>

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -41,7 +41,7 @@ class JDocument extends JObject
 	 * Document full URL
 	 *
 	 * @var    string
-	 * @since   11.1
+	 * @since  11.1
 	 */
 	public $link = '';
 
@@ -57,7 +57,7 @@ class JDocument extends JObject
 	 * Contains the document language setting
 	 *
 	 * @var    string
-	 * @since   11.1
+	 * @since  11.1
 	 */
 	public $language = 'en-gb';
 
@@ -95,7 +95,7 @@ class JDocument extends JObject
 	/**
 	 * Contains the line end string
 	 *
-	 * @var  string
+	 * @var    string
 	 * @since  11.1
 	 */
 	public $_lineEnd = "\12";
@@ -127,7 +127,7 @@ class JDocument extends JObject
 	/**
 	 * Document profile
 	 *
-	 * @var  string
+	 * @var    string
 	 * @since  11.1
 	 */
 	public $_profile = '';
@@ -167,7 +167,7 @@ class JDocument extends JObject
 	/**
 	 * Array of meta tags
 	 *
-	 * @var  array
+	 * @var    array
 	 * @since  11.1
 	 */
 	public $_metaTags = array();
@@ -175,7 +175,7 @@ class JDocument extends JObject
 	/**
 	 * The rendering engine
 	 *
-	 * @var  object
+	 * @var    object
 	 * @since  11.1
 	 */
 	public $_engine = null;
@@ -314,13 +314,15 @@ class JDocument extends JObject
 	 *
 	 * @param   string  $type  Type document is to set to
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
 	public function setType($type)
 	{
 		$this->_type = $type;
+
+		return $this;
 	}
 
 	/**
@@ -353,13 +355,15 @@ class JDocument extends JObject
 	 * @param   string  $content  The content to be set in the buffer.
 	 * @param   array   $options  Array of optional elements.
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
 	public function setBuffer($content, $options = array())
 	{
 		self::$_buffer = $content;
+
+		return $this;
 	}
 
 	/**
@@ -407,7 +411,7 @@ class JDocument extends JObject
 	 * @param   boolean  $http_equiv  META type "http-equiv" defaults to null
 	 * @param   boolean  $sync        Should http-equiv="content-type" by synced with HTTP-header?
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
@@ -440,6 +444,8 @@ class JDocument extends JObject
 				$this->_metaTags['standard'][$name] = $content;
 			}
 		}
+
+		return $this;
 	}
 
 	/**
@@ -450,15 +456,17 @@ class JDocument extends JObject
 	 * @param   boolean  $defer  Adds the defer attribute.
 	 * @param   boolean  $async  Adds the async attribute.
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
-	 * @since  11.1
+	 * @since   11.1
 	 */
 	public function addScript($url, $type = "text/javascript", $defer = false, $async = false)
 	{
 		$this->_scripts[$url]['mime'] = $type;
 		$this->_scripts[$url]['defer'] = $defer;
 		$this->_scripts[$url]['async'] = $async;
+
+		return $this;
 	}
 
 	/**
@@ -467,7 +475,7 @@ class JDocument extends JObject
 	 * @param   string  $content  Script
 	 * @param   string  $type     Scripting mime (defaults to 'text/javascript')
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
@@ -481,6 +489,8 @@ class JDocument extends JObject
 		{
 			$this->_script[strtolower($type)] .= chr(13) . $content;
 		}
+
+		return $this;
 	}
 
 	/**
@@ -491,15 +501,17 @@ class JDocument extends JObject
 	 * @param   string  $media    Media type that this stylesheet applies to
 	 * @param   array   $attribs  Array of attributes
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
-	 * @since    11.1
+	 * @since   11.1
 	 */
 	public function addStyleSheet($url, $type = 'text/css', $media = null, $attribs = array())
 	{
 		$this->_styleSheets[$url]['mime'] = $type;
 		$this->_styleSheets[$url]['media'] = $media;
 		$this->_styleSheets[$url]['attribs'] = $attribs;
+
+		return $this;
 	}
 
 	/**
@@ -508,9 +520,9 @@ class JDocument extends JObject
 	 * @param   string  $content  Style declarations
 	 * @param   string  $type     Type of stylesheet (defaults to 'text/css')
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
-	 * @since    11.1
+	 * @since   11.1
 	 */
 	public function addStyleDeclaration($content, $type = 'text/css')
 	{
@@ -522,6 +534,8 @@ class JDocument extends JObject
 		{
 			$this->_style[strtolower($type)] .= chr(13) . $content;
 		}
+
+		return $this;
 	}
 
 	/**
@@ -529,13 +543,15 @@ class JDocument extends JObject
 	 *
 	 * @param   string  $type  Charset encoding string
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
 	public function setCharset($type = 'utf-8')
 	{
 		$this->_charset = $type;
+
+		return $this;
 	}
 
 	/**
@@ -555,13 +571,15 @@ class JDocument extends JObject
 	 *
 	 * @param   string  $lang  The language to be set
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
 	public function setLanguage($lang = "en-gb")
 	{
 		$this->language = strtolower($lang);
+
+		return $this;
 	}
 
 	/**
@@ -581,13 +599,15 @@ class JDocument extends JObject
 	 *
 	 * @param   string  $dir  The language direction to be set
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
 	public function setDirection($dir = "ltr")
 	{
 		$this->direction = strtolower($dir);
+
+		return $this;
 	}
 
 	/**
@@ -607,13 +627,15 @@ class JDocument extends JObject
 	 *
 	 * @param   string  $title  The title to be set
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
 	public function setTitle($title)
 	{
 		$this->title = $title;
+
+		return $this;
 	}
 
 	/**
@@ -633,13 +655,15 @@ class JDocument extends JObject
 	 *
 	 * @param   string  $base  The base URI to be set
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
 	public function setBase($base)
 	{
 		$this->base = $base;
+
+		return $this;
 	}
 
 	/**
@@ -659,13 +683,15 @@ class JDocument extends JObject
 	 *
 	 * @param   string  $description  The description to set
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
 	public function setDescription($description)
 	{
 		$this->description = $description;
+
+		return $this;
 	}
 
 	/**
@@ -685,13 +711,15 @@ class JDocument extends JObject
 	 *
 	 * @param   string  $url  A url
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
 	public function setLink($url)
 	{
 		$this->link = $url;
+
+		return $this;
 	}
 
 	/**
@@ -711,13 +739,15 @@ class JDocument extends JObject
 	 *
 	 * @param   string  $generator  The generator to be set
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
 	public function setGenerator($generator)
 	{
 		$this->_generator = $generator;
+
+		return $this;
 	}
 
 	/**
@@ -737,13 +767,15 @@ class JDocument extends JObject
 	 *
 	 * @param   string  $date  The date to be set
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
 	public function setModifiedDate($date)
 	{
 		$this->_mdate = $date;
+
+		return $this;
 	}
 
 	/**
@@ -770,7 +802,7 @@ class JDocument extends JObject
 	 * @param   string   $type  The document type to be sent
 	 * @param   boolean  $sync  Should the type be synced with HTML?
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 *
@@ -785,6 +817,8 @@ class JDocument extends JObject
 		{
 			$this->setMetaData('content-type', $type, true, false);
 		}
+
+		return $this;
 	}
 
 	/**
@@ -804,7 +838,7 @@ class JDocument extends JObject
 	 *
 	 * @param   string  $style  "win", "mac", "unix" or custom string.
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
@@ -824,6 +858,8 @@ class JDocument extends JObject
 			default:
 				$this->_lineEnd = $style;
 		}
+
+		return $this;
 	}
 
 	/**
@@ -843,13 +879,15 @@ class JDocument extends JObject
 	 *
 	 * @param   string  $string  String used to indent ("\11", "\t", '  ', etc.).
 	 *
-	 * @return  void
+	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
 	public function setTab($string)
 	{
 		$this->_tab = $string;
+
+		return $this;
 	}
 
 	/**
@@ -906,13 +944,13 @@ class JDocument extends JObject
 	 *
 	 * @param   array  $params  The array of parameters
 	 *
-	 * @return  null
+	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
 	public function parse($params = array())
 	{
-		return null;
+		return $this;
 	}
 
 	/**

--- a/libraries/joomla/document/feed/feed.php
+++ b/libraries/joomla/document/feed/feed.php
@@ -11,8 +11,6 @@ defined('JPATH_PLATFORM') or die();
 
 jimport('joomla.document.document');
 
-jimport('joomla.document.document');
-
 /**
  * DocumentFeed class, provides an easy interface to parse and display any feed document
  *
@@ -244,7 +242,7 @@ class JDocumentFeed extends JDocument
 	 *
 	 * @param   JFeedItem  &$item  The feeditem to add to the feed.
 	 *
-	 * @return  void
+	 * @return  JDocumentFeed  instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
@@ -252,6 +250,8 @@ class JDocumentFeed extends JDocument
 	{
 		$item->source = $this->link;
 		$this->items[] = $item;
+
+		return $this;
 	}
 }
 
@@ -390,13 +390,15 @@ class JFeedItem extends JObject
 	 *
 	 * @param   object  $enclosure  The JFeedItem to add to the feed.
 	 *
-	 * @return  void
+	 * @return  JFeedItem instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
 	public function setEnclosure($enclosure)
 	{
 		$this->enclosure = $enclosure;
+
+		return $this;
 	}
 }
 

--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -140,7 +140,7 @@ class JDocumentHTML extends JDocument
 	 *
 	 * @param   array  $data  The document head data in array form
 	 *
-	 * @return  void
+	 * @return  JDocumentHTML instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
@@ -161,6 +161,8 @@ class JDocumentHTML extends JDocument
 		$this->_scripts = (isset($data['scripts']) && !empty($data['scripts'])) ? $data['scripts'] : $this->_scripts;
 		$this->_script = (isset($data['script']) && !empty($data['script'])) ? $data['script'] : $this->_script;
 		$this->_custom = (isset($data['custom']) && !empty($data['custom'])) ? $data['custom'] : $this->_custom;
+
+		return $this;
 	}
 
 	/**
@@ -168,7 +170,7 @@ class JDocumentHTML extends JDocument
 	 *
 	 * @param   array  $data  The document head data in array form
 	 *
-	 * @return  void
+	 * @return  JDocumentHTML instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
@@ -180,10 +182,12 @@ class JDocumentHTML extends JDocument
 			return;
 		}
 
-		$this->title = (isset($data['title']) && !empty($data['title']) && !stristr($this->title, $data['title'])) ? $this->title . $data['title']
-			: $this->title;
+		$this->title = (isset($data['title']) && !empty($data['title']) && !stristr($this->title, $data['title']))
+					? $this->title . $data['title']
+					: $this->title;
 		$this->description = (isset($data['description']) && !empty($data['description']) && !stristr($this->description, $data['description']))
-			? $this->description . $data['description'] : $this->description;
+							? $this->description . $data['description']
+							: $this->description;
 		$this->link = (isset($data['link'])) ? $data['link'] : $this->link;
 
 		if (isset($data['metaTags']))
@@ -199,9 +203,11 @@ class JDocumentHTML extends JDocument
 		}
 
 		$this->_links = (isset($data['links']) && !empty($data['links']) && is_array($data['links']))
-			? array_unique(array_merge($this->_links, $data['links'])) : $this->_links;
+						? array_unique(array_merge($this->_links, $data['links']))
+						: $this->_links;
 		$this->_styleSheets = (isset($data['styleSheets']) && !empty($data['styleSheets']) && is_array($data['styleSheets']))
-			? array_merge($this->_styleSheets, $data['styleSheets']) : $this->_styleSheets;
+							? array_merge($this->_styleSheets, $data['styleSheets'])
+							: $this->_styleSheets;
 
 		if (isset($data['style']))
 		{
@@ -215,7 +221,8 @@ class JDocumentHTML extends JDocument
 		}
 
 		$this->_scripts = (isset($data['scripts']) && !empty($data['scripts']) && is_array($data['scripts']))
-			? array_merge($this->_scripts, $data['scripts']) : $this->_scripts;
+						? array_merge($this->_scripts, $data['scripts'])
+						: $this->_scripts;
 
 		if (isset($data['script']))
 		{
@@ -229,7 +236,10 @@ class JDocumentHTML extends JDocument
 		}
 
 		$this->_custom = (isset($data['custom']) && !empty($data['custom']) && is_array($data['custom']))
-			? array_unique(array_merge($this->_custom, $data['custom'])) : $this->_custom;
+						? array_unique(array_merge($this->_custom, $data['custom']))
+						: $this->_custom;
+
+		return $this;
 	}
 
 	/**
@@ -244,7 +254,7 @@ class JDocumentHTML extends JDocument
 	 * @param   string  $relType   Relation type attribute.  Either rel or rev (default: 'rel').
 	 * @param   array   $attribs   Associative array of remaining attributes.
 	 *
-	 * @return  void
+	 * @return  JDocumentHTML instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
@@ -253,6 +263,8 @@ class JDocumentHTML extends JDocument
 		$this->_links[$href]['relation'] = $relation;
 		$this->_links[$href]['relType'] = $relType;
 		$this->_links[$href]['attribs'] = $attribs;
+
+		return $this;
 	}
 
 	/**
@@ -266,7 +278,7 @@ class JDocumentHTML extends JDocument
 	 * @param   string  $type      File type
 	 * @param   string  $relation  Relation of link
 	 *
-	 * @return  void
+	 * @return  JDocumentHTML instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
@@ -274,6 +286,8 @@ class JDocumentHTML extends JDocument
 	{
 		$href = str_replace('\\', '/', $href);
 		$this->addHeadLink($href, $relation, 'rel', array('type' => $type));
+
+		return $this;
 	}
 
 	/**
@@ -281,7 +295,7 @@ class JDocumentHTML extends JDocument
 	 *
 	 * @param   string  $html  The HTML to add to the head
 	 *
-	 * @return  void
+	 * @return  JDocumentHTML instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
@@ -289,6 +303,8 @@ class JDocumentHTML extends JDocument
 	public function addCustomTag($html)
 	{
 		$this->_custom[] = trim($html);
+
+		return $this;
 	}
 
 	/**
@@ -366,7 +382,7 @@ class JDocumentHTML extends JDocument
 	 * @param   string  $content  The content to be set in the buffer.
 	 * @param   array   $options  Array of optional elements.
 	 *
-	 * @return  void
+	 * @return  JDocumentHTML instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
@@ -382,6 +398,8 @@ class JDocumentHTML extends JDocument
 		}
 
 		parent::$_buffer[$options['type']][$options['name']] = $content;
+
+		return $this;
 	}
 
 	/**
@@ -389,14 +407,13 @@ class JDocumentHTML extends JDocument
 	 *
 	 * @param   array  $params  Parameters for fetching the template
 	 *
-	 * @return  void
+	 * @return  JDocumentHTML instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
 	public function parse($params = array())
 	{
-		$this->_fetchTemplate($params);
-		$this->_parseTemplate();
+		return $this->_fetchTemplate($params)->_parseTemplate();
 	}
 
 	/**
@@ -446,8 +463,9 @@ class JDocumentHTML extends JDocument
 		{
 			// odd parts (modules)
 			$name = strtolower($words[$i]);
-			$words[$i] = ((isset(parent::$_buffer['modules'][$name])) && (parent::$_buffer['modules'][$name] === false)) ? 0
-				: count(JModuleHelper::getModules($name));
+			$words[$i] = ((isset(parent::$_buffer['modules'][$name])) && (parent::$_buffer['modules'][$name] === false))
+						? 0
+						: count(JModuleHelper::getModules($name));
 		}
 
 		$str = 'return ' . implode(' ', $words) . ';';
@@ -541,7 +559,7 @@ class JDocumentHTML extends JDocument
 	 *
 	 * @param   array  $params  Parameters to determine the template
 	 *
-	 * @return  void
+	 * @return  JDocumentHTML instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
@@ -574,12 +592,16 @@ class JDocumentHTML extends JDocument
 
 		// Load
 		$this->_template = $this->_loadTemplate($directory . '/' . $template, $file);
+
+		return $this;
 	}
 
 	/**
 	 * Parse a document template
 	 *
 	 * @return  The parsed contents of the template
+	 *
+	 * @return  JDocumentHTML instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
@@ -614,6 +636,8 @@ class JDocumentHTML extends JDocument
 
 			$this->_template_tags = $template_tags_first + $template_tags_last;
 		}
+
+		return $this;
 	}
 
 	/**

--- a/libraries/joomla/document/json/json.php
+++ b/libraries/joomla/document/json/json.php
@@ -11,8 +11,6 @@ defined('JPATH_PLATFORM') or die();
 
 jimport('joomla.document.document');
 
-jimport('joomla.document.document');
-
 /**
  * JDocumentJSON class, provides an easy interface to parse and display JSON output
  *
@@ -88,12 +86,14 @@ class JDocumentJSON extends JDocument
 	 *
 	 * @param   string  $name  Document name
 	 *
-	 * @return  void
+	 * @return  JDocumentJSON instance of $this to allow chaining
 	 *
-	 * @since  11.1
+	 * @since   11.1
 	 */
 	public function setName($name = 'joomla')
 	{
 		$this->_name = $name;
+
+		return $this;
 	}
 }

--- a/libraries/joomla/document/opensearch/opensearch.php
+++ b/libraries/joomla/document/opensearch/opensearch.php
@@ -171,13 +171,15 @@ class JDocumentOpensearch extends JDocument
 	 *
 	 * @param   string  $name  The name.
 	 *
-	 * @return  void
+	 * @return  JDocumentOpensearch instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
 	public function setShortName($name)
 	{
 		$this->_shortName = $name;
+
+		return $this;
 	}
 
 	/**
@@ -185,13 +187,15 @@ class JDocumentOpensearch extends JDocument
 	 *
 	 * @param   JOpenSearchUrl  &$url  The url to add to the description.
 	 *
-	 * @return  void
+	 * @return  JDocumentOpensearch instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
 	public function addUrl(&$url)
 	{
 		$this->_urls[] = $url;
+
+		return $this;
 	}
 
 	/**
@@ -199,13 +203,15 @@ class JDocumentOpensearch extends JDocument
 	 *
 	 * @param   JOpenSearchImage  &$image  The image to add to the description.
 	 *
-	 * @return  void
+	 * @return  JDocumentOpensearch instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
 	public function addImage(&$image)
 	{
 		$this->_images[] = $image;
+
+		return $this;
 	}
 }
 

--- a/libraries/joomla/document/xml/xml.php
+++ b/libraries/joomla/document/xml/xml.php
@@ -11,8 +11,6 @@ defined('JPATH_PLATFORM') or die();
 
 jimport('joomla.document.document');
 
-jimport('joomla.document.document');
-
 /**
  * DocumentXML class, provides an easy interface to parse and display XML output
  *
@@ -85,12 +83,14 @@ class JDocumentXml extends JDocument
 	 *
 	 * @param   string  $name  Document name
 	 *
-	 * @return  void
+	 * @return  JDocumentXml instance of $this to allow chaining
 	 *
-	 * @since  11.1
+	 * @since   11.1
 	 */
 	public function setName($name = 'joomla')
 	{
 		$this->_name = $name;
+
+		return $this;
 	}
 }


### PR DESCRIPTION
- changed setters and mutators to return `$this` instead of "void".
- cleanup of duplicate `jimport('joomla.document.document')`
