### PR TITLE
Calling JResponse::setHeader with $replace = false more than once with th

### DIFF
--- a/libraries/joomla/environment/response.php
+++ b/libraries/joomla/environment/response.php
@@ -136,7 +136,7 @@ class JResponse
 				}
 				else
 				{
-					header($header['name'] . ': ' . $header['value']);
+					header($header['name'] . ': ' . $header['value'], false);
 				}
 			}
 		}


### PR DESCRIPTION
Calling JResponse::setHeader with $replace = false more than once with the same name correctly adds multiple entries to the self::$headers array.  But JResponse::sendHeaders would then always replace earlier headers of the same name because the 2nd argument to the PHP header function defaults to true, not false.
