### PR TITLE
Typo in JGrid

### DIFF
--- a/libraries/joomla/html/grid.php
+++ b/libraries/joomla/html/grid.php
@@ -450,7 +450,7 @@ class JGrid
 		$output = array();
 		if (count($this->specialRows['footer']))
 		{
-			$output[] = "<tfooter>\n";
+			$output[] = "<tfoot>\n";
 			foreach ($this->specialRows['footer'] as $id)
 			{
 				$output[] = "\t<tr>\n";
@@ -465,7 +465,7 @@ class JGrid
 
 				$output[] = "\t</tr>\n";
 			}
-			$output[] = "</tfooter>";
+			$output[] = "</tfoot>";
 		}
 		return implode('', $output);
 	}

--- a/tests/suite/joomla/html/JGridTest.php
+++ b/tests/suite/joomla/html/JGridTest.php
@@ -503,7 +503,7 @@ class JGridTest extends PHPUnit_Framework_TestCase
 		$table->specialRows = array('header' => array(), 'footer' => array(0));
 		$this->assertThat(
 			$table->renderFooter(),
-			$this->equalTo("<tfooter>\n\t<tr>\n\t\t<th class=\"test1\">testcontent</th>\n\t</tr>\n</tfooter>")
+			$this->equalTo("<tfoot>\n\t<tr>\n\t\t<th class=\"test1\">testcontent</th>\n\t</tr>\n</tfoot>")
 		);
 	}
 	


### PR DESCRIPTION
A little bit embarassing, but the JGrid class has a typo in the rendering of the footer rows. It should be <tfoot> instead of <tfooter>. This has been fixed in this pull request.
