### PR TITLE
Fixes to test framework and additions to JSession mock

### DIFF
--- a/tests/includes/JoomlaDatabaseTestCase.php
+++ b/tests/includes/JoomlaDatabaseTestCase.php
@@ -40,7 +40,15 @@ abstract class JoomlaDatabaseTestCase extends PHPUnit_Extensions_Database_TestCa
 	 * @var    array
 	 * @since  11.1
 	 */
-	protected $factoryState = array();
+	protected $savedFactoryState = array(
+		'application' => null,
+		'config' => null,
+		'session' => null,
+		'language' => null,
+		'document' => null,
+		'acl' => null,
+		'mailer' => null,
+	);
 
 	/**
 	 * @var    array

--- a/tests/includes/JoomlaDatabaseTestCase.php
+++ b/tests/includes/JoomlaDatabaseTestCase.php
@@ -429,14 +429,16 @@ abstract class JoomlaDatabaseTestCase extends PHPUnit_Extensions_Database_TestCa
 	/**
 	 * Gets a mock session object.
 	 *
+	 * @param   array  $options  An array of key-value options for the JSession mock.
+	 *
 	 * @return  object
 	 *
 	 * @since   11.3
 	 */
-	protected function getMockSession()
+	protected function getMockSession($options = array())
 	{
 		require_once JPATH_TESTS.'/suite/joomla/session/JSessionMock.php';
 
-		return JSessionGlobalMock::create($this);
+		return JSessionGlobalMock::create($this, $options);
 	}
 }

--- a/tests/includes/JoomlaDatabaseTestCase.php
+++ b/tests/includes/JoomlaDatabaseTestCase.php
@@ -43,6 +43,7 @@ abstract class JoomlaDatabaseTestCase extends PHPUnit_Extensions_Database_TestCa
 	protected $savedFactoryState = array(
 		'application' => null,
 		'config' => null,
+		'dates' => null,
 		'session' => null,
 		'language' => null,
 		'document' => null,

--- a/tests/includes/JoomlaDatabaseTestCase.php
+++ b/tests/includes/JoomlaDatabaseTestCase.php
@@ -431,6 +431,10 @@ abstract class JoomlaDatabaseTestCase extends PHPUnit_Extensions_Database_TestCa
 	 * Gets a mock session object.
 	 *
 	 * @param   array  $options  An array of key-value options for the JSession mock.
+	 *                           getId : the value to be returned by the mock getId method
+	 *                           get.user.id : the value to assign to the user object id returned by get('user')
+	 *                           get.user.name : the value to assign to the user object name returned by get('user')
+	 *                           get.user.username : the value to assign to the user object username returned by get('user')
 	 *
 	 * @return  object
 	 *

--- a/tests/includes/JoomlaTestCase.php
+++ b/tests/includes/JoomlaTestCase.php
@@ -20,7 +20,16 @@ abstract class JoomlaTestCase extends PHPUnit_Framework_TestCase
 	 * @var    array
 	 * @since  11.1
 	 */
-	protected $factoryState = array();
+	protected $savedFactoryState = array(
+		'application' => null,
+		'config' => null,
+		'session' => null,
+		'language' => null,
+		'document' => null,
+		'acl' => null,
+		'database' => null,
+		'mailer' => null,
+	);
 
 	/**
 	 * @var    errorState

--- a/tests/includes/JoomlaTestCase.php
+++ b/tests/includes/JoomlaTestCase.php
@@ -403,6 +403,10 @@ abstract class JoomlaTestCase extends PHPUnit_Framework_TestCase
 	 * Gets a mock session object.
 	 *
 	 * @param   array  $options  An array of key-value options for the JSession mock.
+	 *                           getId : the value to be returned by the mock getId method
+	 *                           get.user.id : the value to assign to the user object id returned by get('user')
+	 *                           get.user.name : the value to assign to the user object name returned by get('user')
+	 *                           get.user.username : the value to assign to the user object username returned by get('user')
 	 *
 	 * @return  object
 	 *

--- a/tests/includes/JoomlaTestCase.php
+++ b/tests/includes/JoomlaTestCase.php
@@ -23,6 +23,7 @@ abstract class JoomlaTestCase extends PHPUnit_Framework_TestCase
 	protected $savedFactoryState = array(
 		'application' => null,
 		'config' => null,
+		'dates' => null,
 		'session' => null,
 		'language' => null,
 		'document' => null,

--- a/tests/includes/JoomlaTestCase.php
+++ b/tests/includes/JoomlaTestCase.php
@@ -401,14 +401,16 @@ abstract class JoomlaTestCase extends PHPUnit_Framework_TestCase
 	/**
 	 * Gets a mock session object.
 	 *
+	 * @param   array  $options  An array of key-value options for the JSession mock.
+	 *
 	 * @return  object
 	 *
 	 * @since   11.3
 	 */
-	protected function getMockSession()
+	protected function getMockSession($options = array())
 	{
 		require_once JPATH_TESTS.'/suite/joomla/session/JSessionMock.php';
 
-		return JSessionGlobalMock::create($this);
+		return JSessionGlobalMock::create($this, $options);
 	}
 }

--- a/tests/suite/joomla/session/JSessionMock.php
+++ b/tests/suite/joomla/session/JSessionMock.php
@@ -14,16 +14,49 @@
 class JSessionGlobalMock
 {
 	/**
+	 * An array of options.
+	 *
+	 * @var    array
+	 * @since  11.3
+	 */
+	protected static $options = array();
+
+	/**
+	 * Gets an option.
+	 *
+	 * @param   string  $name     The name of the option.
+	 * @param   string  $default  The default value to use if the option is not found.
+	 *
+	 * @return  mixed  The value of the option, or the default if not found.
+	 *
+	 * @since   11.3
+	 */
+	public function getOption($name, $default = null)
+	{
+		return isset(self::$options[$name]) ? self::$options[$name] : $default;
+	}
+
+	/**
 	 * Creates an instance of the mock JDatabase object.
 	 *
-	 * @param   object  $test  A test object.
+	 * @param   object  $test    A test object.
+	 * @param   array   $config  An array of optional configuration values.
+	 *                           getId : the value to be returned by the mock getId method
+	 *                           get.user.id : the value to assign to the user object id returned by get('user')
+	 *                           get.user.name : the value to assign to the user object name returned by get('user')
+	 *                           get.user.username : the value to assign to the user object username returned by get('user')
 	 *
 	 * @return  object
 	 *
 	 * @since   11.3
 	 */
-	public static function create($test)
+	public static function create($test, $options = array())
 	{
+		if (is_array($options))
+		{
+			self::$options = $options;
+		}
+
 		// Mock all the public methods.
 		$methods = array(
 			'clear',
@@ -60,6 +93,12 @@ class JSessionGlobalMock
 		);
 
 		// Mock selected methods.
+		$test->assignMockReturns(
+			$mockObject, array(
+				'getId' => self::getOption('getId')
+			)
+		);
+
 		$test->assignMockCallbacks(
 			$mockObject,
 			array(
@@ -87,6 +126,10 @@ class JSessionGlobalMock
 				include_once JPATH_PLATFORM . '/joomla/user/user.php';
 
 				$user = new JUser;
+
+				$user->id = (int) self::getOption('get.user.id', 0);
+				$user->name = self::getOption('get.user.name');
+				$user->username = self::getOption('get.user.username');
 
 				return $user;
 		}


### PR DESCRIPTION
Fixed up a naming problem in the variable that is storing the factory state.

Added the ability to pass an array of options when creating the mock JSession object to make it easier for tests to tune the returned results.  Currently supports modifying the session id and the id, name and username of the user object returned by $session->get('user').
