### PR TITLE
Joomla CMS [#25836] Strange behaviour in renderModule ($content variable) 

### DIFF
--- a/libraries/joomla/application/module/helper.php
+++ b/libraries/joomla/application/module/helper.php
@@ -171,10 +171,9 @@ abstract class JModuleHelper
 				$lang->load($module->module, JPATH_BASE, $lang->getDefault(), false, false) ||
 				$lang->load($module->module, dirname($path), $lang->getDefault(), false, false);
 
-			$content = '';
 			ob_start();
 			include $path;
-			$module->content = ob_get_contents() . $content;
+			$module->content = ob_get_contents() . '';
 			ob_end_clean();
 		}
 


### PR DESCRIPTION
From http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=25836 which was in the CMS for a few months waiting for review and now Andrew closed.  It was already tested by people in the CMS. It just eliminates an unnecessary variable which was causing a name clash for some developers.
