### PR TITLE
New event called onBeforeModuleLoad

### DIFF
--- a/libraries/joomla/application/module/helper.php
+++ b/libraries/joomla/application/module/helper.php
@@ -387,6 +387,10 @@ abstract class JModuleHelper
 
 			unset($dupes);
 
+			//Module Plugin
+			$dispatcher	= JDispatcher::getInstance();
+			$dispatcher->trigger('onBeforeModuleLoad', array(&$clean));
+
 			// Return to simple indexing that matches the query order.
 			$clean = array_values($clean);
 

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -834,7 +834,7 @@ class JBrowser extends JObject
 	}
 
 	/**
-	 * Returns the server protocol in use on the current server.
+	 * Returns the server protocol version in use on the current server.
 	 *
 	 * @return  string  The HTTP server protocol version.
 	 *


### PR DESCRIPTION
New event called onBeforeModuleLoad that allow users to have fine control over the modules properties before they get loaded and rendered

Thanks to this developer will have more control of the modules before they get rendered, for example
*Change titles, positions name, etc, dynamically 
*Develop plugins to set conditional statements to prevent render a module under certain situations
*Other enhancements related with modules
