### PR TITLE
Adds headers argument to JHttp get, head and post, and some tests for JHttp.

### DIFF
--- a/libraries/joomla/client/http.php
+++ b/libraries/joomla/client/http.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
-defined('JPATH_PLATFORM') or die();
+defined('JPATH_PLATFORM') or die;
 
 jimport('joomla.environment.uri');
 
@@ -81,14 +81,15 @@ class JHttp
 	/**
 	 * Method to send the HEAD command to the server.
 	 *
-	 * @param   string  $url  Path to the resource.
+	 * @param   string  $url      Path to the resource.
+	 * @param   array   $headers  An array of name-value pairs to include in the header of the request.
 	 *
 	 * @return  boolean  True on success.
 	 *
 	 * @since   11.1
 	 * @throws  Exception
 	 */
-	public function head($url)
+	public function head($url, $headers = null)
 	{
 		// Parse the request url.
 		$uri = JUri::getInstance($url);
@@ -103,7 +104,7 @@ class JHttp
 		}
 
 		// Send the command to the server.
-		if (!$this->sendRequest($connection, 'HEAD', $uri))
+		if (!$this->sendRequest($connection, 'HEAD', $uri, null, $headers))
 		{
 			return false;
 		}
@@ -114,14 +115,15 @@ class JHttp
 	/**
 	 * Method to send the GET command to the server.
 	 *
-	 * @param   string  $url  Path to the resource.
+	 * @param   string  $url      Path to the resource.
+	 * @param   array   $headers  An array of name-value pairs to include in the header of the request.
 	 *
 	 * @return  boolean  True on success.
 	 *
 	 * @since   11.1
 	 * @throws  Exception
 	 */
-	public function get($url)
+	public function get($url, $headers = null)
 	{
 		// Parse the request url.
 		$uri = JUri::getInstance($url);
@@ -136,7 +138,7 @@ class JHttp
 		}
 
 		// Send the command to the server.
-		if (!$this->sendRequest($connection, 'GET', $uri))
+		if (!$this->sendRequest($connection, 'GET', $uri, null, $headers))
 		{
 			return false;
 		}
@@ -147,15 +149,16 @@ class JHttp
 	/**
 	 * Method to send the POST command to the server.
 	 *
-	 * @param   string  $url   Path to the resource.
-	 * @param   array   $data  Associative array of key/value pairs to send as post values.
+	 * @param   string  $url      Path to the resource.
+	 * @param   array   $data     Associative array of key/value pairs to send as post values.
+	 * @param   array   $headers  An array of name-value pairs to include in the header of the request.
 	 *
 	 * @return  boolean  True on success.
 	 *
 	 * @since   11.1
 	 * @throws  Exception
 	 */
-	public function post($url, $data)
+	public function post($url, $data, $headers = null)
 	{
 		// Parse the request url.
 		$uri = JUri::getInstance($url);
@@ -170,7 +173,7 @@ class JHttp
 		}
 
 		// Send the command to the server.
-		if (!$this->sendRequest($connection, 'POST', $uri, $data))
+		if (!$this->sendRequest($connection, 'POST', $uri, $data, $headers))
 		{
 			return false;
 		}
@@ -216,7 +219,12 @@ class JHttp
 		$request = array();
 		$request[] = strtoupper($method) . ' ' . ((empty($path)) ? '/' : $path) . ' HTTP/1.0';
 		$request[] = 'Host: ' . $uri->getHost();
-		$request[] = 'User-Agent: JHttp | Joomla/2.0';
+
+		// If no user agent is set use the base one.
+		if (empty($headers) || !isset($headers['User-Agent']))
+		{
+			$request[] = 'User-Agent: JHttp | JoomlaPlatform/11.3';
+		}
 
 		// If there are custom headers to send add them to the request payload.
 		if (is_array($headers))

--- a/tests/suite/joomla/client/JHttpInspector.php
+++ b/tests/suite/joomla/client/JHttpInspector.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Client
+ *
+ * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Inspector for the JHttp class to expose protected properties and methods.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Client
+ * @since       11.3
+ */
+class JHttpInspector extends JHttp
+{
+	/**
+	 * Method for inspecting protected variables.
+	 *
+	 * @param   string  $name  The name of the property.
+	 *
+	 * @return  mixed  The value of the class variable.
+	 *
+	 * @since   11.3
+	 */
+	public function __get($name)
+	{
+		if (property_exists($this, $name))
+		{
+			return $this->$name;
+		}
+		else
+		{
+			trigger_error('Undefined or private property: ' . __CLASS__.'::'.$name, E_USER_ERROR);
+
+			return null;
+		}
+	}
+
+	/**
+	* Method to connect to a server and get the resource.
+	*
+	* @param   JUri  $uri  The URI to connect with.
+	*
+	* @return  mixed  Connection resource on success or boolean false on failure.
+	*
+	* @since   11.3
+	*/
+	public function connect(JUri $uri)
+	{
+		return parent::connect($uri);
+	}
+}

--- a/tests/suite/joomla/client/JHttpTest.php
+++ b/tests/suite/joomla/client/JHttpTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Client
+ *
+ * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+require_once JPATH_PLATFORM.'/joomla/client/http.php';
+require_once __DIR__.'/JHttpInspector.php';
+
+/**
+ * Tests for the JHttp class.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Client
+ * @since       11.3
+ */
+class JHttpTest extends PHPUnit_Framework_TestCase
+{
+	/**
+	 * Gets the data for testConnect.
+	 *
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	public function getTestConnectData()
+	{
+		return array(
+			'Basic test' => array(
+				// String url.
+				'http://github.com',
+				// Expected hash key for the connection.
+				md5('github.com'.'80')
+			),
+			'Basic test with port' => array(
+				// String url.
+				'http://build.joomla.org:8080',
+				// Expected hash key for the connection.
+				md5('build.joomla.org'.'8080')
+			),
+		);
+	}
+
+	/**
+	 * Tests the JHttp::__construct method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function test__construct()
+	{
+		$http = new JHttpInspector;
+
+		$this->assertThat(
+			$http->timeout,
+			$this->equalTo(5),
+			'Tests the constructor.'
+		);
+
+		$http = new JHttpInspector(array('timeout' => 42));
+
+		$this->assertThat(
+			$http->timeout,
+			$this->equalTo(42),
+			'Tests the consuctor option for timeout is set.'
+		);
+	}
+
+	/**
+	 * Tests the JHttp::connect method.
+	 *
+	 * @param   string  $url  The url to test.
+	 * @param   string  $key  The hash of the internally stored connection.
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider  getTestConnectData
+	 * @since   11.3
+	 */
+	public function testConnect($url, $key)
+	{
+		$http = new JHttpInspector;
+
+		$res = $http->connect(JUri::getInstance($url));
+
+		$this->assertThat(
+			$res,
+			$this->equalTo($http->connections[$key]),
+			'Tests that the internally set connection is what was returned.'
+		);
+
+		// We can't test a bad address because the connector throws a PHP error.
+		$this->assertThat(
+			is_resource($res),
+			$this->isTrue(),
+			'Tests that the return value for a case that should connect is a resource.'
+		);
+	}
+
+	/**
+	 * Tests the JHttp::get method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testGet()
+	{
+		$this->markTestIncomplete();
+	}
+
+	/**
+	 * Tests the JHttp::getResponseObject method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testGetResponseObject()
+	{
+		$this->markTestIncomplete();
+	}
+
+	/**
+	 * Tests the JHttp::head method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testHead()
+	{
+		$this->markTestIncomplete();
+	}
+
+	/**
+	 * Tests the JHttp::post method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testPost()
+	{
+		$this->markTestIncomplete();
+	}
+
+	/**
+	 * Tests the JHttp::sendRequest method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testSendRequest()
+	{
+		$this->markTestIncomplete();
+	}
+}


### PR DESCRIPTION
This pull adds an addition $headers argument to JHttp's get, head and post methods so you can define additional headers for each request.  It also adds some tests for the JHttp class.
