### PR TITLE
Joomla CMS [#26694] Catchable fatal error: Object of class DateTimeZone could not be converted to string 

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -506,18 +506,20 @@ abstract class JFactory
 				$classname = 'JDate';
 			}
 		}
-		$key = $time . '-' . $tzOffset;
 
-		//		if (!isset($instances[$classname][$key])) {
-		$tmp = new $classname($time, $tzOffset);
-		//We need to serialize to break the reference
-		//			$instances[$classname][$key] = serialize($tmp);
-		//			unset($tmp);
-		//		}
+		$key = $time . '-' . ($tzOffset instanceof DateTimeZone ? $tzOffset->getName() : (string) $tzOffset);
 
-		//		$date = unserialize($instances[$classname][$key]);
-		//		return $date;
-		return $tmp;
+		if (!isset($instances[$classname][$key]))
+		{
+			$tmp = new $classname($time, $tzOffset);
+			// We need to serialize to break the reference
+			$instances[$classname][$key] = serialize($tmp);
+			unset($tmp);
+		}
+
+		$date = unserialize($instances[$classname][$key]);
+
+		return $date;
 	}
 
 	/**

--- a/tests/includes/JoomlaDatabaseTestCase.php
+++ b/tests/includes/JoomlaDatabaseTestCase.php
@@ -403,6 +403,20 @@ abstract class JoomlaDatabaseTestCase extends PHPUnit_Extensions_Database_TestCa
 	}
 
 	/**
+	 * Gets a mock language object.
+	 *
+	 * @return  object
+	 *
+	 * @since   11.3
+	 */
+	protected function getMockLanguage()
+	{
+		require_once JPATH_TESTS.'/suite/joomla/language/JLanguageMock.php';
+
+		return JLanguageGlobalMock::create($this);
+	}
+
+	/**
 	 * Gets a mock session object.
 	 *
 	 * @return  object

--- a/tests/includes/JoomlaTestCase.php
+++ b/tests/includes/JoomlaTestCase.php
@@ -374,6 +374,20 @@ abstract class JoomlaTestCase extends PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Gets a mock language object.
+	 *
+	 * @return  object
+	 *
+	 * @since   11.3
+	 */
+	protected function getMockLanguage()
+	{
+		require_once JPATH_TESTS.'/suite/joomla/language/JLanguageMock.php';
+
+		return JLanguageGlobalMock::create($this);
+	}
+
+	/**
 	 * Gets a mock session object.
 	 *
 	 * @return  object

--- a/tests/suite/joomla/JFactoryTest.php
+++ b/tests/suite/joomla/JFactoryTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Utilities
+ * @copyright   Copyright (C) 2005 - 2011 Open Source Matters. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+require_once JPATH_PLATFORM . '/joomla/factory.php';
+
+/**
+ * Tests for JDate class.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Utilities
+ * @since       11.3
+ */
+class JFactoryTest extends JoomlaTestCase
+{
+	/**
+	 * Sets up the fixture.
+	 *
+	 * This method is called before a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function setUp()
+	{
+		parent::setUp();
+
+		$this->saveFactoryState();
+	}
+
+	/**
+	 * Tears down the fixture.
+	 *
+	 * This method is called after a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	function tearDown()
+	{
+		$this->restoreFactoryState();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests the JFactory::getDate method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testGetDate()
+	{
+		JFactory::$language = $this->getMockLanguage();
+
+		$date = JFactory::getDate('2001-01-01 01:01:01');
+
+		$this->assertThat(
+			(string) $date,
+			$this->equalTo('2001-01-01 01:01:01'),
+			'Tests that a date passed in comes back unchanged.'
+		);
+
+		$date = JFactory::getDate('now');
+		sleep(2);
+		$date2 = JFactory::getDate('now');
+
+		$this->assertThat(
+			$date2,
+			$this->equalTo($date),
+			'Tests that the cache for the same time is working.'
+		);
+
+		$tz = 'Etc/GMT+0';
+		$date = JFactory::getDate('2001-01-01 01:01:01', $tz);
+
+		$this->assertThat(
+			(string) $date,
+			$this->equalTo('2001-01-01 01:01:01'),
+			'Tests that a date passed in with UTC timezone string comes back unchanged.'
+		);
+
+		$tz = new DateTimeZone('Etc/GMT+0');
+		$date = JFactory::getDate('2001-01-01 01:01:01', $tz);
+
+		$this->assertThat(
+			(string) $date,
+			$this->equalTo('2001-01-01 01:01:01'),
+			'Tests that a date passed in with UTC timezone comes back unchanged.'
+		);
+	}
+}

--- a/tests/suite/joomla/language/JLanguageMock.php
+++ b/tests/suite/joomla/language/JLanguageMock.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @package    Joomla.UnitTest
+ * @copyright  Copyright (C) 2005 - 2011 Open Source Matters. All rights reserved.
+ * @license    GNU General Public License
+ */
+
+/**
+ * Mock class for JLanguage.
+ *
+ * @package  Joomla.UnitTest
+ * @since    11.3
+ */
+class JLanguageGlobalMock
+{
+	/**
+	 * Creates and instance of the mock JLanguage object.
+	 *
+	 * @param   object  $test   A test object.
+	 *
+	 * @return  object
+	 *
+	 * @since   11.3
+	 */
+	public static function create($test)
+	{
+		// Collect all the relevant methods in JDatabase.
+		$methods = array(
+			'getTag',
+		);
+
+		// Create the mock.
+		$mockObject = $test->getMock(
+			'JLanguage',
+			$methods,
+			// Constructor arguments.
+			array(),
+			// Mock class name.
+			'',
+			// Call original constructor.
+			false
+		);
+
+		// Mock selected methods.
+		$test->assignMockReturns(
+			$mockObject, array(
+				'getTag' => 'en-GB'
+			)
+		);
+
+		return $mockObject;
+	}
+}

--- a/tests/suite/joomla/utilities/JDateTest.php
+++ b/tests/suite/joomla/utilities/JDateTest.php
@@ -50,6 +50,11 @@ class JDateTest extends PHPUnit_Framework_TestCase
 				'US/Central',
 				'Tue 12/23/2008 13:45',
 			),
+			'DateTime tzCT' => array(
+				'12/23/2008 13:45',
+				new DateTimeZone('US/Central'),
+				'Tue 12/23/2008 13:45',
+			),
 		);
 	}
 


### PR DESCRIPTION
Fixes error in JFactory::getDate where timezone is passed as a DateTimeZone.

Restores backward compatibility of JFactory::getDate to Joomla 1.5 in that is caches the date for a given time.

Adds unit test for JFactory::getDate.

Adds addition test case for JDate constructor where timezone is passed as a DateTimeZone object.

Adds universal JLanguage mock to Joomla test harnesses.
