### PR TITLE
Adding a check for "getHeadData" in Cache

### DIFF
--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -564,7 +564,7 @@ class JCache extends JObject
 		$cached['body'] = $data;
 
 		// Document head data
-		if ($loptions['nohead'] != 1)
+		if ($loptions['nohead'] != 1 && method_exists($document, 'getHeadData'))
 		{
 
 			if ($loptions['modulemode'] == 1)


### PR DESCRIPTION
Added a check to the Cache for the method "getHeadData" to prevent issue #327 when JDocumentRaw is loaded where the method doesn't exist.
