### PR TITLE
Joomla CMS [#26863] countMenuChildren has incorrect column reference and generates 1054 error when debug turned on

### DIFF
--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -496,7 +496,7 @@ class JDocumentHTML extends JDocument
 				$query->getQuery(true);
 				$query->select('COUNT(*)');
 				$query->from('#__menu');
-				$query->where('parent = ' . $active->id);
+				$query->where('parent_id = ' . $active->id);
 				$query->where('published = 1');
 				$children = $dbo->loadResult();
 			}


### PR DESCRIPTION
I'm using countMenuChildren in my template (using Joomla 1.7.0). It seems to work fine except when I turned on error reporting / debug. It gave me the following error message:

JDatabaseMySQL::query: 1054 - Unknown column 'parent' in 'where clause' SQL=SELECT COUNT(*) FROM hc5wg_menu WHERE parent = 101 AND published = 1

The page gives a 500 error and has the following backtrace:
# Function    Location

1   JSite->render()     /.../index.php:49
2   JDocumentHTML->parse()  /.../includes/application.php:249
3   JDocumentHTML->_fetchTemplate()     /.../libraries/joomla/document/html/html.php:378
4   JDocumentHTML->_loadTemplate()  /.../libraries/joomla/document/html/html.php:547
5   require()   /.../libraries/joomla/document/html/html.php:488
6   JDocumentHTML->countMenuChildren()  /.../templates/hp1/index.php:112
7   JDatabase->loadResult()     /.../libraries/joomla/document/html/html.php:455
8   JDatabaseMySQLi->query()    /.../libraries/joomla/database/database.php:1008
9   JError::raiseError()    /.../libraries/joomla/database/database/mysqli.php:535
10  JError::raise()     /.../libraries/joomla/error/error.php:215

Line 112 in my template is where I call $this->countMenuChildren()

I looked in the database and there is not a field called 'parent' in the #__menu table. However, there is a field called "parent_id"

The libraries/joomla/document/html/html.php file on line 499 (line 452 in current library used in Joomla 1.7.0) is:

$where[] = 'parent = ' . $active->id;

but I think it should be:

$where[] = 'parent_id = ' . $active->id;

Whenever I make that change, everything seems to work fine.
