### PR TITLE
Joomla CMS  [#25962] APC lock method seems to be returning the wrong thing 

### DIFF
--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -314,7 +314,7 @@ class JCache extends JObject
 	 * @param   string  $group     The cache data group
 	 * @param   string  $locktime  The default locktime for locking the cache.
 	 *
-	 * @return  boolean  True on success, false otherwise.
+	 * @return  object  Properties are lock and locklooped
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/cache/storage/apc.php
+++ b/libraries/joomla/cache/storage/apc.php
@@ -186,7 +186,7 @@ class JCacheStorageApc extends JCacheStorage
 	 * @param   string   $group     The cache data group
 	 * @param   integer  $locktime  Cached item max lock time
 	 *
-	 * @return  boolean  True on success, false otherwise.
+	 * @return  object   Properties are lock and locklooped
 	 *
 	 * @since   11.1
 	 */


### PR DESCRIPTION
Fixes incorrect return value in docblocks.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=25962
