### PR TITLE
Fixes bad default value for the offset in JString::strrpos; more options for JHtmlTruncate.

### DIFF
--- a/libraries/joomla/html/html/string.php
+++ b/libraries/joomla/html/html/string.php
@@ -22,68 +22,95 @@ abstract class JHtmlString
 {
 	/**
 	 * Truncates text blocks over the specified character limit and closes
-	 * all open HTML tags. The behavior will not truncate an individual
+	 * all open HTML tags. The method will optionally not truncate an individual
 	 * word, it will find the first space that is within the limit and
 	 * truncate at that point. This method is UTF-8 safe.
 	 *
-	 * @param   string   $text    The text to truncate.
-	 * @param   integer  $length  The maximum length of the text.
+	 * @param   string   $text       The text to truncate.
+	 * @param   integer  $length     The maximum length of the text.
+	 * @param   boolean  $noSplit    Don't split a word if that is where the cutoff occurs (default: true).
+	 * @param   boolean  $allowHtml  Allow HTML tags in the output, and close any open tags (default: true).
 	 *
 	 * @return  string   The truncated text.
 	 *
 	 * @since   11.1
 	 */
-	public static function truncate($text, $length = 0)
+	public static function truncate($text, $length = 0, $noSplit = true, $allowHtml = true)
 	{
+		// Check if HTML tags are allowed.
+		if (!$allowHtml)
+		{
+			// Deal with spacing issues in the input.
+			$text = str_replace('>', '> ', $text);
+			$text = str_replace(array('&nbsp;', '&#160;'), ' ', $text);
+			$text = JString::trim(preg_replace('#\s+#mui', ' ', $text));
+
+			// Strip the tags from the input and decode entities.
+			$text = strip_tags($text);
+			$text = html_entity_decode($text, ENT_QUOTES, 'UTF-8');
+
+			// Remove remaining extra spaces.
+			$text = str_replace('&nbsp;', ' ', $text);
+			$text = JString::trim(preg_replace('#\s+#mui', ' ', $text));
+		}
+
 		// Truncate the item text if it is too long.
 		if ($length > 0 && JString::strlen($text) > $length)
 		{
 			// Find the first space within the allowed length.
 			$tmp = JString::substr($text, 0, $length);
-			$offset = JString::strrpos($tmp, ' ');
-			if (JString::strrpos($tmp, '<') > JString::strrpos($tmp, '>'))
+
+			if ($noSplit)
 			{
-				$offset = JString::strrpos($tmp, '<');
-			}
-			$tmp = JString::substr($tmp, 0, $offset);
-
-			// If we don't have 3 characters of room, go to the second space within the limit.
-			if (JString::strlen($tmp) > $length - 3)
-			{
-				$tmp = JString::substr($tmp, 0, JString::strrpos($tmp, ' '));
-			}
-
-			// Put all opened tags into an array
-			preg_match_all("#<([a-z][a-z0-9]*)\b.*?(?!/)>#i", $tmp, $result);
-			$openedTags = $result[1];
-			$openedTags = array_diff($openedTags, array("img", "hr", "br"));
-			$openedTags = array_values($openedTags);
-
-			// Put all closed tags into an array
-			preg_match_all("#</([a-z]+)>#iU", $tmp, $result);
-			$closedTags = $result[1];
-
-			$numOpened = count($openedTags);
-			// All tags are closed
-			if (count($closedTags) == $numOpened)
-			{
-				return $tmp . '...';
-			}
-
-			$openedTags = array_reverse($openedTags);
-
-			// Close tags
-			for ($i = 0; $i < $numOpened; $i++)
-			{
-				if (!in_array($openedTags[$i], $closedTags))
+				$offset = JString::strrpos($tmp, ' ');
+				if (JString::strrpos($tmp, '<') > JString::strrpos($tmp, '>'))
 				{
-					$tmp .= "</" . $openedTags[$i] . ">";
+					$offset = JString::strrpos($tmp, '<');
 				}
-				else
+				$tmp = JString::substr($tmp, 0, $offset);
+
+				// If we don't have 3 characters of room, go to the second space within the limit.
+				if (JString::strlen($tmp) > $length - 3)
 				{
-					unset($closedTags[array_search($openedTags[$i], $closedTags)]);
+					$tmp = JString::substr($tmp, 0, JString::strrpos($tmp, ' '));
 				}
 			}
+
+			if ($allowHtml)
+			{
+				// Put all opened tags into an array
+				preg_match_all("#<([a-z][a-z0-9]*)\b.*?(?!/)>#i", $tmp, $result);
+				$openedTags = $result[1];
+				$openedTags = array_diff($openedTags, array("img", "hr", "br"));
+				$openedTags = array_values($openedTags);
+
+				// Put all closed tags into an array
+				preg_match_all("#</([a-z]+)>#iU", $tmp, $result);
+				$closedTags = $result[1];
+
+				$numOpened = count($openedTags);
+				// All tags are closed
+				if (count($closedTags) == $numOpened)
+				{
+					return $tmp . '...';
+				}
+
+				$openedTags = array_reverse($openedTags);
+
+				// Close tags
+				for ($i = 0; $i < $numOpened; $i++)
+				{
+					if (!in_array($openedTags[$i], $closedTags))
+					{
+						$tmp .= "</" . $openedTags[$i] . ">";
+					}
+					else
+					{
+						unset($closedTags[array_search($openedTags[$i], $closedTags)]);
+					}
+				}
+			}
+
 			$text = $tmp . '...';
 		}
 

--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -155,7 +155,7 @@ abstract class JString
 	 * @see     http://www.php.net/strrpos
 	 * @since   11.1
 	 */
-	public static function strrpos($str, $search, $offset = false)
+	public static function strrpos($str, $search, $offset = 0)
 	{
 		return utf8_strrpos($str, $search, $offset);
 	}

--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -103,7 +103,8 @@ abstract class JString
 		}
 
 		// Check if we are incrementing an existing pattern, or appending a new one.
-		if (preg_match($rxSearch, $string, $matches)) {
+		if (preg_match($rxSearch, $string, $matches))
+		{
 			$n = empty($n) ? ($matches[1] + 1) : $n;
 			$string = preg_replace($rxReplace, sprintf($oldFormat, $n), $string);
 		}

--- a/tests/suite/joomla/html/html/JHtmlStringTest.php
+++ b/tests/suite/joomla/html/html/JHtmlStringTest.php
@@ -55,72 +55,121 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 			'No change case' => array(
 				'Plain text',
 				0,
+				true,
+				true,
 				'Plain text',
 			),
 			'Plain text under the limit' => array(
 				'Plain text',
 				100,
+				true,
+				true,
 				'Plain text',
 			),
 			'Plain text at the limit' => array(
 				'Plain text',
 				10,
+				true,
+				true,
 				'Plain text',
 			),
 			'Plain text over the limit by two words' => array(
 				'Plain text test',
 				12,
+				true,
+				true,
 				'Plain...',
 			),
 			'Plain text over the limit by one word' => array(
 				'Plain text test',
 				13,
+				true,
+				true,
 				'Plain text...',
 			),
 			'Plain text over the limit with short trailing words' => array(
 				'Plain text a b c d',
 				13,
+				true,
+				true,
 				'Plain text...',
 			),
 			'Plain text over the limit splitting first word' => array(
 				'Plain text',
 				3,
+				true,
+				true,
 				'Pla...',
+			),
+			'Plain text with word split' => array(
+				'Plain split-less',
+				7,
+				false,
+				false,
+				'Plain s...',
 			),
 			'Plain html under the limit' => array(
 				'<span>Plain text</span>',
 				100,
+				true,
+				true,
 				'<span>Plain text</span>',
 			),
 			'Plain html at the limit' => array(
 				'<span>Plain text</span>',
 				23,
+				true,
+				true,
 				'<span>Plain text</span>',
 			),
 			'Plain html over the limit' => array(
 				'<span>Plain text</span>',
 				22,
+				true,
+				true,
 				'<span>Plain text</span>...',
 			),
 			'Plain html over the limit by one word' => array(
 				'<span>Plain text</span>',
 				12,
+				true,
+				true,
 				'<span>Plain</span>...',
 			),
 			'Plain html over the limit splitting first word' => array(
 				'<span>Plain text</span>',
 				10,
+				true,
+				true,
 				'<span>Plai</span>...',
 			),
 			'Complex html over the limit' => array(
 				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
 				37,
+				true,
+				true,
 				'<div><span><i>Plain</i></span></div>...',
 			),
 			'Complex html over the limit 2' => array(
 				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
 				38,
+				true,
+				true,
 				'<div><span><i>Plain</i> <b>text</b></span></div>...',
+			),
+			'HTML not allowed, split words' => array(
+				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
+				8,
+				false,
+				false,
+				'Plain te...',
+			),
+			'HTML not allowed, no split' => array(
+				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
+				8,
+				true,
+				false,
+				'Plain...',
 			),
 		);
 	}
@@ -128,10 +177,10 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 	/**
 	 * Tests the JHtmlString::abridge method.
 	 *
-	 * @param   string   $text      The text to truncate.
-	 * @param   integer  $length    The maximum length of the text.
-	 * @param   integer  $intro     The maximum length of the intro text.
-	 * @param   string   $expected  The expected result.
+	 * @param   string   $text       The text to truncate.
+	 * @param   integer  $length     The maximum length of the text.
+	 * @param   integer  $intro      The maximum length of the intro text.
+	 * @param   string   $expected   The expected result.
 	 *
 	 * @return  void
 	 *
@@ -151,17 +200,19 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 	 *
 	 * @param   string   $text      The text to truncate.
 	 * @param   integer  $length    The maximum length of the text.
-	 * @param   string   $expected  The expected result.
+	 * @param   boolean  $noSplit    Don't split a word if that is where the cutoff occurs (default: true).
+	 * @param   boolean  $allowHtml  Allow HTML tags in the output, and close any open tags (default: true).
+	 * @param   string   $expected   The expected result.
 	 *
 	 * @return  void
 	 *
 	 * @dataProvider  getTestTruncateData
 	 * @since   11.3
 	 */
-	public function testTruncate($text, $length, $expected)
+	public function testTruncate($text, $length, $noSplit, $allowedHtml, $expected)
 	{
 		$this->assertThat(
-			JHtmlString::truncate($text, $length),
+			JHtmlString::truncate($text, $length, $noSplit, $allowedHtml),
 			$this->equalTo($expected)
 		);
 	}


### PR DESCRIPTION
Fixes a platform dependent error (utf8_strrpos expects parameter 3 to be long) caused by the offset of JString::strrpos having a default of false instead of integer zero.

Also adds options to JHtmlString::truncate for allowing a word to be split at the length marker, and also to optionally strip out all HTML tags.
