### PR TITLE
Fix to the warnings call_user_func_array() throws

### DIFF
--- a/libraries/joomla/event/event.php
+++ b/libraries/joomla/event/event.php
@@ -40,6 +40,12 @@ abstract class JEvent extends JObserver
 		$event = $args['event'];
 		unset($args['event']);
 
+		$temp = $args;
+		$args = array();
+		foreach ($temp as $k => $v) {
+			$args[] = &$temp[$k];
+		}
+
 		/*
 		 * If the method to handle an event exists, call it and return its return
 		 * value.  If it does not exist, return null.


### PR DESCRIPTION
Fix to the warnings call_user_func_array() throws when  elements aren't refereces. This warnings happens with php-5.3.x.
