### PR TITLE
Joomla CMS [#25676] Suggestion for improved error handling for libraries/joomla/installer/adapters/component.php 

### DIFF
--- a/libraries/joomla/installer/adapters/component.php
+++ b/libraries/joomla/installer/adapters/component.php
@@ -1441,13 +1441,7 @@ class JInstallerComponent extends JAdapterInstance
 			if (!$table->setLocation(1, 'last-child') || !$table->bind($data) || !$table->check() || !$table->store())
 			{
 				// Install failed, warn user and rollback changes
-				JLog::add($table->getError(), JLog::WARNING, 'installer');
-
-				if (JError::$legacy)
-				{
-					JError::raiseWarning(1, $table->getError());
-				}
-
+				JError::raiseWarning(1, $table->getError());
 				return false;
 			}
 
@@ -1476,13 +1470,7 @@ class JInstallerComponent extends JAdapterInstance
 			if (!$table->setLocation(1, 'last-child') || !$table->bind($data) || !$table->check() || !$table->store())
 			{
 				// Install failed, warn user and rollback changes
-				JLog::add($table->getError(), JLog::WARNING, 'installer');
-
-				if (JError::$legacy)
-				{
-					JError::raiseWarning(1, $table->getError());
-				}
-
+				JError::raiseWarning(1, $table->getError());
 				return false;
 			}
 

--- a/libraries/joomla/installer/adapters/component.php
+++ b/libraries/joomla/installer/adapters/component.php
@@ -1440,7 +1440,14 @@ class JInstallerComponent extends JAdapterInstance
 
 			if (!$table->setLocation(1, 'last-child') || !$table->bind($data) || !$table->check() || !$table->store())
 			{
-				// Install failed, rollback changes
+				// Install failed, warn user and rollback changes
+				JLog::add($table->getError(), JLog::WARNING, 'installer');
+
+				if (JError::$legacy)
+				{
+					JError::raiseWarning(1, $table->getError());
+				}
+
 				return false;
 			}
 
@@ -1468,7 +1475,14 @@ class JInstallerComponent extends JAdapterInstance
 
 			if (!$table->setLocation(1, 'last-child') || !$table->bind($data) || !$table->check() || !$table->store())
 			{
-				// Install failed, rollback changes
+				// Install failed, warn user and rollback changes
+				JLog::add($table->getError(), JLog::WARNING, 'installer');
+
+				if (JError::$legacy)
+				{
+					JError::raiseWarning(1, $table->getError());
+				}
+
 				return false;
 			}
 


### PR DESCRIPTION
Improves error reporting if there is any problem building the admin menus when installing a component.

See:
https://github.com/joomla/joomla-platform/issues/246
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=25676
