### PR TITLE
Joomla CMS [#26353] Invalid opendir + readdir construct is used in Joomla 

### DIFF
--- a/libraries/joomla/filesystem/path.php
+++ b/libraries/joomla/filesystem/path.php
@@ -78,6 +78,10 @@ class JPath
 
 		if (is_dir($path))
 		{
+			if (!($handle = @opendir($path)))
+			{
+				return $ret;
+			}
 			$dh = opendir($path);
 
 			while ($file = readdir($dh))


### PR DESCRIPTION
Based on http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=26353

Addresses an issue when folders are unwritable.
