### PR TITLE
Allow package extension types to use scriptfiles

### DIFF
--- a/libraries/joomla/installer/adapters/package.php
+++ b/libraries/joomla/installer/adapters/package.php
@@ -90,7 +90,7 @@ class JInstallerPackage extends JAdapterInstance
 		$group = (string) $this->manifest->packagename;
 		if (!empty($group))
 		{
-			$this->parent->setPath('extension_root', JPATH_ADMINISTRATOR . '/manifests/packages/' . implode(DS, explode('/', $group)));
+			$this->parent->setPath('extension_root', JPATH_MANIFESTS . '/packages/' . implode(DS, explode('/', $group)));
 		}
 		else
 		{

--- a/libraries/joomla/installer/adapters/package.php
+++ b/libraries/joomla/installer/adapters/package.php
@@ -105,7 +105,7 @@ class JInstallerPackage extends JAdapterInstance
 		 */
 		// If there is an manifest class file, lets load it; we'll copy it later (don't have dest yet)
 		$this->scriptElement = $this->manifest->scriptfile;
-		$manifestScript = (string)$this->manifest->scriptfile;
+		$manifestScript = (string) $this->manifest->scriptfile;
 
 		if ($manifestScript)
 		{

--- a/libraries/joomla/installer/adapters/package.php
+++ b/libraries/joomla/installer/adapters/package.php
@@ -109,7 +109,7 @@ class JInstallerPackage extends JAdapterInstance
 
 		if ($manifestScript)
 		{
-			$manifestScriptFile = $this->parent->getPath('source').'/'.$manifestScript;
+			$manifestScriptFile = $this->parent->getPath('source') . '/' . $manifestScript;
 
 			if (is_file($manifestScriptFile))
 			{
@@ -118,7 +118,7 @@ class JInstallerPackage extends JAdapterInstance
 			}
 
 			// Set the class name
-			$classname = $element.'InstallerScript';
+			$classname = $element . 'InstallerScript';
 
 			if (class_exists($classname))
 			{

--- a/libraries/joomla/installer/adapters/package.php
+++ b/libraries/joomla/installer/adapters/package.php
@@ -90,7 +90,7 @@ class JInstallerPackage extends JAdapterInstance
 		$group = (string) $this->manifest->packagename;
 		if (!empty($group))
 		{
-			$this->parent->setPath('extension_root', JPATH_ADMINISTRATOR . '/manifests/packages/' . implode(DS,explode('/',$group)));
+			$this->parent->setPath('extension_root', JPATH_ADMINISTRATOR . '/manifests/packages/' . implode(DS, explode('/', $group)));
 		}
 		else
 		{

--- a/libraries/joomla/installer/adapters/package.php
+++ b/libraries/joomla/installer/adapters/package.php
@@ -90,14 +90,63 @@ class JInstallerPackage extends JAdapterInstance
 		$group = (string) $this->manifest->packagename;
 		if (!empty($group))
 		{
-			// TODO: Remark this location
-			$this->parent->setPath('extension_root', JPATH_ROOT . '/packages/' . implode(DS, explode('/', $group)));
+			$this->parent->setPath('extension_root', JPATH_ADMINISTRATOR . '/manifests/packages/' . implode(DS,explode('/',$group)));
 		}
 		else
 		{
 			$this->parent->abort(JText::sprintf('JLIB_INSTALLER_ABORT_PACK_INSTALL_NO_PACK', JText::_('JLIB_INSTALLER_' . strtoupper($this->route))));
 			return false;
 		}
+
+		/**
+		 * ---------------------------------------------------------------------------------------------
+		 * Installer Trigger Loading
+		 * ---------------------------------------------------------------------------------------------
+		 */
+		// If there is an manifest class file, lets load it; we'll copy it later (don't have dest yet)
+		$this->scriptElement = $this->manifest->scriptfile;
+		$manifestScript = (string)$this->manifest->scriptfile;
+
+		if ($manifestScript)
+		{
+			$manifestScriptFile = $this->parent->getPath('source').'/'.$manifestScript;
+
+			if (is_file($manifestScriptFile))
+			{
+				// load the file
+				include_once $manifestScriptFile;
+			}
+
+			// Set the class name
+			$classname = $element.'InstallerScript';
+
+			if (class_exists($classname))
+			{
+				// create a new instance
+				$this->parent->manifestClass = new $classname($this);
+				// and set this so we can copy it later
+				$this->set('manifest_script', $manifestScript);
+				// Note: if we don't find the class, don't bother to copy the file
+			}
+		}
+
+		// run preflight if possible (since we know we're not an update)
+		ob_start();
+		ob_implicit_flush(false);
+
+		if ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'preflight'))
+		{
+			if ($this->parent->manifestClass->preflight($this->route, $this) === false)
+			{
+				// Install failed, rollback changes
+				$this->parent->abort(JText::_('JLIB_INSTALLER_ABORT_PACKAGE_INSTALL_CUSTOM_INSTALL_FAILURE'));
+
+				return false;
+			}
+		}
+
+		$msg = ob_get_contents(); // create msg object; first use here
+		ob_end_clean();
 
 		// Filesystem Processing Section
 
@@ -113,6 +162,7 @@ class JInstallerPackage extends JAdapterInstance
 		// Install all necessary files
 		if (count($this->manifest->files->children()))
 		{
+			$i = 0;
 			foreach ($this->manifest->files->children() as $child)
 			{
 				$file = $source . '/' . $child;
@@ -139,6 +189,14 @@ class JInstallerPackage extends JAdapterInstance
 					);
 					return false;
 				}
+				else
+				{
+					$results[$i] = array(
+						'name' => $tmpInstaller->manifest->name,
+						'result' => $tmpInstaller->install($package['dir'])
+					);
+				}
+				$i++;
 			}
 		}
 		else
@@ -185,6 +243,24 @@ class JInstallerPackage extends JAdapterInstance
 
 		// Finalization and Cleanup Section
 
+		// Start Joomla! 1.6
+		ob_start();
+		ob_implicit_flush(false);
+
+		if ($this->parent->manifestClass && method_exists($this->parent->manifestClass, $this->route))
+		{
+			if ($this->parent->manifestClass->{$this->route}($this) === false)
+			{
+				// Install failed, rollback changes
+				$this->parent->abort(JText::_('JLIB_INSTALLER_ABORT_FILE_INSTALL_CUSTOM_INSTALL_FAILURE'));
+
+				return false;
+			}
+		}
+
+		$msg .= ob_get_contents(); // append messages
+		ob_end_clean();
+
 		// Lastly, we will copy the manifest file to its appropriate place.
 		$manifest = array();
 		$manifest['src'] = $this->parent->getPath('manifest');
@@ -197,6 +273,49 @@ class JInstallerPackage extends JAdapterInstance
 				JText::sprintf('JLIB_INSTALLER_ABORT_PACK_INSTALL_COPY_SETUP', JText::_('JLIB_INSTALLER_ABORT_PACK_INSTALL_NO_FILES'))
 			);
 			return false;
+		}
+
+		// If there is a manifest script, let's copy it.
+		if ($this->get('manifest_script'))
+		{
+			// First, we have to create a folder for the script if one isn't present
+			$created = false;
+
+			if (!file_exists($this->parent->getPath('extension_root')))
+			{
+				JFolder::create($this->parent->getPath('extension_root'));
+			}
+
+			$path['src'] = $this->parent->getPath('source') . '/' . $this->get('manifest_script');
+			$path['dest'] = $this->parent->getPath('extension_root') . '/' . $this->get('manifest_script');
+
+			if (!file_exists($path['dest']) || $this->parent->getOverwrite())
+			{
+				if (!$this->parent->copyFiles(array($path)))
+				{
+					// Install failed, rollback changes
+					$this->parent->abort(JText::_('JLIB_INSTALLER_ABORT_PACKAGE_INSTALL_MANIFEST'));
+
+					return false;
+				}
+			}
+		}
+
+		// And now we run the postflight
+		ob_start();
+		ob_implicit_flush(false);
+
+		if ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'postflight'))
+		{
+			$this->parent->manifestClass->postflight($this->route, $this, $results);
+		}
+
+		$msg .= ob_get_contents(); // append messages
+		ob_end_clean();
+
+		if ($msg != '')
+		{
+			$this->parent->set('extension_message', $msg);
 		}
 		return $row->extension_id;
 	}
@@ -276,6 +395,46 @@ class JInstallerPackage extends JAdapterInstance
 			return false;
 		}
 
+		// If there is an manifest class file, let's load it
+		$this->scriptElement = $manifest->scriptfile;
+		$manifestScript = (string) $manifest->scriptfile;
+
+		if ($manifestScript)
+		{
+			$manifestScriptFile = $this->parent->getPath('extension_root') . '/' . $manifestScript;
+
+			if (is_file($manifestScriptFile))
+			{
+				// Load the file
+				include_once $manifestScriptFile;
+			}
+
+			// Set the class name
+			$classname = $row->element . 'InstallerScript';
+
+			if (class_exists($classname))
+			{
+				// Create a new instance
+				$this->parent->manifestClass = new $classname($this);
+				// And set this so we can copy it later
+				$this->set('manifest_script', $manifestScript);
+
+				// Note: if we don't find the class, don't bother to copy the file
+			}
+		}
+
+		ob_start();
+		ob_implicit_flush(false);
+
+		// Run uninstall if possible
+		if ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'uninstall'))
+		{
+			$this->parent->manifestClass->uninstall($this);
+		}
+
+		$msg = ob_get_contents();
+		ob_end_clean();
+
 		$error = false;
 		foreach ($manifest->filelist as $extension)
 		{
@@ -303,6 +462,7 @@ class JInstallerPackage extends JAdapterInstance
 		if (!$error)
 		{
 			JFile::delete($manifestFile);
+			JFolder::delete($this->parent->getPath('extension_root'));
 			$row->delete();
 		}
 		else

--- a/libraries/joomla/installer/packagemanifest.php
+++ b/libraries/joomla/installer/packagemanifest.php
@@ -54,7 +54,7 @@ class JPackageManifest extends JObject
 	/**
 	 * @var string scriptfile Scriptfile for the package
 	 */
-	var $scriptfile = '';
+	protected $scriptfile = '';
 
 	/**
 	 * @var string update Update site for the package

--- a/libraries/joomla/installer/packagemanifest.php
+++ b/libraries/joomla/installer/packagemanifest.php
@@ -52,6 +52,11 @@ class JPackageManifest extends JObject
 	protected $packagerurl = '';
 
 	/**
+	 * @var string scriptfile Scriptfile for the package
+	 */
+	var $scriptfile = '';
+
+	/**
 	 * @var string update Update site for the package
 	 */
 	protected $update = '';
@@ -118,6 +123,7 @@ class JPackageManifest extends JObject
 			$this->description = (string) $xml->description;
 			$this->packager = (string) $xml->packager;
 			$this->packagerurl = (string) $xml->packagerurl;
+			$this->scriptfile = (string) $xml->scriptfile;
 			$this->version = (string) $xml->version;
 
 			if (isset($xml->files->file) && count($xml->files->file))


### PR DESCRIPTION
This pull request makes changes to the package extension installer to allow for a scriptfile to be included on a package.

This will allow for a package to have a single preflight method, for example to check for any dependencies, such as another extension's presence or a minimum Joomla! version.

Additionally, a $results array has been created with each extension's name and $tmpInstaller->install result (which should be true given where it is compiled).  This array is pushed forward to the postflight method, and can be used to display a list of the installed extensions, something many 3PD already do with their custom installation methods (see http://twitpic.com/65xw3i for an example).

Lastly, the TODO concerning the extension_root has been resolved by setting it to JPATH_MANIFESTS/packages/packagename and this is the location the scriptfile is stored in.
