### PR TITLE
Logging

### DIFF
--- a/docs/manual/appendices/changelog.xml
+++ b/docs/manual/appendices/changelog.xml
@@ -68,7 +68,7 @@
 				<para>Fixed bug in JHtml: stream_set_timeout was misspelled as stream_settimeout, throwing a Fatal Error each time the class was used</para>
 			</listitem>
 			<listitem>
-				<para></para>
+				<para>Added loading of JLog to import.php.</para>
 			</listitem>
 			<listitem>
 				<para></para>

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -54,7 +54,7 @@ if (!class_exists('JLoader'))
 // Import the factory library.
 JLoader::import('joomla.factory');
 
-// Import the exception and error handling libraries.
+// Import the exception, error handling and logging libraries.
 JLoader::import('joomla.error.error');
 JLoader::import('joomla.error.exception');
 JLoader::import('joomla.log.log');

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -57,6 +57,7 @@ JLoader::import('joomla.factory');
 // Import the exception and error handling libraries.
 JLoader::import('joomla.error.error');
 JLoader::import('joomla.error.exception');
+JLoader::import('joomla.log.log');
 
 /*
  * If the HTTP_HOST environment variable is set we assume a Web request and

--- a/libraries/joomla/error/error.php
+++ b/libraries/joomla/error/error.php
@@ -43,7 +43,7 @@ abstract class JError
 	public static $legacy = false;
 
 	/**
-	 * Array of message lvwls
+	 * Array of message levels
 	 *
 	 * @var    array
 	 * @since  11.1
@@ -179,9 +179,9 @@ abstract class JError
 	 *
 	 * @return  reference
 	 *
-	 * @since       11.1
 	 * @deprecated  12.1  Use PHP Exception
-	 * @see         JException
+	 * @see     JException
+	 * @since   11.1
 	 */
 	public static function throwError(&$exception)
 	{
@@ -223,16 +223,16 @@ abstract class JError
 	/**
 	 * Wrapper method for the raise() method with predefined error level of E_ERROR and backtrace set to true.
 	 *
-	 * @param   string  $code  The application-internal error code for this error
-	 * @param   string  $msg   The error message, which may also be shown the user if need be.
-	 * @param   mixed   $info  Optional: Additional error information (usually only developer-relevant information that
-	 *                  the user should never see, like a database DSN).
+	 * @param   string   $code  The application-internal error code for this error
+	 * @param   string   $msg   The error message, which may also be shown the user if need be.
+	 * @param   mixed    $info  Optional: Additional error information (usually only developer-relevant information that
+	 *                          the user should never see, like a database DSN).
 	 *
 	 * @return  object  $error  The configured JError object
 	 *
-	 * @since       11.1
-	 * @deprecated  12.1  Use PHP Exception
-	 * @see         raise()
+	 * @deprecated   12.1     Use PHP Exception
+	 * @see        raise()
+	 * @since   11.1
 	 */
 	public static function raiseError($code, $msg, $info = null)
 	{
@@ -252,10 +252,10 @@ abstract class JError
 	 *
 	 * @return  object  The configured JError object
 	 *
-	 * @since   11.1
 	 * @deprecated  12.1  Use PHP Exception
-	 * @see         JError
-	 * @see         raise()
+	 * @see        JError
+	 * @see        raise()
+	 * @since      11.1
 	 */
 	public static function raiseWarning($code, $msg, $info = null)
 	{
@@ -275,9 +275,9 @@ abstract class JError
 	 *
 	 * @return  object   The configured JError object
 	 *
-	 * @since       11.1
-	 * @deprecated  12.1  Use PHP Exception
-	 * @see         raise()
+	 * @deprecated       12.1   Use PHP Exception
+	 * @see     raise()
+	 * @since   11.1
 	 */
 	public static function raiseNotice($code, $msg, $info = null)
 	{
@@ -294,9 +294,8 @@ abstract class JError
 	 *
 	 * @return  array  All error handling details
 	 *
-	 * @since   11.1
-	 *
 	 * @deprecated   12.1  Use PHP Exception
+	 * @since   11.1
 	 */
 	public static function getErrorHandling($level)
 	{
@@ -330,9 +329,8 @@ abstract class JError
 	 *
 	 * @return  mixed  True on success or a JException object if failed.
 	 *
-	 * @since   11.1
-	 *
 	 * @deprecated  12.1  Use PHP Exception
+	 * @since   11.1
 	 */
 	public static function setErrorHandling($level, $mode, $options = null)
 	{
@@ -413,6 +411,7 @@ abstract class JError
 	 *
 	 * @return  void
 	 *
+	 * @deprecated  12.1
 	 * @see restore_error_handler
 	 * @since   11.1
 	 */
@@ -438,6 +437,7 @@ abstract class JError
 	 *
 	 * @return  boolean  True on success; false if the level already has been registered
 	 *
+	 * @deprecated  12.1
 	 * @since   11.1
 	 */
 	public static function registerErrorLevel($level, $name, $handler = 'ignore')
@@ -488,8 +488,9 @@ abstract class JError
 	 * @param   object  &$error   Exception object to handle
 	 * @param   array   $options  Handler options
 	 *
-	 * @return  object  The exception object
+	 * @return  object   The exception object
 	 *
+	 * @deprecated  12.1
 	 * @see     raise()
 	 * @since   11.1
 	 */
@@ -720,8 +721,8 @@ abstract class JError
 	 *
 	 * @return  void
 	 *
-	 * @since       11.1
 	 * @deprecated  12.1
+	 * @since   11.1
 	 */
 	public static function customErrorPage(&$error)
 	{
@@ -753,15 +754,15 @@ abstract class JError
 	}
 
 	/**
-	 * Display a custom error page and exit gracefully
+	 * Display a message to the user
 	 *
 	 * @param   integer  $level  The error level - use any of PHP's own error levels for this: E_ERROR, E_WARNING, E_NOTICE, E_USER_ERROR, E_USER_WARNING, E_USER_NOTICE.
 	 * @param   string   $msg    Error message, shown to user if need be.
 	 *
 	 * @return  void
 	 *
-	 * @since       11.1
 	 * @deprecated  12.1
+	 * @since   11.1
 	 */
 	public static function customErrorHandler($level, $msg)
 	{
@@ -778,8 +779,8 @@ abstract class JError
 	 *
 	 * @return  string  Contents of the backtrace
 	 *
-	 * @since       11.1
 	 * @deprecated  12.1
+	 * @since   11.1
 	 */
 	public static function renderBacktrace($error)
 	{


### PR DESCRIPTION
Currently import loads JError and JException both of which are deprecated. What happens is that every time JError or JException are called is that they call JLog to log use of deprecated methods. This causes a number of issues if JLog has not been loaded elsewhere including an infinite loop.  So if we are loading the first two we need to load JLog. Thus far the CMS seems to be managing okay but other applications including installation are not.
