### PR TITLE
Added delay to fix tests on build server

### DIFF
--- a/tests/suite/joomla/access/JAccessTest.php
+++ b/tests/suite/joomla/access/JAccessTest.php
@@ -59,6 +59,8 @@ class JAccessTest extends JoomlaDatabaseTestCase
 			$this->markTestSkipped('The database is not available');
 		}
 
+		usleep(100);
+
 		$access = new JAccess();
 		$array1 = array(
 			0	=> 1,


### PR DESCRIPTION
On the build server there is a weird issue where the select in this test doesn't return all the data.  This usleep call fixes the issue.
