### PR TITLE
Add improved support for JSON responses to JController.

### DIFF
--- a/docs/manual/appendices/changelog.xml
+++ b/docs/manual/appendices/changelog.xml
@@ -315,6 +315,9 @@
 				<para>More JavaScript functions have been moved to the Joomla namespaced and updated.</para>
 			</listitem>
 			<listitem>
+				<para>Add improved support for JSON responses to JController.</para>
+			</listitem>
+			<listitem>
 				<para></para>
 			</listitem>
 			<listitem>


### PR DESCRIPTION
This is based on the functionality found the installation controller, it was expanded quite a bit for the AJAX installation in 1.7. This is basically the same as found in 1.7 except for some cleanup. (No deprecated APIs, a MIME type bug fixed, some unnecessary code removed)

This API makes it somewhat easier to send JSON responses because it takes care of some of the repetitive tasks like sending along any enqueued messages, the token and so on.

Having these things always in the same format will also make it possible to add a JS API in the future that takes care of all these things.

I'm not completely sure about the API. For now I just followed what was present but I see at least three options:
1) Remove JControllerJsonResponse and fold it's functionality into JController::sendJsonResponse().
2) Add JControllerJsonResponse::send() that contains the json encoding and response header parts of JController::sendJsonResponse().
3) The way the pull is done.

The advantage of 2) and 3) is that JControllerJsonResponse is also potentially useful for JSON views.
