### PR TITLE
JGrid for dynamically generated HTML tables

### DIFF
--- a/libraries/joomla/html/grid.php
+++ b/libraries/joomla/html/grid.php
@@ -1,0 +1,350 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  HTML
+ *
+ * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * JGrid class to dynamically generate HTML tables
+ *
+ * @package     Joomla.Platform
+ * @subpackage  HTML
+ * @since       11.1
+ */
+class JGrid
+{
+	/**
+	 * Array of columns
+	 * @var array
+	 */
+	protected $columns = array();
+	
+	/**
+	 * Current active row
+	 * @var int
+	 */
+	protected $activeRow = 0;
+	
+	/**
+	 * Rows of the table (including header and footer rows)
+	 * @var array
+	 */
+	protected $rows = array();
+	
+	/**
+	 * Header and Footer row-IDs
+	 * @var array
+	 */
+	protected $specialRows = array('header' => array(), 'footer' => array());
+	
+	/**
+	 * Associative array of attributes for the table-tag
+	 * @var array
+	 */
+	protected $options;
+	
+	/**
+	 * Constructor for a JGrid object
+	 * 
+	 * @param array Associative array of attributes for the table-tag
+	 */
+	function __construct($options = array())
+	{
+		$this->setTableOptions($options, true);
+	}
+	
+	/**
+	 * Method to set the attributes for a table-tag
+	 * 
+	 * @param array Associative array of attributes for the table-tag
+	 * @param bool Replace possibly existing attributes
+	 * @return JGrid This object for chaining
+	 */
+	function setTableOptions($options = array(), $replace = false)
+	{
+		if($replace) {
+			$this->options = $options;
+		} else {
+			$this->options = array_merge($this->options, $options);
+		}
+		return $this;
+	}
+	
+	/**
+	 * Get the Attributes of the current table
+	 * @return array Associative array of attributes
+	 */
+	function getTableOptions()
+	{
+		return $this->options;
+	}
+
+	/**
+	 * Add new column name to process
+	 * 
+	 * @param string Internal column name
+	 * @return JGrid This object for chaining
+	 */
+	function addColumn($name)
+	{
+		$this->columns[] = $name;
+		
+		return $this;
+	}
+	
+	/**
+	 * Returns the list of internal columns
+	 * @return array List of internal columns
+	 */
+	function getColumns()
+	{
+		return $this->columns;
+	}
+	
+	/**
+	 * Delete column by name
+	 * 
+	 * @param string Name of the column to be deleted
+	 * @return JGrid This object for chaining
+	 */
+	function deleteColumn($name)
+	{
+		$index = array_search($name, $this->columns);
+		if($index !== false)
+		{
+			unset($this->columns[$index]);
+		}
+		
+		return $this;
+	}
+	
+	/**
+	 * Method to set a whole range of columns at once
+	 * This can be used to re-order the columns, too
+	 * 
+	 * @param array List of internal column names
+	 * @return JGrid This object for chaining
+	 */
+	function setColumns($columns)
+	{
+		$this->columns = $columns;
+		
+		return $this;
+	}
+	
+	/**
+	 * Adds a row to the table and sets the currently
+	 * active row to the new row
+	 * 
+	 * @param array Associative array of attributes for the row
+	 * @param int 1 for a new row in the header, 2 for a new row in the footer
+	 * @return JGrid This object for chaining
+	 */
+	function addRow($options = array(), $special = false)
+	{
+		$this->rows[]['_row'] = $options;
+		$this->activeRow = count($this->rows) - 1;
+		if($special) {
+			if($special === 1) {
+				$this->specialRows['header'][] = $this->activeRow;
+			} else {
+				$this->specialRows['footer'][] = $this->activeRow;
+			}
+		}
+		
+		return $this;
+	}
+	
+	/**
+	 * Set the currently active row
+	 * 
+	 * @param int ID of the row to be set to current
+	 * @return JGrid This object for chaining
+	 */
+	function setActiveRow($id)
+	{
+		$this->activeRow = (int) $id;
+		return $this;
+	}
+	
+	/**
+	 * Add information for a specific column for the
+	 * currently active row
+	 * 
+	 * @param string Name of the column
+	 * @param string Content for the cell
+	 * @param array Associative array of attributes for the td-element
+	 * @param bool If false, the content is appended to the current content of the cell
+	 * @return JGrid This object for chaining
+	 */
+	function addRowCell($name, $content, $option = array(), $replace = true)
+	{
+		if($replace || !isset($this->rows[$this->activeRow][$name]))
+		{
+			$cell = new stdClass();
+			$cell->options = $option;
+			$cell->content = $content;
+			$this->rows[$this->activeRow][$name] = $cell;
+		} else {
+			$this->rows[$this->activeRow][$name]->content .= $content;
+			$this->rows[$this->activeRow][$name]->options = array_merge($this->rows[$this->activeRow][$name]->options, $option);
+		}
+		
+		return $this;
+	}	
+	
+	/**
+	 * Get all data for a row
+	 * 
+	 * @param int ID of the row to return
+	 * @return array Array of columns of a table row
+	 */
+	function getRow($id)
+	{
+		return $this->rows[$id];
+	}
+	
+	/**
+	 * Get the IDs of all rows in the table
+	 * 
+	 * @param int false for the standard rows, 1 for the header rows, 2 for the footer rows
+	 * @return array Array of IDs
+	 */
+	function getRows($special = false)
+	{
+		if($special) {
+			if($special === 1) {
+				return array_keys($this->specialRows['header']);
+			} else {
+				return array_keys($this->specialRows['footer']);
+			}
+		}
+		return array_keys($this->rows);
+	}
+		
+	/**
+	 * Delete a row from the object
+	 * 
+	 * @param int ID of the row to be deleted
+	 * @return JGrid This object for chaining
+	 */
+	function deleteRow($id)
+	{
+		unset($this->rows[$id]);
+		
+		if(in_array($id, $this->specialRows['header'])) {
+			unset($this->specialRows['header'][array_search($id, $this->specialRows['header'])]);
+		}
+
+		if(in_array($id, $this->specialRows['footer'])) {
+			unset($this->specialRows['footer'][array_search($id, $this->specialRows['footer'])]);
+		}
+		
+		return $this;
+	}
+		
+	/**
+	 * Render the HTML table
+	 * 
+	 * @return string The rendered HTML table
+	 */
+	function render()
+	{
+		$output = array();
+		$output[] = '<table'.$this->renderAttributes($this->getTableOptions()).'>';
+		
+		$output[] = $this->renderHeader();
+		
+		$output[] = $this->renderFooter();
+		
+		$output[] = $this->renderBody();
+		
+		$output[] = '</table>';
+		return implode('', $output);		
+	}
+	
+	protected function renderHeader()
+	{
+		$output = array();
+		if(count($this->specialRows['header'])) {
+			$output[] = "<thead>\n";
+			foreach($this->specialRows['header'] as $id) {
+				$output[] = "\t<tr>\n";
+				foreach($this->getColumns() as $name)
+				{
+					if(isset($this->rows[$id][$name])) {
+						$column = $this->rows[$id][$name];
+						$output[] = "\t\t<th".$this->renderAttributes($column->options).'>'.$column->content."</th>\n";
+					}	
+				}
+				
+				$output[] = "\t</tr>\n";
+			}
+			$output[] = "</thead>";
+		}
+		return implode('', $output);
+	} 
+
+	protected function renderBody()
+	{
+		$output = array();
+		if(count(array_diff(array_keys($this->rows), $this->specialRows['header']))) {
+			$output[] = "<tbody>\n";
+			$row_ids = array_diff(array_keys($this->rows), $this->specialRows['header']);
+			foreach($row_ids as $id) {
+				$output[] = "\t<tr>\n";
+				foreach($this->getColumns() as $name)
+				{
+					if(isset($this->rows[$id][$name])) {
+						$column = $this->rows[$id][$name];
+						$output[] = "\t\t<td".$this->renderAttributes($column->options).'>'.$column->content."</td>\n";
+					}	
+				}
+				
+				$output[] = "\t</tr>\n";
+			}
+			$output[] = "</tbody>";
+		}
+		return implode('', $output);
+	} 
+	
+	protected function renderFooter()
+	{
+		$output = array();
+		if(count($this->specialRows['footer'])) {
+			$output[] = "<tfooter>\n";
+			foreach($this->specialRows['footer'] as $id) {
+				$output[] = "\t<tr>\n";
+				foreach($this->getColumns() as $name)
+				{
+					if(isset($this->rows[$id][$name])) {
+						$column = $this->rows[$id][$name];
+						$output[] = "\t\t<th".$this->renderAttributes($column->options).'>'.$column->content."</th>\n";
+					}	
+				}
+				
+				$output[] = "\t</tr>\n";
+			}
+			$output[] = "</tfooter>";
+		}
+		return implode('', $output);
+	}
+	
+	protected function renderAttributes($attributes)
+	{
+		if(count((array)$attributes) == 0) {
+			return '';
+		}
+		$return = array();
+		foreach($attributes as $key => $option)
+		{
+			$return[] = $key.'="'.$option.'"';
+		}
+		return ' '.implode(' ', $return);
+	}
+}


### PR DESCRIPTION
The JGrid class in this pull request allows to generate valid HTML tables. The benefit over hard-coding the table in a layout is the possibility to run it through a plugin event and thus easily extend the table.

A specific usage example:
In the backend user list view, we generate a JGrid table object and then fill it with all the current columns and rows. Now we send that table object (together with the used data) through a plugin event. A shopping cart plugin now adds a column that displays if these users have open invoices, which is added before the "Last Visit Date" column. Another plugin takes the current "Name" column and changes the content for each user to display some more statistics when you hover over the name. Last but not least, when finally in the layout, you only do a echo $table->render(); and have a valid HTML table with properly indented markup.

A few remarks to the implementation:
The class does not escape or check the data for cells or attributes. This is done on purpose, since the developer should be able to use all sorts of mark-up and not have his code changed by the class. Basically, the class is only supposed to delay the rendering of the table and not interfer with the mark-up any further.

The indentation of the generated table HTML is also not perfect. The moment a developer introduces line-breaks in his table content, the indentation is broken, but in general it should make reading the generated code a little bit easier. I also used it without the indentation and line breaks, but that became pretty much unreadable, which is why not all strings are done with single quotes, but for the indentation and line breaks with double quotes.

After the last pull request, Andrew Eddie told me that I maybe should add support for chaining to the class. This is done in this revision. I also thought about breaking this up into smaller classes, like on a row or even cell base, but that seems to just overcomplicate stuff. So I intentionally stuck with this single monolithic class. I'm not entirely happy with the setting-object-to-a-current-row solution, but it was necessary for the chaining and it requires less code than the previous approach.

Last but not least the class name. We are already using JTable and I didn't want to call it JHTMLTable, since it would then interfer with the JHTML class namespace. Who knows, maybe we want to have a JHTMLTable class in the future that generates some table content. So in the end, JGrid seemed to be the best compromise and its a reference to the Grid elements of Visual-C or Visual Basic.

Here is a small example how it can be used in the user manager. This is a copy from the header of the table from the backend users view of com_users in Joomla 1.7.0:

``` php
<?php
jimport('joomla.html.grid');

$table = new JGrid(array('class' => 'adminlist'));
$table->setColumns(array('checkbox', 'name', 'username', 'block', 'active', 'groups', 'email', 'lastvisit', 'registerdate', 'id'));

$table->addRow(array(), 1)
->addRowCell('checkbox', '<input type="checkbox" name="checkall-toggle" value="" title="'.JText::_('JGLOBAL_CHECK_ALL').'" onclick="Joomla.checkAll(this)" />', array('width'=> '1%'))
->addRowCell('name', JHtml::_('grid.sort', 'COM_USERS_HEADING_NAME', 'a.name', $listDirn, $listOrder), array('class' => 'left'))
->addRowCell('username', JHtml::_('grid.sort', 'JGLOBAL_USERNAME', 'a.username', $listDirn, $listOrder), array('class' => 'nowrap', 'width' => '10%'))
->addRowCell('block', JHtml::_('grid.sort', 'COM_USERS_HEADING_ENABLED', 'a.block', $listDirn, $listOrder), array('class' => 'nowrap', 'width' => '5%'))
->addRowCell('active', JHtml::_('grid.sort', 'COM_USERS_HEADING_ACTIVATED', 'a.activation', $listDirn, $listOrder), array('class' => 'nowrap', 'width' => '5%'))
->addRowCell('groups', JText::_('COM_USERS_HEADING_GROUPS'), array('class' => 'nowrap', 'width' => '10%'))
->addRowCell('email', JHtml::_('grid.sort', 'JGLOBAL_EMAIL', 'a.email', $listDirn, $listOrder), array('class' => 'nowrap', 'width' => '15%'))
->addRowCell('lastvisit', JHtml::_('grid.sort', 'COM_USERS_HEADING_LAST_VISIT_DATE', 'a.lastvisitDate', $listDirn, $listOrder), array('class' => 'nowrap', 'width' => '10%'))
->addRowCell('registerdate', JHtml::_('grid.sort', 'COM_USERS_HEADING_REGISTRATION_DATE', 'a.registerDate', $listDirn, $listOrder), array('class' => 'nowrap', 'width' => '10%'))
->addRowCell('id', JHtml::_('grid.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder), array('class' => 'nowrap', 'width' => '3%'));

echo $table->render();
```
