### PR TITLE
Fixes wrong URLs in changelog generator

### DIFF
--- a/build/changelog.php
+++ b/build/changelog.php
@@ -136,7 +136,7 @@ class Changelog extends JCli
 				mkdir('./docs');
 			}
 
-			file_put_contents('./docs/xchangelog.xml', $doc->outputMemory());
+			file_put_contents('./docs/changelog.xml', $doc->outputMemory());
 		}
 		catch (Exception $e)
 		{

--- a/build/changelog.php
+++ b/build/changelog.php
@@ -99,7 +99,7 @@ class Changelog extends JCli
 					// Prepare the link to the pull.
 					$doc->text('[');
 					$doc->startElement('link');
-					$doc->writeAttribute('ns2:href', $issue->url);
+					$doc->writeAttribute('ns2:href', $issue->html_url);
 					$doc->writeAttribute('ns2:title', 'Closed '.$issue->closed_at);
 					$doc->text('#'.$issue->number);
 					$doc->endElement(); // ulink
@@ -107,7 +107,7 @@ class Changelog extends JCli
 
 					// Prepare the link to the author.
 					$doc->startElement('link');
-					$doc->writeAttribute('ns2:href', $issue->user->url);
+					$doc->writeAttribute('ns2:href', 'https://github.com/'.$issue->user->login);
 					$doc->text($issue->user->login);
 					$doc->endElement(); // ulink
 					$doc->text(')');
@@ -136,7 +136,7 @@ class Changelog extends JCli
 				mkdir('./docs');
 			}
 
-			file_put_contents('./docs/changelog.xml', $doc->outputMemory());
+			file_put_contents('./docs/xchangelog.xml', $doc->outputMemory());
 		}
 		catch (Exception $e)
 		{


### PR DESCRIPTION
Changes the URLs in the generated changelog
e.g.:
https://api.github.com/repos/joomla/joomla-platform/issues/100
to
https://github.com/joomla/joomla-platform/issues/100

And for the user:
https://api.github.com/users/elkuku
to
https://github.com/elkuku

The last one is 'hard coded' as the response does not provide a "good" URL.

I discovered this while playing around with git pages and docbook build tools.
This is the result => http://elkuku.github.com/joomla-platform/ <= pls Klick !
Feel free ;)
