### PR TITLE
Fixed a typo in JHttp (stream_set_timeout vs stream_settimeout)

### DIFF
--- a/libraries/joomla/client/http.php
+++ b/libraries/joomla/client/http.php
@@ -350,7 +350,7 @@ class JHttp
 		$this->connections[$key] = fsockopen($host, $port, $errno, $err, $this->timeout);
 		if ($this->connections[$key])
 		{
-			stream_settimeout($this->connections[$key], $this->timeout);
+			stream_set_timeout($this->connections[$key], $this->timeout);
 		}
 
 		return $this->connections[$key];


### PR DESCRIPTION
JHttp is throwing a fatal error when used due to a typo (stream_set_timeout misspelled as stream_settimeout)
