### PR TITLE
Sniff fixes

### DIFF
--- a/build/phpcs/Joomla/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/build/phpcs/Joomla/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -50,10 +50,9 @@ class Joomla_Sniffs_ControlStructures_ControlSignatureSniff extends PHP_CodeSnif
 	protected function getPatterns()
 	{
 		return array(
-			'if (...)EOL...{...}EOL',
-			'elseEOL...{EOL',
-			'elseif (...)EOL...{EOL',
-			'else if (...)EOL...{EOL',
+			'if (...)EOL...{...}EOL...elseEOL',
+			'if (...)EOL...{...}EOL...elseif (...)EOL',
+			'if (...)EOL',
 
 			'tryEOL...{EOL...}EOL',
 			'catch (...)EOL...{EOL',
@@ -88,8 +87,8 @@ class Joomla_Sniffs_ControlStructures_ControlSignatureSniff extends PHP_CodeSnif
 		{
 			/*
 			 * @todo disabled - This is a special sniff for the Joomla! CMS to exclude
-			 * the tmpl folder which may contain constructs in colon notation
-			 */
+			* the tmpl folder which may contain constructs in colon notation
+			*/
 
 			$parts = explode(DIRECTORY_SEPARATOR, $phpcsFile->getFileName());
 

--- a/build/phpcs/Joomla/Sniffs/ControlStructures/MultiLineConditionSniff.php
+++ b/build/phpcs/Joomla/Sniffs/ControlStructures/MultiLineConditionSniff.php
@@ -29,7 +29,6 @@
 class Joomla_Sniffs_ControlStructures_MultiLineConditionSniff implements PHP_CodeSniffer_Sniff
 {
 
-
     /**
      * Returns an array of tokens this test wants to listen for.
      *
@@ -40,7 +39,6 @@ class Joomla_Sniffs_ControlStructures_MultiLineConditionSniff implements PHP_Cod
         return array(T_IF);
 
     }//end register()
-
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -74,24 +72,21 @@ class Joomla_Sniffs_ControlStructures_MultiLineConditionSniff implements PHP_Cod
         // function call, in which case it is ignored.
         $openBracket  = $tokens[$stackPtr]['parenthesis_opener'];
         $closeBracket = $tokens[$stackPtr]['parenthesis_closer'];
-        $lastLine     = $tokens[$openBracket]['line'];
-        for ($i = ($openBracket + 1); $i < $closeBracket; $i++) {
+        $lastLine = $tokens[$openBracket]['line'];
+
+        for ($i = ($openBracket + 1); $i <= $closeBracket; $i++) {
             if ($tokens[$i]['line'] !== $lastLine) {
                 if ($tokens[$i]['line'] === $tokens[$closeBracket]['line']) {
                     $next = $phpcsFile->findNext(T_WHITESPACE, $i, null, true);
-                    if ($next !== $closeBracket) {
-                        // Closing bracket is on the same line as a condition.
-                        $error = 'Closing parenthesis of a multi-line IF statement must be on a new line';
-                        $phpcsFile->addError($error, $i, 'CloseBracketNewLine');
-                        $expectedIndent = ($statementIndent + 1);
-                    } else {
-                        // Closing brace needs to be indented to the same level
-                        // as the function.
-                        $expectedIndent = $statementIndent;
+                    if ($next == $closeBracket) {
+	                    $error = 'Closing parenthesis of a multi-line IF statement must be on the same line';
+	                    $phpcsFile->addError($error, $i, 'CloseBracketNewLine');
+	                    $i ++;
+	                    continue;
                     }
-                } else {
-                    $expectedIndent = ($statementIndent + 1);
                 }
+
+                    $expectedIndent = ($statementIndent + 1);
 
                 // We changed lines, so this should be a whitespace indent token.
                 if ($tokens[$i]['code'] !== T_WHITESPACE) {
@@ -109,12 +104,11 @@ class Joomla_Sniffs_ControlStructures_MultiLineConditionSniff implements PHP_Cod
                     $phpcsFile->addError($error, $i, 'Alignment', $data);
                 }
 
-                if ($tokens[$i]['line'] !== $tokens[$closeBracket]['line']) {
-                    $next = $phpcsFile->findNext(T_WHITESPACE, $i, null, true);
-                    if (in_array($tokens[$next]['code'], PHP_CodeSniffer_Tokens::$booleanOperators) === false) {
-                        $error = 'Each line in a multi-line IF statement must begin with a boolean operator';
-                        $phpcsFile->addError($error, $i, 'StartWithBoolean');
-                    }
+                $next = $phpcsFile->findNext(T_WHITESPACE, $i, null, true);
+
+                if (in_array($tokens[$next]['code'], PHP_CodeSniffer_Tokens::$booleanOperators) === false) {
+                    $error = 'Each line in a multi-line IF statement must begin with a boolean operator';
+                    $phpcsFile->addError($error, $i, 'StartWithBoolean');
                 }
 
                 $lastLine = $tokens[$i]['line'];
@@ -132,30 +126,7 @@ class Joomla_Sniffs_ControlStructures_MultiLineConditionSniff implements PHP_Cod
             }
         }//end for
 
-        // From here on, we are checking the spacing of the opening and closing
-        // braces. If this IF statement does not use braces, we end here.
-        if (isset($tokens[$stackPtr]['scope_opener']) === false) {
-            return;
-        }
-
-        // The opening brace needs to be one space away from the closing parenthesis.
-        if ($tokens[($closeBracket + 1)]['code'] !== T_WHITESPACE) {
-            $length = 0;
-        } else if ($tokens[($closeBracket + 1)]['content'] === $phpcsFile->eolChar) {
-            $length = -1;
-        } else {
-            $length = strlen($tokens[($closeBracket + 1)]['content']);
-        }
-
-        // And just in case they do something funny before the brace...
-        $next = $phpcsFile->findNext(T_WHITESPACE, ($closeBracket + 1), null, true);
-        if ($next !== false && $tokens[$next]['code'] !== T_OPEN_CURLY_BRACKET) {
-            $error = 'There must be a single space between the closing parenthesis and the opening brace of a multi-line IF statement';
-            $phpcsFile->addError($error, $next, 'NoSpaceBeforeOpenBrace');
-        }
-
     }//end process()
-
 
 }//end class
 

--- a/build/phpcs/Joomla/Sniffs/Files/IncludingFileSniff.php
+++ b/build/phpcs/Joomla/Sniffs/Files/IncludingFileSniff.php
@@ -83,6 +83,12 @@ class Joomla_Sniffs_Files_IncludingFileSniff implements PHP_CodeSniffer_Sniff
             $phpcsFile->addError($error, $stackPtr, 'BracketsNotRequired', $data);
         }
 
+        /*
+         * elkuku: The test for conditional including has been disabled.
+         */
+
+        return;
+
         $inCondition = (count($tokens[$stackPtr]['conditions']) !== 0) ? true : false;
 
         // Check to see if this including statement is within the parenthesis

--- a/build/phpcs/Joomla/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/build/phpcs/Joomla/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * Joomla_Sniffs_Functions_FunctionDeclarationSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
+ * @version   CVS: $Id: FunctionDeclarationSniff.php 308840 2011-03-02 05:32:18Z squiz $
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Joomla_Sniffs_Functions_FunctionDeclarationSniff.
+ *
+ * Ensure single and multi-line function declarations are defined correctly.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @copyright 2006 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   http://matrix.squiz.net/developer/tools/php_cs/licence BSD Licence
+ * @version   Release: 1.3.0
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Joomla_Sniffs_Functions_FunctionDeclarationSniff implements PHP_CodeSniffer_Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_FUNCTION);
+    }//end register()
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Check if this is a single line or multi-line declaration.
+        $openBracket  = $tokens[$stackPtr]['parenthesis_opener'];
+        $closeBracket = $tokens[$stackPtr]['parenthesis_closer'];
+        if ($tokens[$openBracket]['line'] === $tokens[$closeBracket]['line']) {
+            $this->processSingleLineDeclaration($phpcsFile, $stackPtr, $tokens);
+        } else {
+            $this->processMultiLineDeclaration($phpcsFile, $stackPtr, $tokens);
+        }
+
+    }//end process()
+
+    /**
+     * Processes single-line declarations.
+     *
+     * Just uses the Generic BSD-Allman brace sniff.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     * @param array                $tokens    The stack of tokens that make up
+     *                                        the file.
+     *
+     * @return void
+     */
+    public function processSingleLineDeclaration(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $tokens)
+    {
+        if (class_exists('Generic_Sniffs_Functions_OpeningFunctionBraceBsdAllmanSniff', true) === false) {
+            throw new PHP_CodeSniffer_Exception('Class Generic_Sniffs_Functions_OpeningFunctionBraceBsdAllmanSniff not found');
+        }
+
+        $sniff = new Generic_Sniffs_Functions_OpeningFunctionBraceBsdAllmanSniff();
+        $sniff->process($phpcsFile, $stackPtr);
+
+    }//end processSingleLineDeclaration()
+
+
+    /**
+     * Processes mutli-line declarations.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     * @param array                $tokens    The stack of tokens that make up
+     *                                        the file.
+     *
+     * @return void
+     */
+    public function processMultiLineDeclaration(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $tokens)
+    {
+        // We need to work out how far indented the function
+        // declaration itself is, so we can work out how far to
+        // indent parameters.
+        $functionIndent = 0;
+        for ($i = ($stackPtr - 1); $i >= 0; $i--) {
+            if ($tokens[$i]['line'] !== $tokens[$stackPtr]['line']) {
+                $i++;
+                break;
+            }
+        }
+
+        if ($tokens[$i]['code'] === T_WHITESPACE) {
+            $functionIndent = strlen($tokens[$i]['content']);
+        }
+
+        // Each line between the parenthesis should be indented 4 spaces.
+        $openBracket  = $tokens[$stackPtr]['parenthesis_opener'];
+        $closeBracket = $tokens[$stackPtr]['parenthesis_closer'];
+        $lastLine     = $tokens[$openBracket]['line'];
+        for ($i = ($openBracket + 1); $i < $closeBracket; $i++) {
+            if ($tokens[$i]['line'] !== $lastLine)
+            {
+                //-- elkuku: disabled
+//                 if ($tokens[$i]['line'] === $tokens[$closeBracket]['line']) {
+//                     // Closing brace needs to be indented to the same level
+//                     // as the function.
+//                     $expectedIndent = $functionIndent;
+//                 } else {
+//                     $expectedIndent = $functionIndent + 4;
+//                 }
+
+                $expectedIndent = $functionIndent + 1;
+
+                // We changed lines, so this should be a whitespace indent token.
+                if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                    $foundIndent = 0;
+                } else {
+                    $foundIndent = strlen($tokens[$i]['content']);
+                }
+
+                if ($expectedIndent !== $foundIndent) {
+                    $error = 'Multi-line function declaration not indented correctly; expected %s spaces but found %s';
+                    $data  = array(
+                              $expectedIndent,
+                              $foundIndent,
+                             );
+                    $phpcsFile->addError($error, $i, 'Indent', $data);
+                }
+
+                $lastLine = $tokens[$i]['line'];
+            }//end if
+
+            if ($tokens[$i]['code'] === T_ARRAY) {
+                // Skip arrays as they have their own indentation rules.
+                $i        = $tokens[$i]['parenthesis_closer'];
+                $lastLine = $tokens[$i]['line'];
+                continue;
+            }
+        }//end for
+
+        if (isset($tokens[$stackPtr]['scope_opener']) === true) {
+            // The openning brace needs to be one space away
+            // from the closing parenthesis.
+            $next = $tokens[($closeBracket + 1)];
+            if ($next['code'] !== T_WHITESPACE) {
+                $length = 0;
+            } else if ($next['content'] === $phpcsFile->eolChar) {
+                $length = -1;
+            } else {
+                $length = strlen($next['content']);
+            }
+
+            if (false)//$length !== 1) {
+            {
+                $data = array($length);
+                $code = 'SpaceBeforeOpenBrace';
+
+            //-- elkuku: nonsens ?
+//                 $error = 'There must be a single space between the closing parenthesis and the opening brace of a multi-line function declaration; found ';
+//                 if ($length === -1) {
+//                     $error .= 'newline';
+//                     $code   = 'NewlineBeforeOpenBrace';
+//                 } else {
+//                     $error .= '%s spaces';
+//                 }
+
+                $phpcsFile->addError($error, ($closeBracket + 1), $code, $data);
+                return;
+            }
+
+            // And just in case they do something funny before the brace...
+            $next = $phpcsFile->findNext(
+                T_WHITESPACE,
+                ($closeBracket + 1),
+                null,
+                true
+            );
+
+            //-- elkuku: nonsens ?
+//             if ($next !== false && $tokens[$next]['code'] !== T_OPEN_CURLY_BRACKET) {
+//                 $error = 'There must be a single space between the closing parenthesis and the opening brace of a multi-line function declaration';
+//                 $phpcsFile->addError($error, $next, 'NoSpaceBeforeOpenBrace');
+//             }
+        }//end if
+
+        // The closing parenthesis must be on a new line, even
+        // when checking abstract function definitions.
+        $prev = $phpcsFile->findPrevious(
+            T_WHITESPACE,
+            ($closeBracket - 1),
+            null,
+            true
+        );
+
+        //-- elkuku: disabled
+//         if ($tokens[$prev]['line'] === $tokens[$closeBracket]['line']) {
+//             $error = 'The closing parenthesis of a multi-line function declaration must be on a new line';
+//             $phpcsFile->addError($error, $closeBracket, 'CloseBracketLine');
+//         }
+
+    }//end processMultiLineDeclaration()
+
+
+}//end class
+
+?>

--- a/build/phpcs/Joomla/Sniffs/Functions/FunctionDeclarationSniff.php
+++ b/build/phpcs/Joomla/Sniffs/Functions/FunctionDeclarationSniff.php
@@ -215,11 +215,10 @@ class Joomla_Sniffs_Functions_FunctionDeclarationSniff implements PHP_CodeSniffe
             true
         );
 
-        //-- elkuku: disabled
-//         if ($tokens[$prev]['line'] === $tokens[$closeBracket]['line']) {
-//             $error = 'The closing parenthesis of a multi-line function declaration must be on a new line';
-//             $phpcsFile->addError($error, $closeBracket, 'CloseBracketLine');
-//         }
+        if ($tokens[$prev]['line'] != $tokens[$closeBracket]['line']) {
+            $error = 'The closing parenthesis of a multi-line function declaration must be on the same line';
+            $phpcsFile->addError($error, $closeBracket, 'CloseBracketLine');
+        }
 
     }//end processMultiLineDeclaration()
 

--- a/build/phpcs/Joomla/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
+++ b/build/phpcs/Joomla/Sniffs/WhiteSpace/SuperfluousWhitespaceSniff.php
@@ -59,6 +59,7 @@ class Joomla_Sniffs_WhiteSpace_SuperfluousWhitespaceSniff implements PHP_CodeSni
         T_CLOSE_TAG,
         T_WHITESPACE,
         T_COMMENT,
+        T_CLOSE_CURLY_BRACKET,
         );
     }//function
 

--- a/build/phpcs/Joomla/ruleset.xml
+++ b/build/phpcs/Joomla/ruleset.xml
@@ -10,14 +10,12 @@
  
  <rule ref="PEAR.Commenting.InlineComment"/>
  
- <rule ref="PEAR.Files.IncludingFile"/>
  <rule ref="Generic.Files.LineEndings"/>
  <rule ref="Generic.Files.LineLength"/>
  
  <rule ref="PEAR.Formatting.MultiLineAssignment"/>
  
  <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
-<!-- <rule ref="PEAR.Functions.FunctionDeclaration"/> -->
  <rule ref="PEAR.Functions.ValidDefaultValue"/>
 
  <rule ref="PEAR.NamingConventions.ValidClassName"/>

--- a/build/phpcs/Joomla/ruleset.xml
+++ b/build/phpcs/Joomla/ruleset.xml
@@ -10,7 +10,7 @@
  
  <rule ref="PEAR.Commenting.InlineComment"/>
  
-<!-- <rule ref="PEAR.Files.IncludingFile"/> -->
+ <rule ref="PEAR.Files.IncludingFile"/>
  <rule ref="Generic.Files.LineEndings"/>
  <rule ref="Generic.Files.LineLength"/>
  

--- a/build/phpcs/Joomla/ruleset.xml
+++ b/build/phpcs/Joomla/ruleset.xml
@@ -10,14 +10,14 @@
  
  <rule ref="PEAR.Commenting.InlineComment"/>
  
- <rule ref="PEAR.Files.IncludingFile"/>
+<!-- <rule ref="PEAR.Files.IncludingFile"/> -->
  <rule ref="Generic.Files.LineEndings"/>
  <rule ref="Generic.Files.LineLength"/>
  
  <rule ref="PEAR.Formatting.MultiLineAssignment"/>
  
  <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
- <rule ref="PEAR.Functions.FunctionDeclaration"/>
+<!-- <rule ref="PEAR.Functions.FunctionDeclaration"/> -->
  <rule ref="PEAR.Functions.ValidDefaultValue"/>
 
  <rule ref="PEAR.NamingConventions.ValidClassName"/>
@@ -43,13 +43,6 @@
  <!-- This messgae is not required as spaces are allowed for alignment -->
  <rule ref="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma">
   <severity>0</severity>
- </rule>
-
- <!-- Use warnings for inline control structures -->
- <rule ref="Joomla.ControlStructures.InlineControlStructure">
-  <properties>
-   <property name="error" value="false"/>
-  </properties>
  </rule>
 
 </ruleset>

--- a/libraries/joomla/application/application.php
+++ b/libraries/joomla/application/application.php
@@ -1047,8 +1047,7 @@ class JApplication extends JObject
 
 		// Check to see the the session already exists.
 		if (($this->getCfg('session_handler') != 'database' && ($time % 2 || $session->isNew()))
-			|| ($this->getCfg('session_handler') == 'database' && $session->isNew())
-		)
+			|| ($this->getCfg('session_handler') == 'database' && $session->isNew()))
 		{
 				$this->checkSession();
 		}

--- a/libraries/joomla/database/table/category.php
+++ b/libraries/joomla/database/table/category.php
@@ -221,8 +221,7 @@ class JTableCategory extends JTableNested
 		// Verify that the alias is unique
 		$table = JTable::getInstance('Category', 'JTable');
 		if ($table->load(array('alias' => $this->alias, 'parent_id' => $this->parent_id, 'extension' => $this->extension))
-			&& ($table->id != $this->id || $this->id == 0)
-		)
+			&& ($table->id != $this->id || $this->id == 0))
 		{
 
 			$this->setError(JText::_('JLIB_DATABASE_ERROR_CATEGORY_UNIQUE_ALIAS'));

--- a/libraries/joomla/database/table/menu.php
+++ b/libraries/joomla/database/table/menu.php
@@ -148,8 +148,7 @@ class JTableMenu extends JTableNested
 		// Verify that the alias is unique
 		$table = JTable::getInstance('Menu', 'JTable');
 		if ($table->load(array('alias' => $this->alias, 'parent_id' => $this->parent_id, 'client_id' => $this->client_id))
-			&& ($table->id != $this->id || $this->id == 0)
-		)
+			&& ($table->id != $this->id || $this->id == 0))
 		{
 			if ($this->menutype == $table->menutype)
 			{

--- a/libraries/joomla/database/table/user.php
+++ b/libraries/joomla/database/table/user.php
@@ -239,8 +239,7 @@ class JTableUser extends JTable
 			$this->_db->setQuery($query);
 			$xid = intval($this->_db->loadResult());
 			if ($rootUser == $this->username && (!$xid || $xid && $xid != intval($this->id))
-				|| $xid && $xid == intval($this->id) && $rootUser != $this->username
-			)
+				|| $xid && $xid == intval($this->id) && $rootUser != $this->username)
 			{
 				$this->setError(JText::_('JLIB_DATABASE_ERROR_USERNAME_CANNOT_CHANGE'));
 				return false;

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -577,8 +577,7 @@ abstract class JFolder
 		while (($file = readdir($handle)) !== false)
 		{
 			if ($file != '.' && $file != '..' && !in_array($file, $exclude)
-				&& (empty($excludefilter_string) || !preg_match($excludefilter_string, $file))
-			)
+				&& (empty($excludefilter_string) || !preg_match($excludefilter_string, $file)))
 			{
 				// Compute the fullpath
 				$fullpath = $path . '/' . $file;

--- a/libraries/joomla/form/fields/componentlayout.php
+++ b/libraries/joomla/form/fields/componentlayout.php
@@ -205,8 +205,7 @@ class JFormFieldComponentLayout extends JFormField
 						{
 							// Remove layout files that exist in the component folder or that have XML files
 							if ((in_array(JFile::stripext(JFile::getName($file)), $component_layouts))
-								|| (in_array(JFile::stripext(JFile::getName($file)), $xml_files))
-							)
+								|| (in_array(JFile::stripext(JFile::getName($file)), $xml_files)))
 							{
 								unset($files[$i]);
 							}

--- a/libraries/joomla/form/rules/url.php
+++ b/libraries/joomla/form/rules/url.php
@@ -76,8 +76,7 @@ class JFormRuleUrl extends JFormRule
 		// For some schemes here must be two slashes.
 		if (($urlScheme == 'http' || $urlScheme == 'https' || $urlScheme == 'ftp' || $urlScheme == 'sftp' || $urlScheme == 'gopher'
 			|| $urlScheme == 'wais' || $urlScheme == 'gopher' || $urlScheme == 'prospero' || $urlScheme == 'telnet')
-			&& ((substr($value, strlen($urlScheme), 3)) !== '://')
-		)
+			&& ((substr($value, strlen($urlScheme), 3)) !== '://'))
 		{
 			return false;
 		}

--- a/libraries/joomla/installer/adapters/component.php
+++ b/libraries/joomla/installer/adapters/component.php
@@ -214,8 +214,7 @@ class JInstallerComponent extends JAdapterInstance
 			// Update tag detected
 
 			if ($this->parent->getUpgrade() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
-				|| $updateElement
-			)
+				|| $updateElement)
 			{
 				return $this->update(); // transfer control to the update function
 			}

--- a/libraries/joomla/installer/adapters/language.php
+++ b/libraries/joomla/installer/adapters/language.php
@@ -184,8 +184,7 @@ class JInstallerLanguage extends JAdapterInstance
 			// Update function available or
 			// Update tag detected
 			if ($this->parent->getUpgrade() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
-				|| is_a($updateElement, 'JXMLElement')
-			)
+				|| is_a($updateElement, 'JXMLElement'))
 			{
 				return $this->update(); // transfer control to the update function
 			}

--- a/libraries/joomla/installer/adapters/module.php
+++ b/libraries/joomla/installer/adapters/module.php
@@ -245,8 +245,7 @@ class JInstallerModule extends JAdapterInstance
 			// Update function available or
 			// Update tag detected
 			if ($this->parent->getUpgrade() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
-				|| is_a($updateElement, 'JXMLElement')
-			)
+				|| is_a($updateElement, 'JXMLElement'))
 			{
 				// Force this one
 				$this->parent->setOverwrite(true);

--- a/libraries/joomla/installer/adapters/plugin.php
+++ b/libraries/joomla/installer/adapters/plugin.php
@@ -211,8 +211,7 @@ class JInstallerPlugin extends JAdapterInstance
 			// Update function available or
 			// Update tag detected
 			if ($this->parent->getUpgrade() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
-				|| is_a($updateElement, 'JXMLElement')
-			)
+				|| is_a($updateElement, 'JXMLElement'))
 			{
 				// Force this one
 				$this->parent->setOverwrite(true);

--- a/libraries/joomla/installer/adapters/template.php
+++ b/libraries/joomla/installer/adapters/template.php
@@ -125,8 +125,7 @@ class JInstallerTemplate extends JAdapterInstance
 			// Update function available or
 			// Update tag detected
 			if ($this->parent->getUpgrade() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
-				|| is_a($updateElement, 'JXMLElement')
-			)
+				|| is_a($updateElement, 'JXMLElement'))
 			{
 				// Force this one
 				$this->parent->setOverwrite(true);

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -369,8 +369,7 @@ class JMail extends PHPMailer
 		}
 
 		if (($this->SMTPAuth !== null && $this->Host !== null && $this->Username !== null && $this->Password !== null)
-			|| ($this->SMTPAuth === null && $this->Host !== null)
-		)
+			|| ($this->SMTPAuth === null && $this->Host !== null))
 		{
 			$this->IsSMTP();
 

--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -818,8 +818,7 @@ abstract class JString
 						if (((2 == $mBytes) && ($mUcs4 < 0x0080)) || ((3 == $mBytes) && ($mUcs4 < 0x0800)) || ((4 == $mBytes) && ($mUcs4 < 0x10000))
 							|| (4 < $mBytes)
 							|| (($mUcs4 & 0xFFFFF800) == 0xD800) // From Unicode 3.2, surrogate characters are illegal
-							|| ($mUcs4 > 0x10FFFF) // Codepoints outside the Unicode range are illegal
-						)
+							|| ($mUcs4 > 0x10FFFF)) // Codepoints outside the Unicode range are illegal
 						{
 							return false;
 						}

--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -82,8 +82,7 @@ class JUpdaterExtension extends JUpdateAdapter
 				$product = strtolower(JFilterInput::getInstance()->clean($ver->PRODUCT, 'cmd')); // lower case and remove the exclamation mark
 				// Check that the product matches and that the version matches (optionally a regexp)
 				if ($product == $this->current_update->targetplatform['NAME']
-					&& preg_match('/' . $this->current_update->targetplatform['VERSION'] . '/', $ver->RELEASE)
-				)
+					&& preg_match('/' . $this->current_update->targetplatform['VERSION'] . '/', $ver->RELEASE))
 				{
 					// Target platform isn't a valid field in the update table so unset it to prevent J! from trying to store it
 					unset($this->current_update->targetplatform);

--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -212,8 +212,7 @@ class JUpdate extends JObject
 				$ver = new JVersion;
 				$product = strtolower(JFilterInput::getInstance()->clean($ver->PRODUCT, 'cmd'));
 				if ($product == $this->_current_update->targetplatform->name
-					&& preg_match('/' . $this->_current_update->targetplatform->version . '/', $ver->RELEASE)
-				)
+					&& preg_match('/' . $this->_current_update->targetplatform->version . '/', $ver->RELEASE))
 				{
 					if (isset($this->_latest))
 					{


### PR DESCRIPTION
This will
- Fix the else and elseif sniff
- Fix the standard for multi line function declaration
- Fix the standard for multi line if declaration as discussed in #424 and requested by @eddieajau
- Fix the last line empty sniff not working in classes
- Remove the "File is being conditionally included" sniff as suggested by @LouisLandry in #424

(Includes unmerged changes from #425)
### Result

```
phpcs -np --standard=build/phpcs/Joomla/ libraries/joomla
............................................................  60 / 305
............................................................ 120 / 305
............................................................ 180 / 305
............................................................ 240 / 305
............................................................ 300 / 305
.....

Time: 47 seconds, Memory: 14.25Mb
```

which means there are no more **errors** - _hooray_ - Could we include the sniffer in the process of approving pull requests and reject code that doesn't meet the standards ? (this will also prevent further annoying pull requests changing white space only ;) )

BTW: There are still some
### Warnings

```
------------------------------------------------------------------------------
SOURCE                                                                    COUNT
------------------------------------------------------------------------------
Joomla.NamingConventions.ValidVariableName.PublicUnderscore                234
Joomla.NamingConventions.ValidFunctionName.PublicUnderscore                168
Joomla.NamingConventions.ValidFunctionName.NotCamelCaps                    24
Generic.Files.LineLength.TooLong                                           14
Joomla.NamingConventions.ValidFunctionName.ScopeNotCamelCaps               10
------------------------------------------------------------------------------
A TOTAL OF 450 SNIFF VIOLATION(S) WERE FOUND IN 5 SOURCE(S)
------------------------------------------------------------------------------
```
