### PR TITLE
Fixes wrong quotes in the js script in JHtmlBehavior::noframes.

### DIFF
--- a/libraries/joomla/html/html/behavior.php
+++ b/libraries/joomla/html/html/behavior.php
@@ -834,8 +834,8 @@ abstract class JHtmlBehavior
 		// Include MooTools framework
 		self::framework();
 
-		$js = "window.addEvent('domready', function () {if (top == self) {document.documentElement.style.display = 'block'; }' .
-			' else {top.location = self.location; }});";
+		$js = "window.addEvent('domready', function () {if (top == self) {document.documentElement.style.display = 'block'; }" .
+			" else {top.location = self.location; }});";
 		$document = JFactory::getDocument();
 		$document->addStyleDeclaration('html { display:none }');
 		$document->addScriptDeclaration($js);


### PR DESCRIPTION
This bug causes the CMS Administrator login page to appear blank.
