### PR TITLE
Joomla CMS [#26451] Favicon disappears 

### DIFF
--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -570,7 +570,7 @@ class JCache extends JObject
 			if ($loptions['modulemode'] == 1)
 			{
 				$headnow = $document->getHeadData();
-				$unset = array('title', 'description', 'link', 'metaTags');
+				$unset = array('title', 'description', 'link', 'links', 'metaTags');
 
 				foreach ($unset as $un)
 				{


### PR DESCRIPTION
Links is needed in JCache:: setWorkarounds in order to not preserve the favicon on caching

See patch for older code here:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=26451
