### PR TITLE
Unit test fails on document package

### DIFF
--- a/tests/suite/joomla/document/JDocumentTest.php
+++ b/tests/suite/joomla/document/JDocumentTest.php
@@ -706,7 +706,7 @@ class JDocumentTest extends PHPUnit_Framework_TestCase
 
 		$this->assertThat(
 			$this->object->parse(),
-			$this->equalTo(null)
+			$this->isInstanceOf('JDocument')
 		);
 	}
 


### PR DESCRIPTION
Fixed unit test.  The test for parse verified that the method returned null.  The method now returns a JDocument object.  Test changed to reflect that.
