### PR TITLE
Fixed function name mentioned in deprecated warning.

### DIFF
--- a/libraries/joomla/database/database.php
+++ b/libraries/joomla/database/database.php
@@ -1655,7 +1655,7 @@ abstract class JDatabase implements JDatabaseInterface
 	public function loadResultArray($offset = 0)
 	{
 		// Deprecation warning.
-		JLog::add('JDatabase::loadResultArray() is deprecated. Use JDatabase::getColumn().', JLog::WARNING, 'deprecated');
+		JLog::add('JDatabase::loadResultArray() is deprecated. Use JDatabase::loadColumn().', JLog::WARNING, 'deprecated');
 
 		return $this->loadColumn($offset);
 	}


### PR DESCRIPTION
Deprecated JDatabase::loadResultArray() logged a warning with the incorrect replacement function name. This patch changes it from getColumn() to loadColumn().
