### PR TITLE
CodeSniffer should run from any directory

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -81,7 +81,7 @@
   <exec executable="phpcs">
    <arg value="--report=checkstyle" />
    <arg value="--report-file=${basedir}/build/logs/checkstyle.xml" />
-   <arg value="--standard=Joomla" />
+   <arg value="--standard=${basedir}/build/phpcs/Joomla" />
    <arg path="${source}/joomla" />
   </exec>
  </target>

--- a/build/phpcs/Joomla/Sniffs/Commenting/ClassCommentSniff.php
+++ b/build/phpcs/Joomla/Sniffs/Commenting/ClassCommentSniff.php
@@ -19,6 +19,8 @@ if (class_exists('PHP_CodeSniffer_CommentParser_ClassCommentParser', true) === f
     throw new PHP_CodeSniffer_Exception($error);
 }
 
+require_once 'FileCommentSniff.php';
+
 if (class_exists('Joomla_Sniffs_Commenting_FileCommentSniff', true) === false) {
     $error = 'Class Joomla_Sniffs_Commenting_FileCommentSniff not found';
     throw new PHP_CodeSniffer_Exception($error);

--- a/build/phpcs/Joomla/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/build/phpcs/Joomla/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -46,7 +46,7 @@ class Joomla_Sniffs_ControlStructures_InlineControlStructureSniff extends Generi
      *
      * @var bool
      */
-    public $error = true;
+    public $error = false;
 
 
     /**

--- a/build/phpcs/Joomla/ruleset.xml
+++ b/build/phpcs/Joomla/ruleset.xml
@@ -45,11 +45,4 @@
   <severity>0</severity>
  </rule>
 
- <!-- Use warnings for inline control structures -->
- <rule ref="Joomla.ControlStructures.InlineControlStructure">
-  <properties>
-   <property name="error" value="false"/>
-  </properties>
- </rule>
-
 </ruleset>


### PR DESCRIPTION
Right now it is required to copy or softlink the coding standards to your system standards directory in order to use them.
I find this difficult for testing and it might also raise the barriers for developers.

The reason the sniffs won't run from any directory is the fact that they make one reference to a system standard called "Joomla" - only to set the severity for inline control structures from error to warning...

So, I removed that reference, updated the corresponding sniff file and also modified the build.xml to pick the Joomla! Standard found in the directory instead of the system standard.
