### PR TITLE
Add improved support for JSON responses to JController.

### DIFF
--- a/libraries/joomla/application/component/controller.php
+++ b/libraries/joomla/application/component/controller.php
@@ -1129,4 +1129,76 @@ class JController extends JObject
 
 		return $this;
 	}
+
+	/**
+	 * Method to handle a send a JSON response. The data parameter
+	 * can be an Exception object for when a fatal error has occurred or
+	 * a JObject for a good response.
+	 *
+	 * @param   object  $response	JObject on success, Exception on failure.
+	 *
+	 * @return	void
+	 *
+	 * @since	11.3
+	 */
+	public function sendJsonResponse($response)
+	{
+		// Check if we need to send an error code.
+		if ($response instanceof Exception) {
+			// Send the appropriate error code response.
+			JResponse::setHeader('status', $response->getCode());
+		}
+
+		// Send the JSON response.
+		echo json_encode(new JControllerJsonResponse($response));
+	}
+}
+
+/**
+ * Joomla Core JSON Response Class
+ *
+ * @package    Joomla.Platform
+ * @subpackage Application
+ * @since      11.3
+ */
+class JControllerJsonResponse
+{
+	function __construct($state)
+	{
+		// The old token is invalid so send a new one.
+		$this->token = JUtility::getToken(true);
+
+		// Get the language and send it's code along
+		$this->lang = JFactory::getLanguage()->getTag();
+
+		// Get the message queue
+		$messages = JFactory::getApplication()->getMessageQueue();
+
+		// Build the sorted message list
+		if (is_array($messages) && count($messages)) {
+			foreach ($messages as $msg)
+			{
+				if (isset($msg['type']) && isset($msg['message'])) {
+					$lists[$msg['type']][] = $msg['message'];
+				}
+			}
+		}
+
+		// If messages exist add them to the output
+		if (isset($lists) && is_array($lists)) {
+			$this->messages = $lists;
+		}
+
+		// Check if we are dealing with an error.
+		if ($state instanceof Exception) {
+			// Prepare the error response.
+			$this->error	= true;
+			$this->header	= JText::_('INSTL_HEADER_ERROR');
+			$this->message	= $state->getMessage();
+		} else {
+			// Prepare the response data.
+			$this->error	= false;
+			$this->data		= $state;
+		}
+	}
 }


### PR DESCRIPTION
This is based on the functionality found the installation controller, it was expanded quite a bit for the AJAX installation in 1.7. This is basically the same as found in 1.7 except for some cleanup. (No deprecated APIs, a MIME type bug fixed, some unnecessary code removed)

This API makes it somewhat easier to send JSON responses because it takes care of some of the repetitive tasks like sending along any enqueued messages, the token and so on.

Having these things always in the same format will also make it possible to add a JS API in the future that takes care of all these things.

I'm not completely sure about the API. For now I just followed what was present but I see at least three options:
1) Remove JControllerJsonResponse and fold it's functionality into JController::sendJsonResponse().
2) Add JControllerJsonResponse::send() that contains the json encoding and response header parts of JController::sendJsonResponse().
3) The way the pull is done.

The advantage of 2) and 3) is that JControllerJsonResponse is also potentially useful for JSON views.
