### PR TITLE
Fixed fatal error in Sql Azure driver

### DIFF
--- a/libraries/joomla/database/database/sqlazure.php
+++ b/libraries/joomla/database/database/sqlazure.php
@@ -9,7 +9,7 @@
 
 defined('JPATH_PLATFORM') or die();
 
-require dirname(__FILE__).'sqlsrv.php';
+require dirname(__FILE__).'/sqlsrv.php';
 
 JLoader::register('JDatabaseQuerySQLAzure', dirname(__FILE__) . '/sqlazurequery.php');
 


### PR DESCRIPTION
Fixed this => Fatal error: require() [function.require]: Failed opening required '/users/amystephen/sites/molajo/libraries/jplatform/joomla/database/databasesqlsrv.php' (include_path='.:/Applications/MAMP/bin/php5.3/lib/php') in /users/amystephen/sites/molajo/libraries/jplatform/joomla/database/database/sqlazure.php on line 12
