### PR TITLE
Converts JDispatcher::getInstance to use a protected static class to store its singleton.

### DIFF
--- a/libraries/joomla/event/dispatcher.php
+++ b/libraries/joomla/event/dispatcher.php
@@ -26,6 +26,14 @@ jimport('joomla.base.observable');
 class JDispatcher extends JObservable
 {
 	/**
+	 * Stores the singleton instance of the dispatcher.
+	 *
+	 * @var    JDispatcher
+	 * @since  11.3
+	 */
+	protected static $instance = null;
+
+	/**
 	 * Returns the global Event Dispatcher object, only creating it
 	 * if it doesn't already exist.
 	 *
@@ -35,14 +43,12 @@ class JDispatcher extends JObservable
 	 */
 	public static function getInstance()
 	{
-		static $instance;
-
-		if (!is_object($instance))
+		if (self::$instance === null)
 		{
-			$instance = new JDispatcher;
+			self::$instance = new JDispatcher;
 		}
 
-		return $instance;
+		return self::$instance;
 	}
 
 	/**

--- a/tests/suite/joomla/event/JDispatcherInspector.php
+++ b/tests/suite/joomla/event/JDispatcherInspector.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Event
+ * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+require_once JPATH_PLATFORM.'/joomla/event/dispatcher.php';
+
+/**
+ * Inspector JContentHelperTest class.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Event
+ * @since       11.3
+ */
+class JDispatcherInspector extends JDispatcher
+{
+	/**
+	 * Allows the internal singleton to be set and mocked.
+	 *
+	 * @param   JDispatcher  $instance  A dispatcher object.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function setInstance($instance)
+	{
+		self::$instance = $instance;
+	}
+}

--- a/tests/suite/joomla/event/JDispatcherTest.php
+++ b/tests/suite/joomla/event/JDispatcherTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Event
+ *
+ * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+require_once __DIR__ . '/JDispatcherInspector.php';
+
+/**
+ * Test class for JForm.
+ *
+ * @package		Joomla.UnitTest
+ * @subpackage  Event
+ * @since       11.3
+ */
+class JDispatcherTest extends JoomlaTestCase
+{
+	/**
+	 * Tests the JDispatcher::getInstance method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testGetInstance()
+	{
+		$instance = JDispatcher::getInstance();
+
+		$this->assertInstanceOf(
+			'JDispatcher',
+			$instance,
+			'Tests that getInstance returns a JDispatcher object.'
+		);
+
+		// Push a new instance into the class.
+		JDispatcherInspector::setInstance('foo');
+
+		$this->assertThat(
+			JDispatcher::getInstance(),
+			$this->equalTo('foo'),
+			'Tests that a subsequent call to JDispatcher::getInstance returns the cached singleton.'
+		);
+	}
+
+	/**
+	 * Tests the JDispatcher::register method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testRegister()
+	{
+		$this->markTestIncomplete('Todo');
+	}
+
+	/**
+	 * Tests the JDispatcher::trigger method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testTrigger()
+	{
+		$this->markTestIncomplete('Todo');
+	}
+}


### PR DESCRIPTION
Currently JDispatcher cannot be mocked due to static storage within the getInstance method.  This method is changed to use a protected static class variable which can be overridden in child classes.  Also adds base tests for JDispatcher and an inspector class that can inject a mock dispatcher if required.
