### PR TITLE
Check if module properly is set

### DIFF
--- a/libraries/joomla/application/module/helper.php
+++ b/libraries/joomla/application/module/helper.php
@@ -162,7 +162,7 @@ abstract class JModuleHelper
 		$path = JPATH_BASE . '/modules/' . $module->module . '/' . $module->module . '.php';
 
 		// Load the module
-		if (!$module->user && file_exists($path))
+		if ((!isset($module->user) || !$module->user ) && file_exists($path))
 		{
 			$lang = JFactory::getLanguage();
 			// 1.5 or Core then 1.6 3PD

--- a/libraries/joomla/application/module/helper.php
+++ b/libraries/joomla/application/module/helper.php
@@ -162,7 +162,8 @@ abstract class JModuleHelper
 		$path = JPATH_BASE . '/modules/' . $module->module . '/' . $module->module . '.php';
 
 		// Load the module
-		if ((!isset($module->user) || !$module->user ) && file_exists($path))
+		// $module->user is a check for 1.0 custom modules and is deprecated refactoring
+		if ((!empty($module->user)) && file_exists($path))
 		{
 			$lang = JFactory::getLanguage();
 			// 1.5 or Core then 1.6 3PD
@@ -370,7 +371,14 @@ abstract class JModuleHelper
 				// Only accept modules without explicit exclusions.
 				if (!$negHit)
 				{
-					$module->name = substr($module->module, 4);
+					// Determine if this is a 1.0 style custom module (no mod_ prefix)
+					// This should be eliminated when the class is refactored.
+					// $module->user is deprecated.
+					$file = $module->module;
+					$custom = substr($file, 0, 4) == 'mod_' ?  0 : 1;
+					$module->user = $custom;
+					// 1.0 style custom module name is given by the title field, otherwise strip off "mod_"
+					$module->name = $custom ? $module->module : substr($file, 4);
 					$module->style = null;
 					$module->position = strtolower($module->position);
 					$clean[$module->id] = $module;

--- a/libraries/joomla/error/error.php
+++ b/libraries/joomla/error/error.php
@@ -43,7 +43,7 @@ abstract class JError
 	public static $legacy = false;
 
 	/**
-	 * Array of message lvwls
+	 * Array of message levels
 	 *
 	 * @var    array
 	 * @since  11.1
@@ -179,9 +179,9 @@ abstract class JError
 	 *
 	 * @return  reference
 	 *
-	 * @since       11.1
 	 * @deprecated  12.1  Use PHP Exception
-	 * @see         JException
+	 * @see     JException
+	 * @since   11.1
 	 */
 	public static function throwError(&$exception)
 	{
@@ -223,16 +223,16 @@ abstract class JError
 	/**
 	 * Wrapper method for the raise() method with predefined error level of E_ERROR and backtrace set to true.
 	 *
-	 * @param   string  $code  The application-internal error code for this error
-	 * @param   string  $msg   The error message, which may also be shown the user if need be.
-	 * @param   mixed   $info  Optional: Additional error information (usually only developer-relevant information that
-	 *                  the user should never see, like a database DSN).
+	 * @param   string   $code  The application-internal error code for this error
+	 * @param   string   $msg   The error message, which may also be shown the user if need be.
+	 * @param   mixed    $info  Optional: Additional error information (usually only developer-relevant information that
+	 *                          the user should never see, like a database DSN).
 	 *
 	 * @return  object  $error  The configured JError object
 	 *
-	 * @since       11.1
-	 * @deprecated  12.1  Use PHP Exception
-	 * @see         raise()
+	 * @deprecated   12.1     Use PHP Exception
+	 * @see        raise()
+	 * @since   11.1
 	 */
 	public static function raiseError($code, $msg, $info = null)
 	{
@@ -252,10 +252,10 @@ abstract class JError
 	 *
 	 * @return  object  The configured JError object
 	 *
-	 * @since   11.1
 	 * @deprecated  12.1  Use PHP Exception
-	 * @see         JError
-	 * @see         raise()
+	 * @see        JError
+	 * @see        raise()
+	 * @since      11.1
 	 */
 	public static function raiseWarning($code, $msg, $info = null)
 	{
@@ -275,9 +275,9 @@ abstract class JError
 	 *
 	 * @return  object   The configured JError object
 	 *
-	 * @since       11.1
-	 * @deprecated  12.1  Use PHP Exception
-	 * @see         raise()
+	 * @deprecated       12.1   Use PHP Exception
+	 * @see     raise()
+	 * @since   11.1
 	 */
 	public static function raiseNotice($code, $msg, $info = null)
 	{
@@ -294,9 +294,8 @@ abstract class JError
 	 *
 	 * @return  array  All error handling details
 	 *
-	 * @since   11.1
-	 *
 	 * @deprecated   12.1  Use PHP Exception
+	 * @since   11.1
 	 */
 	public static function getErrorHandling($level)
 	{
@@ -330,9 +329,8 @@ abstract class JError
 	 *
 	 * @return  mixed  True on success or a JException object if failed.
 	 *
-	 * @since   11.1
-	 *
 	 * @deprecated  12.1  Use PHP Exception
+	 * @since   11.1
 	 */
 	public static function setErrorHandling($level, $mode, $options = null)
 	{
@@ -413,6 +411,7 @@ abstract class JError
 	 *
 	 * @return  void
 	 *
+	 * @deprecated  12.1
 	 * @see restore_error_handler
 	 * @since   11.1
 	 */
@@ -438,6 +437,7 @@ abstract class JError
 	 *
 	 * @return  boolean  True on success; false if the level already has been registered
 	 *
+	 * @deprecated  12.1
 	 * @since   11.1
 	 */
 	public static function registerErrorLevel($level, $name, $handler = 'ignore')
@@ -488,8 +488,9 @@ abstract class JError
 	 * @param   object  &$error   Exception object to handle
 	 * @param   array   $options  Handler options
 	 *
-	 * @return  object  The exception object
+	 * @return  object   The exception object
 	 *
+	 * @deprecated  12.1
 	 * @see     raise()
 	 * @since   11.1
 	 */
@@ -720,8 +721,8 @@ abstract class JError
 	 *
 	 * @return  void
 	 *
-	 * @since       11.1
 	 * @deprecated  12.1
+	 * @since   11.1
 	 */
 	public static function customErrorPage(&$error)
 	{
@@ -753,15 +754,15 @@ abstract class JError
 	}
 
 	/**
-	 * Display a custom error page and exit gracefully
+	 * Display a message to the user
 	 *
 	 * @param   integer  $level  The error level - use any of PHP's own error levels for this: E_ERROR, E_WARNING, E_NOTICE, E_USER_ERROR, E_USER_WARNING, E_USER_NOTICE.
 	 * @param   string   $msg    Error message, shown to user if need be.
 	 *
 	 * @return  void
 	 *
-	 * @since       11.1
 	 * @deprecated  12.1
+	 * @since   11.1
 	 */
 	public static function customErrorHandler($level, $msg)
 	{
@@ -778,8 +779,8 @@ abstract class JError
 	 *
 	 * @return  string  Contents of the backtrace
 	 *
-	 * @since       11.1
 	 * @deprecated  12.1
+	 * @since   11.1
 	 */
 	public static function renderBacktrace($error)
 	{

--- a/libraries/joomla/error/error.php
+++ b/libraries/joomla/error/error.php
@@ -43,7 +43,7 @@ abstract class JError
 	public static $legacy = false;
 
 	/**
-	 * Array of message levels
+	 * Array of message lvwls
 	 *
 	 * @var    array
 	 * @since  11.1
@@ -179,9 +179,9 @@ abstract class JError
 	 *
 	 * @return  reference
 	 *
+	 * @since       11.1
 	 * @deprecated  12.1  Use PHP Exception
-	 * @see     JException
-	 * @since   11.1
+	 * @see         JException
 	 */
 	public static function throwError(&$exception)
 	{
@@ -223,16 +223,16 @@ abstract class JError
 	/**
 	 * Wrapper method for the raise() method with predefined error level of E_ERROR and backtrace set to true.
 	 *
-	 * @param   string   $code  The application-internal error code for this error
-	 * @param   string   $msg   The error message, which may also be shown the user if need be.
-	 * @param   mixed    $info  Optional: Additional error information (usually only developer-relevant information that
-	 *                          the user should never see, like a database DSN).
+	 * @param   string  $code  The application-internal error code for this error
+	 * @param   string  $msg   The error message, which may also be shown the user if need be.
+	 * @param   mixed   $info  Optional: Additional error information (usually only developer-relevant information that
+	 *                  the user should never see, like a database DSN).
 	 *
 	 * @return  object  $error  The configured JError object
 	 *
-	 * @deprecated   12.1     Use PHP Exception
-	 * @see        raise()
-	 * @since   11.1
+	 * @since       11.1
+	 * @deprecated  12.1  Use PHP Exception
+	 * @see         raise()
 	 */
 	public static function raiseError($code, $msg, $info = null)
 	{
@@ -252,10 +252,10 @@ abstract class JError
 	 *
 	 * @return  object  The configured JError object
 	 *
+	 * @since   11.1
 	 * @deprecated  12.1  Use PHP Exception
-	 * @see        JError
-	 * @see        raise()
-	 * @since      11.1
+	 * @see         JError
+	 * @see         raise()
 	 */
 	public static function raiseWarning($code, $msg, $info = null)
 	{
@@ -275,9 +275,9 @@ abstract class JError
 	 *
 	 * @return  object   The configured JError object
 	 *
-	 * @deprecated       12.1   Use PHP Exception
-	 * @see     raise()
-	 * @since   11.1
+	 * @since       11.1
+	 * @deprecated  12.1  Use PHP Exception
+	 * @see         raise()
 	 */
 	public static function raiseNotice($code, $msg, $info = null)
 	{
@@ -294,8 +294,9 @@ abstract class JError
 	 *
 	 * @return  array  All error handling details
 	 *
-	 * @deprecated   12.1  Use PHP Exception
 	 * @since   11.1
+	 *
+	 * @deprecated   12.1  Use PHP Exception
 	 */
 	public static function getErrorHandling($level)
 	{
@@ -329,8 +330,9 @@ abstract class JError
 	 *
 	 * @return  mixed  True on success or a JException object if failed.
 	 *
-	 * @deprecated  12.1  Use PHP Exception
 	 * @since   11.1
+	 *
+	 * @deprecated  12.1  Use PHP Exception
 	 */
 	public static function setErrorHandling($level, $mode, $options = null)
 	{
@@ -411,7 +413,6 @@ abstract class JError
 	 *
 	 * @return  void
 	 *
-	 * @deprecated  12.1
 	 * @see restore_error_handler
 	 * @since   11.1
 	 */
@@ -437,7 +438,6 @@ abstract class JError
 	 *
 	 * @return  boolean  True on success; false if the level already has been registered
 	 *
-	 * @deprecated  12.1
 	 * @since   11.1
 	 */
 	public static function registerErrorLevel($level, $name, $handler = 'ignore')
@@ -488,9 +488,8 @@ abstract class JError
 	 * @param   object  &$error   Exception object to handle
 	 * @param   array   $options  Handler options
 	 *
-	 * @return  object   The exception object
+	 * @return  object  The exception object
 	 *
-	 * @deprecated  12.1
 	 * @see     raise()
 	 * @since   11.1
 	 */
@@ -721,8 +720,8 @@ abstract class JError
 	 *
 	 * @return  void
 	 *
+	 * @since       11.1
 	 * @deprecated  12.1
-	 * @since   11.1
 	 */
 	public static function customErrorPage(&$error)
 	{
@@ -754,15 +753,15 @@ abstract class JError
 	}
 
 	/**
-	 * Display a message to the user
+	 * Display a custom error page and exit gracefully
 	 *
 	 * @param   integer  $level  The error level - use any of PHP's own error levels for this: E_ERROR, E_WARNING, E_NOTICE, E_USER_ERROR, E_USER_WARNING, E_USER_NOTICE.
 	 * @param   string   $msg    Error message, shown to user if need be.
 	 *
 	 * @return  void
 	 *
+	 * @since       11.1
 	 * @deprecated  12.1
-	 * @since   11.1
 	 */
 	public static function customErrorHandler($level, $msg)
 	{
@@ -779,8 +778,8 @@ abstract class JError
 	 *
 	 * @return  string  Contents of the backtrace
 	 *
+	 * @since       11.1
 	 * @deprecated  12.1
-	 * @since   11.1
 	 */
 	public static function renderBacktrace($error)
 	{


### PR DESCRIPTION
In testing the JBs found a regression in that in getModule the module helper is now not setting $module->user to 0 for all modules any more. I did some digging and this seems to be a legacy property from 1.0 and seemed to possible check if you were a super user for menu modules.  As far as I can tell it has no use at all in the current CMS. (Looking at the 1.0 module code explains a lot about some other parts of the module helper.)
