### PR TITLE
Coding standards: Various little fixes

### DIFF
--- a/build/phpcs/Joomla/Sniffs/Classes/StaticThisUsageSniff.php
+++ b/build/phpcs/Joomla/Sniffs/Classes/StaticThisUsageSniff.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Squiz_Sniffs_Classes_StaticThisUsageSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
+ * @version   CVS: $Id: StaticThisUsageSniff.php 8 2010-11-06 00:40:23Z elkuku $
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+if(class_exists('PHP_CodeSniffer_Standards_AbstractScopeSniff', true) === false)
+{
+    throw new PHP_CodeSniffer_Exception('Class PHP_CodeSniffer_Standards_AbstractScopeSniff not found');
+}
+
+/**
+ * Checks for usage of "$this" in static methods, which will cause runtime errors.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
+ * @version   Release: 1.3.0RC1
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Joomla_Sniffs_Classes_StaticThisUsageSniff extends PHP_CodeSniffer_Standards_AbstractScopeSniff
+{
+    /**
+     * Constructs the test with the tokens it wishes to listen for.
+     */
+    public function __construct()
+    {
+        parent::__construct(array(T_CLASS), array(T_FUNCTION));
+    }//function
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The current file being scanned.
+     * @param integer                  $stackPtr  The position of the current token in the
+     *                                        stack passed in $tokens.
+     * @param integer                  $currScope A pointer to the start of the scope.
+     *
+     * @return void
+     */
+    public function processTokenWithinScope(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $currScope)
+    {
+        $tokens   = $phpcsFile->getTokens();
+        $function = $tokens[($stackPtr + 2)];
+
+        if($function['code'] !== T_STRING)
+        {
+            return;
+        }
+
+        $functionName = $function['content'];
+        $classOpener  = $tokens[$currScope]['scope_condition'];
+        $className    = $tokens[($classOpener + 2)]['content'];
+
+        $methodProps = $phpcsFile->getMethodProperties($stackPtr);
+
+        if($methodProps['is_static'] === true)
+        {
+            if(isset($tokens[$stackPtr]['scope_closer']) === false)
+            {
+                // There is no scope opener or closer, so the function
+                // must be abstract.
+                return;
+            }
+
+            $thisUsage = $stackPtr;
+
+            while(($thisUsage = $phpcsFile->findNext(array(T_VARIABLE)
+            , ($thisUsage + 1), $tokens[$stackPtr]['scope_closer'], false, '$this')) !== false)
+            {
+                if($thisUsage === false)
+                {
+                    return;
+                }
+
+                $error = 'Usage of "$this" in static methods will cause runtime errors';
+                $phpcsFile->addError($error, $thisUsage, 'Found');
+            }//while
+        }
+    }//function
+}//class

--- a/build/phpcs/Joomla/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
+++ b/build/phpcs/Joomla/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Squiz_Sniffs_WhiteSpace_SemicolonSpacingSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
+ * @version   CVS: $Id: SemicolonSpacingSniff.php 8 2010-11-06 00:40:23Z elkuku $
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Ensure there is no whitespace before a semicolon <b>;</b>.
+ *
+ * Example:
+ * <b class="bad">echo $a ;</b>
+ * <b class="good">echo $a;</b>
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
+ * @version   Release: 1.3.0RC1
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Joomla_Sniffs_WhiteSpace_SemicolonSpacingSniff implements PHP_CodeSniffer_Sniff
+{
+    /**
+     * A list of tokenizers this sniff supports.
+     *
+     * @var array
+     */
+    public $supportedTokenizers = array(
+                                   'PHP',
+                                   'JS',
+    );
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_SEMICOLON);
+    }//function
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param integer                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $prevType = $tokens[($stackPtr - 1)]['code'];
+
+        if(in_array($prevType, PHP_CodeSniffer_Tokens::$emptyTokens) === true)
+        {
+            $nonSpace = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 2), null, true);
+            $expected = $tokens[$nonSpace]['content'].';';
+            $found    = $phpcsFile->getTokensAsString($nonSpace, ($stackPtr - $nonSpace)).';';
+
+            $error    = sprintf('Space found before semicolon; expected "%s" but found "%s"'
+            , $expected, $found);
+
+            $phpcsFile->addError($error, $stackPtr, 'Incorrect');
+        }
+    }//function
+}//class

--- a/libraries/joomla/base/object.php
+++ b/libraries/joomla/base/object.php
@@ -32,7 +32,7 @@ class JObject
 	/**
 	 * Class constructor, overridden in descendant classes.
 	 *
-	 * @param   mixed  $properties	Either and associative array or another
+	 * @param   mixed  $properties  Either and associative array or another
 	 *                              object to set the initial properties of the object.
 	 *
 	 * @return  JObject

--- a/libraries/joomla/database/table/user.php
+++ b/libraries/joomla/database/table/user.php
@@ -208,7 +208,7 @@ class JTableUser extends JTable
 
 		// check for existing username
 		$query = 'SELECT id' . ' FROM #__users ' . ' WHERE username = ' . $this->_db->Quote($this->username) . ' AND id != ' . (int) $this->id;
-		;
+
 		$this->_db->setQuery($query);
 		$xid = intval($this->_db->loadResult());
 		if ($xid && $xid != intval($this->id))

--- a/libraries/joomla/error/error.php
+++ b/libraries/joomla/error/error.php
@@ -753,7 +753,7 @@ abstract class JError
 		jimport('joomla.document.document');
 		$app = JFactory::getApplication();
 		$document = JDocument::getInstance('error');
- 		if ($document)
+		if ($document)
 		{
 			$config = JFactory::getConfig();
 

--- a/libraries/joomla/event/dispatcher.php
+++ b/libraries/joomla/event/dispatcher.php
@@ -79,8 +79,8 @@ class JDispatcher extends JObservable
 	 * Triggers an event by dispatching arguments to all observers that handle
 	 * the event and returning their return values.
 	 *
-	 * @param   string   $event  The event to trigger.
-	 * @param   array    $args   An array of arguments.
+	 * @param   string  $event  The event to trigger.
+	 * @param   array   $args   An array of arguments.
 	 *
 	 * @return  array  An array of results from each function call.
 	 *

--- a/libraries/joomla/filesystem/archive/tar.php
+++ b/libraries/joomla/filesystem/archive/tar.php
@@ -143,7 +143,7 @@ class JArchiveTar extends JObject
 		{
 			$info = @unpack(
 				"a100filename/a8mode/a8uid/a8gid/a12size/a12mtime/a8checksum/Ctypeflag/a100link/a6magic/a2version/a32uname/a32gname/a8devmajor/a8devminor",
-				 substr($data, $position)
+				substr($data, $position)
 			);
 			if (!$info)
 			{

--- a/libraries/joomla/html/html/behavior.php
+++ b/libraries/joomla/html/html/behavior.php
@@ -114,8 +114,8 @@ abstract class JHtmlBehavior
 		JHtml::_('script', 'system/caption' . $uncompressed . '.js', true, true);
 
 		// Attach caption to document
-		JFactory::getDocument()->addScriptDeclaration("
-			window.addEvent('load', function() {
+		JFactory::getDocument()->addScriptDeclaration(
+			"window.addEvent('load', function() {
 				new JCaption('".$selector."');
 			});"
 		);
@@ -284,8 +284,8 @@ abstract class JHtmlBehavior
 		$options = JHtmlBehavior::_getJSObject($opt);
 
 		// Attach tooltips to document
-		JFactory::getDocument()->addScriptDeclaration("
-		window.addEvent('domready', function() {
+		JFactory::getDocument()->addScriptDeclaration(
+		"window.addEvent('domready', function() {
 			$$('$selector').each(function(el) {
 				var title = el.get('title');
 				if (title) {
@@ -428,8 +428,8 @@ abstract class JHtmlBehavior
 		JHtml::_('script', 'system/multiselect.js', true, true);
 
 		// Attach multiselect to document
-		JFactory::getDocument()->addScriptDeclaration("
-			window.addEvent('domready', function() {
+		JFactory::getDocument()->addScriptDeclaration(
+			"window.addEvent('domready', function() {
 				new Joomla.JMultiSelect('".$id."');
 			});"
 		);

--- a/libraries/joomla/html/parameter/element.php
+++ b/libraries/joomla/html/parameter/element.php
@@ -43,7 +43,7 @@ class JElement extends JObject
 	/**
 	 * Constructor
 	 *
-	 * @param  string  $parent  Element parent
+	 * @param   string  $parent  Element parent
 	 *
 	 * @deprecated    12.1
 	 * @since   11.1

--- a/libraries/joomla/html/parameter/element/usergroup.php
+++ b/libraries/joomla/html/parameter/element/usergroup.php
@@ -27,7 +27,6 @@ class JElementUserGroup extends JElement
 	protected $_name = 'UserGroup';
 
 	/**
-	/**
 	 * Fetch the timezones element
 	 *
 	 * @param   string  $name          Element name

--- a/libraries/joomla/language/help.php
+++ b/libraries/joomla/language/help.php
@@ -104,26 +104,26 @@ class JHelp
 
 		// Replace substitution codes in help URL.
 		$search = array('{app}', // Application name (eg. 'Administrator')
-'{component}', // Component name (eg. 'com_content')
-'{keyref}', // Help screen key reference
-'{language}', // Full language code (eg. 'en-GB')
-'{langcode}', // Short language code (eg. 'en')
-'{langregion}', // Region code (eg. 'GB')
-'{major}', // Joomla major version number
-'{minor}', // Joomla minor version number
-'{maintenance}')// Joomla maintenance version number
-;
+			'{component}', // Component name (eg. 'com_content')
+			'{keyref}', // Help screen key reference
+			'{language}', // Full language code (eg. 'en-GB')
+			'{langcode}', // Short language code (eg. 'en')
+			'{langregion}', // Region code (eg. 'GB')
+			'{major}', // Joomla major version number
+			'{minor}', // Joomla minor version number
+			'{maintenance}'// Joomla maintenance version number
+		);
 
 		$replace = array($app->getName(), // {app}
-$component, // {component}
-$keyref, // {keyref}
-$lang->getTag(), // {language}
-$jlang[0], // {langcode}
-$jlang[1], // {langregion}
-$jver[0], // {major}
-$jver[1], // {minor}
-$jver[2])// {maintenance}
-;
+			$component, // {component}
+			$keyref, // {keyref}
+			$lang->getTag(), // {language}
+			$jlang[0], // {langcode}
+			$jlang[1], // {langregion}
+			$jver[0], // {major}
+			$jver[1], // {minor}
+			$jver[2]// {maintenance}
+		);
 
 		// If the help file is local then check it exists.
 		// If it doesn't then fallback to English.

--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -246,7 +246,7 @@ abstract class JUserHelper
 		// Let's get the id of the user we want to activate
 		$query = 'SELECT id' . ' FROM #__users' . ' WHERE activation = ' . $db->Quote($activation) . ' AND block = 1' . ' AND lastvisitDate = '
 			. $db->Quote('0000-00-00 00:00:00');
-		;
+
 		$db->setQuery($query);
 		$id = intval($db->loadResult());
 


### PR DESCRIPTION
This adds two new sniffs to prevent the following errors:

```
class Foo
{
    public static function bar()
    {
        /*
         * Usage of "$this" in static methods will cause runtime errors
         * Classes_StaticThisUsageSniff
         */
        echo $this->baz;

        /*
         * Space found before semicolon; expected "'foo';" but found "'foo' ;"
         * WhiteSpace_SemicolonSpacingSniff
         */
        echo 'foo' ;
    }
}
```
