### PR TITLE
Joomla CMS [#26844] Improvements to batch processing

### DIFF
--- a/libraries/joomla/application/component/modeladmin.php
+++ b/libraries/joomla/application/component/modeladmin.php
@@ -253,7 +253,7 @@ abstract class JModelAdmin extends JModelForm
 	 * @param   integer  $value  The new category.
 	 * @param   array    $pks    An array of row IDs.
 	 *
-	 * @return  boolean  True if successful, false otherwise and internal error is set.
+	 * @return  mixed  An array of new IDs on success, boolean false on failure.
 	 *
 	 * @since	11.1
 	 */
@@ -263,6 +263,7 @@ abstract class JModelAdmin extends JModelForm
 
 		$table = $this->getTable();
 		$db = $this->getDbo();
+		$i = 0;
 
 		// Check that the category exists
 		if ($categoryId)
@@ -351,12 +352,19 @@ abstract class JModelAdmin extends JModelForm
 				$this->setError($table->getError());
 				return false;
 			}
+
+			// Get the new extension ID
+			$newId = $table->get('id');
+
+			// Add the new ID to the array
+			$newIds[$i]	= $newId;
+			$i++;
 		}
 
 		// Clean the cache
 		$this->cleanCache();
 
-		return true;
+		return $newIds;
 	}
 
 	/**

--- a/libraries/joomla/application/component/modeladmin.php
+++ b/libraries/joomla/application/component/modeladmin.php
@@ -172,9 +172,17 @@ abstract class JModelAdmin extends JModelForm
 		{
 			$cmd = JArrayHelper::getValue($commands, 'move_copy', 'c');
 
-			if ($cmd == 'c' && !$this->batchCopy($commands['category_id'], $pks))
+			if ($cmd == 'c')
 			{
-				return false;
+				$result = $this->batchCopy($commands['category_id'], $pks);
+				if (is_array($result))
+				{
+					$pks = $result;
+				}
+				else
+				{
+					return false;
+				}
 			}
 			else if ($cmd == 'm' && !$this->batchMove($commands['category_id'], $pks))
 			{

--- a/libraries/joomla/application/component/modeladmin.php
+++ b/libraries/joomla/application/component/modeladmin.php
@@ -168,16 +168,6 @@ abstract class JModelAdmin extends JModelForm
 
 		$done = false;
 
-		if (!empty($commands['assetgroup_id']))
-		{
-			if (!$this->batchAccess($commands['assetgroup_id'], $pks))
-			{
-				return false;
-			}
-
-			$done = true;
-		}
-
 		if (!empty($commands['category_id']))
 		{
 			$cmd = JArrayHelper::getValue($commands, 'move_copy', 'c');
@@ -190,6 +180,16 @@ abstract class JModelAdmin extends JModelForm
 			{
 				return false;
 			}
+			$done = true;
+		}
+
+		if (!empty($commands['assetgroup_id']))
+		{
+			if (!$this->batchAccess($commands['assetgroup_id'], $pks))
+			{
+				return false;
+			}
+
 			$done = true;
 		}
 

--- a/libraries/joomla/application/component/modeladmin.php
+++ b/libraries/joomla/application/component/modeladmin.php
@@ -361,7 +361,7 @@ abstract class JModelAdmin extends JModelForm
 				return false;
 			}
 
-			// Get the new extension ID
+			// Get the new item ID
 			$newId = $table->get('id');
 
 			// Add the new ID to the array


### PR DESCRIPTION
There is a bug in the current batch processing method in that when items are copied, if the access level is also changed, then the access change is applied to the original item.  The batchCopy process is modified to return an array of new item IDs to the batch process and the batch process is modified so that the copy/move command is executed first and that the $pks array is reset with the new IDs on a successful copy.

See CMS issue: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=26844
