### PR TITLE
Fixed case typo in modellist.php (changed getstart to getStart)

### DIFF
--- a/libraries/joomla/application/component/modellist.php
+++ b/libraries/joomla/application/component/modellist.php
@@ -252,7 +252,7 @@ class JModelList extends JModel
 	 *
 	 * @since   11.1
 	 */
-	public function getstart()
+	public function getStart()
 	{
 		$store = $this->getStoreId('getstart');
 


### PR DESCRIPTION
Fixed case typo in libraries/joomla/application/component/modellist.php:255.  

Should have been 'function getStart' but was 'function getstart.  

It worked fine but made it hard to find in case-dependent searches.  Unit test unaffected.
