### PR TITLE
Fixes a bug in JFactory::getDate caused by serialisation of the cached JDate object. 

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -16,14 +16,64 @@ defined('JPATH_PLATFORM') or die;
  */
 abstract class JFactory
 {
+	/**
+	 * @var    JApplication
+	 * @since  11.1
+	 */
 	public static $application = null;
+
+	/**
+	 * @var    JCache
+	 * @since  11.1
+	 */
 	public static $cache = null;
+
+	/**
+	 * @var    JConfig
+	 * @since  11.1
+	 */
 	public static $config = null;
+
+	/**
+	 * @var    array
+	 * @since  11.3
+	 */
+	public static $dates = array();
+
+	/**
+	 * @var    JSession
+	 * @since  11.1
+	 */
 	public static $session = null;
+
+	/**
+	 * @var    JLanguage
+	 * @since  11.1
+	 */
 	public static $language = null;
+
+	/**
+	 * @var    JDocument
+	 * @since  11.1
+	 */
 	public static $document = null;
+
+	/**
+	 * @var    JAccess
+	 * @since  11.1
+	 */
 	public static $acl = null;
+
+	/**
+	 * @var    JDatabase
+	 * @since  11.1
+	 */
 	public static $database = null;
+
+	/**
+	 * @var    JMail
+	 * @since  11.1
+	 */
 	public static $mailer = null;
 
 	/**
@@ -473,14 +523,8 @@ abstract class JFactory
 	public static function getDate($time = 'now', $tzOffset = null)
 	{
 		jimport('joomla.utilities.date');
-		static $instances;
 		static $classname;
 		static $mainLocale;
-
-		if (!isset($instances))
-		{
-			$instances = array();
-		}
 
 		$language = self::getLanguage();
 		$locale = $language->getTag();
@@ -509,15 +553,12 @@ abstract class JFactory
 
 		$key = $time . '-' . ($tzOffset instanceof DateTimeZone ? $tzOffset->getName() : (string) $tzOffset);
 
-		if (!isset($instances[$classname][$key]))
+		if (!isset(self::$dates[$classname][$key]))
 		{
-			$tmp = new $classname($time, $tzOffset);
-			// We need to serialize to break the reference
-			$instances[$classname][$key] = serialize($tmp);
-			unset($tmp);
+			self::$dates[$classname][$key] = new $classname($time, $tzOffset);
 		}
 
-		$date = unserialize($instances[$classname][$key]);
+		$date = clone self::$dates[$classname][$key];
 
 		return $date;
 	}

--- a/tests/includes/JoomlaDatabaseTestCase.php
+++ b/tests/includes/JoomlaDatabaseTestCase.php
@@ -320,6 +320,7 @@ abstract class JoomlaDatabaseTestCase extends PHPUnit_Extensions_Database_TestCa
 	{
 		$this->savedFactoryState['application'] = JFactory::$application;
 		$this->savedFactoryState['config'] = JFactory::$config;
+		$this->savedFactoryState['dates'] = JFactory::$dates;
 		$this->savedFactoryState['session'] = JFactory::$session;
 		$this->savedFactoryState['language'] = JFactory::$language;
 		$this->savedFactoryState['document'] = JFactory::$document;
@@ -339,6 +340,7 @@ abstract class JoomlaDatabaseTestCase extends PHPUnit_Extensions_Database_TestCa
 	{
 		JFactory::$application = $this->savedFactoryState['application'];
 		JFactory::$config = $this->savedFactoryState['config'];
+		JFactory::$dates = $this->savedFactoryState['dates'];
 		JFactory::$session = $this->savedFactoryState['session'];
 		JFactory::$language = $this->savedFactoryState['language'];
 		JFactory::$document = $this->savedFactoryState['document'];

--- a/tests/includes/JoomlaTestCase.php
+++ b/tests/includes/JoomlaTestCase.php
@@ -304,6 +304,7 @@ abstract class JoomlaTestCase extends PHPUnit_Framework_TestCase
 	{
 		$this->savedFactoryState['application'] = JFactory::$application;
 		$this->savedFactoryState['config'] = JFactory::$config;
+		$this->savedFactoryState['dates'] = JFactory::$dates;
 		$this->savedFactoryState['session'] = JFactory::$session;
 		$this->savedFactoryState['language'] = JFactory::$language;
 		$this->savedFactoryState['document'] = JFactory::$document;
@@ -323,6 +324,7 @@ abstract class JoomlaTestCase extends PHPUnit_Framework_TestCase
 	{
 		JFactory::$application = $this->savedFactoryState['application'];
 		JFactory::$config = $this->savedFactoryState['config'];
+		JFactory::$dates = $this->savedFactoryState['dates'];
 		JFactory::$session = $this->savedFactoryState['session'];
 		JFactory::$language = $this->savedFactoryState['language'];
 		JFactory::$document = $this->savedFactoryState['document'];


### PR DESCRIPTION
Converted the internal storage of the date from a static function variable to a static class variable, and then return a clone in getDate to work around problems caused by serialising and unserialising the JDate object with embedded DateTimeZone objects (they are never restored properly).

Also added the ability to save, override and restore the date property of JFactory in the Joomla test harnesses.
