### PR TITLE
Allow $format in JHtml::date to contain a language key and call JText::_() if so.

### DIFF
--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -697,6 +697,11 @@ abstract class JHtml
 		{
 			$format = JText::_('DATE_FORMAT_LC1');
 		}
+		// format is an existing language key
+		elseif (JFactory::getLanguage()->hasKey($format))
+		{
+			$format = JText::_($format);
+		}
 
 		if ($gregorian)
 		{


### PR DESCRIPTION
ie. `JHtml::_('date', $datevalue, 'DATE_FORMAT_LC4');`

This patch tests if $format is an existing language key and should make the interface of this helper more convenient, "obvious" and DRY. 
Makes this a shortcut to the common, repetitive, and ugly looking 
`JHtml::_('date', $datevalue, JText::_('DATE_FORMAT_LC4'));`
