### PR TITLE
Added JLog dependency to JError and JException

### DIFF
--- a/libraries/joomla/error/error.php
+++ b/libraries/joomla/error/error.php
@@ -16,6 +16,9 @@ define('JERROR_CALLBACK_NOT_CALLABLE', 2);
 // Error Definition: Illegal Handler
 define('JERROR_ILLEGAL_MODE', 3);
 
+// Pull in JLog for deprecation logging.
+jimport('joomla.log.log');
+
 /**
  * Error Handling Class
  *

--- a/libraries/joomla/error/exception.php
+++ b/libraries/joomla/error/exception.php
@@ -9,6 +9,9 @@
 
 defined('JPATH_PLATFORM') or die();
 
+// Pull in JLog for deprecation logging.
+jimport('joomla.log.log');
+
 /**
  * Joomla! Exception object.
  *


### PR DESCRIPTION
Add JLog for JError and JException since both are deprecated and deprecation logging was causing an infinite loop.
