### PR TITLE
Fixes login and module display issues in the CMS 

### DIFF
--- a/libraries/joomla/application/module/helper.php
+++ b/libraries/joomla/application/module/helper.php
@@ -163,7 +163,7 @@ abstract class JModuleHelper
 
 		// Load the module
 		// $module->user is a check for 1.0 custom modules and is deprecated refactoring
-		if ((!empty($module->user)) && file_exists($path))
+		if (empty($module->user) && file_exists($path))
 		{
 			$lang = JFactory::getLanguage();
 			// 1.5 or Core then 1.6 3PD

--- a/libraries/joomla/session/storage/database.php
+++ b/libraries/joomla/session/storage/database.php
@@ -72,10 +72,12 @@ class JSessionStorageDatabase extends JSessionStorage
 
 		// Get the session data from the database table.
 		$query = $db->getQuery(true);
-		$query->select($query->qn('data'))
-			->from($query->qn('#__session'));
-		$query->where($query->qn('session_id') . ' = ' . $query->q($id));
+		$query->select($db->quoteName('data'))
+			->from($db->quoteName('#__session'))
+			->where($db->quoteName('session_id') . ' = ' . $db->quote($id));
+
 		$db->setQuery($query);
+
 		return (string) $db->loadResult();
 	}
 
@@ -99,11 +101,10 @@ class JSessionStorageDatabase extends JSessionStorage
 		}
 
 		// Try to update the session data in the database table.
-		$query = $db->getQuery(true);
 		$db->setQuery(
-			'UPDATE ' . $query->qn('#__session') .
-			' SET ' . $query->qn('data') . ' = ' . $query->q($data) . ',' . '	  ' . $query->qn('time') . ' = ' . (int) time() .
-			' WHERE ' . $query->qn('session_id') . ' = ' . $query->q($id)
+			'UPDATE ' . $db->quoteName('#__session') .
+			' SET ' . $db->quoteName('data') . ' = ' . $db->quote($data) . ',' . '	  ' . $db->quoteName('time') . ' = ' . (int) time() .
+			' WHERE ' . $db->quoteName('session_id') . ' = ' . $db->quote($id)
 		);
 		if (!$db->query())
 		{
@@ -118,9 +119,9 @@ class JSessionStorageDatabase extends JSessionStorage
 		{
 			// If the session does not exist, we need to insert the session.
 			$db->setQuery(
-				'INSERT INTO ' . $query->qn('#__session') .
-				' (' . $query->qn('session_id') . ', ' . $query->qn('data') . ', ' . $query->qn('time') . ')' .
-				' VALUES (' . $query->q($id) . ', ' . $query->q($data) . ', ' . (int) time() . ')'
+				'INSERT INTO ' . $db->quoteName('#__session') .
+				' (' . $db->quoteName('session_id') . ', ' . $db->quoteName('data') . ', ' . $db->quoteName('time') . ')' .
+				' VALUES (' . $db->quote($id) . ', ' . $db->quote($data) . ', ' . (int) time() . ')'
 			);
 			return (boolean) $db->query();
 		}
@@ -145,8 +146,11 @@ class JSessionStorageDatabase extends JSessionStorage
 		}
 
 		// Remove a session from the database.
-		$query = $db->getQuery(true);
-		$db->setQuery('DELETE FROM ' . $query->qn('#__session') . ' WHERE ' . $query->qn('session_id') . ' = ' . $query->q($id));
+		$db->setQuery(
+			'DELETE FROM ' . $db->quoteName('#__session') .
+			' WHERE ' . $db->quoteName('session_id') . ' = ' . $db->quote($id)
+		);
+
 		return (boolean) $db->query();
 	}
 
@@ -172,8 +176,11 @@ class JSessionStorageDatabase extends JSessionStorage
 		$past = time() - $lifetime;
 
 		// Remove expired sessions from the database.
-		$query = $db->getQuery(true);
-		$db->setQuery('DELETE FROM ' . $query->qn('#__session') . ' WHERE ' . $query->qn('time') . ' < ' . (int) $past);
+		$db->setQuery(
+			'DELETE FROM ' . $db->quoteName('#__session') .
+			' WHERE ' . $db->quoteName('time') . ' < ' . (int) $past
+		);
+
 		return (boolean) $db->query();
 	}
 }

--- a/libraries/joomla/user/authentication.php
+++ b/libraries/joomla/user/authentication.php
@@ -139,7 +139,7 @@ class JAuthentication extends JObservable
 	 * @see     JAuthenticationResponse
 	 * @since   11.1
 	 */
-	public static function authenticate($credentials, $options = Array())
+	public function authenticate($credentials, $options = Array())
 	{
 		// Initialise variables.
 		$auth = false;


### PR DESCRIPTION
Using database magic calls (qn and q) causes problems in the session database class, so these have been replaced with the fully qualified names.
A small glitch in the module display was fixed.
JAuthentication::authenticate was still being defined as static which caused problems with the plugins.
