### PR TITLE
Turn JAuthentication back from static class and updated tests accordingly

### DIFF
--- a/libraries/joomla/application/application.php
+++ b/libraries/joomla/application/application.php
@@ -673,13 +673,14 @@ class JApplication extends JObject
 		// Get the global JAuthentication object.
 		jimport('joomla.user.authentication');
 
-		$response = JAuthentication::authenticate($credentials, $options);
+		$authenticate = JAuthentication::getInstance();
+		$response = $authenticate->authenticate($credentials, $options);
 
 		if ($response->status === JAuthentication::STATUS_SUCCESS)
 		{
 			// validate that the user should be able to login (different to being authenticated)
 			// this permits authentication plugins blocking the user
-			$authorisations = JAuthentication::authorise($response, $options);
+			$authorisations = $authenticate->authorise($response, $options);
 			foreach ($authorisation as $authorisation)
 			{
 				$denied_states = Array(JAuthentication::STATUS_EXPIRED, JAuthentication::STATUS_DENIED);

--- a/tests/suite/joomla/user/JAuthenticationTest.php
+++ b/tests/suite/joomla/user/JAuthenticationTest.php
@@ -92,9 +92,10 @@ class JAuthenticationTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testAuthentication($input, $expect, $message)
 	{
+		$authenticate = JAuthentication::getInstance();
 		$this->assertEquals(
 			$expect,
-			JAuthentication::authenticate($input),
+			$authenticate->authenticate($input),
 			$message
 		);
 	}
@@ -157,9 +158,10 @@ class JAuthenticationTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testAuthorise($input, $expect, $message)
 	{
+		$authentication = JAuthentication::getInstance();
 		$this->assertEquals(
 			$expect,
-			JAuthentication::authorise($input),
+			$authentication->authorise($input),
 			$message
 		);
 	}

--- a/tests/suite/joomla/user/TestStubs/JPluginHelper.php
+++ b/tests/suite/joomla/user/TestStubs/JPluginHelper.php
@@ -2,12 +2,17 @@
 
 class JPluginHelper
 {
-      public function getPlugin($type, $plugin = null)
-      {
-         require_once dirname(__FILE__).'/FakeAuthenticationPlugin.php';
-         $testPlugin = new stdClass;
-         $testPlugin->type = 'authentication';
-         $testPlugin->name = 'fake';
-         return array($testPlugin);
-      }  
+	public function getPlugin($type, $plugin = null)
+	{
+		require_once dirname(__FILE__).'/FakeAuthenticationPlugin.php';
+		$testPlugin = new stdClass;
+		$testPlugin->type = 'authentication';
+		$testPlugin->name = 'fake';
+		return array($testPlugin);
+	}
+
+	public function importPlugin()
+	{
+		// :)
+	}
 }


### PR DESCRIPTION
This fixes an issue with syncing the CMS where the CMS breaks because the plugins aren't loaded properly. This restores the pre-11.2 behaviour of not using a static class. Also a minor update to fix spaces used instead of tabs in the test.
