### PR TITLE
Adding the possibility to delay the output of JGrid

### DIFF
--- a/libraries/joomla/html/grid.php
+++ b/libraries/joomla/html/grid.php
@@ -272,10 +272,12 @@ class JGrid
 	 * Set cell content for a specific column for the
 	 * currently active row
 	 *
-	 * @param   string  $name     Name of the column
-	 * @param   string  $content  Content for the cell
-	 * @param   array   $option   Associative array of attributes for the td-element
-	 * @param   bool    $replace  If false, the content is appended to the current content of the cell
+	 * @param   string               $name     Name of the column
+	 * @param   string|object|array  $content  Content for the cell
+	 *                                         If it is an array, a call to JHtml::_ will be done using this array as arguments.
+	 *                                         Else a conversion to string will be done
+	 * @param   array                $option   Associative array of attributes for the td-element
+	 * @param   bool                 $replace  If false, the content is appended to the current content of the cell
 	 *
 	 * @return  JGrid This object for chaining
 	 *

--- a/libraries/joomla/html/grid.php
+++ b/libraries/joomla/html/grid.php
@@ -11,6 +11,9 @@
 
 defined('JPATH_PLATFORM') or die;
 
+// Import JHtml library
+jimport('joomla.html.html');
+
 /**
  * JGrid class to dynamically generate HTML tables
  *
@@ -284,12 +287,12 @@ class JGrid
 		{
 			$cell = new stdClass;
 			$cell->options = $option;
-			$cell->content = $content;
+			$cell->content = array($content);
 			$this->rows[$this->activeRow][$name] = $cell;
 		}
 		else
 		{
-			$this->rows[$this->activeRow][$name]->content .= $content;
+			$this->rows[$this->activeRow][$name]->content[] = $content;
 			$this->rows[$this->activeRow][$name]->options = $option;
 		}
 
@@ -434,7 +437,7 @@ class JGrid
 				if (isset($this->rows[$id][$name]))
 				{
 					$column = $this->rows[$id][$name];
-					$output[] = "\t\t<".$cell.$this->renderAttributes($column->options).'>'.$column->content.'</'.$cell.">\n";
+					$output[] = "\t\t<".$cell.$this->renderAttributes($column->options).'>'.implode(array_map(array(__CLASS__, 'renderValue'), $column->content)).'</'.$cell.">\n";
 				}
 			}
 
@@ -466,5 +469,26 @@ class JGrid
 			$return[] = $key.'="'.$option.'"';
 		}
 		return ' '.implode(' ', $return);
+	}
+
+	/**
+	 * Renders an HTML attribute from an associative array
+	 *
+	 * @param   array  $attributes  Associative array of attributes
+	 *
+	 * @return  string The HTML attribute string
+	 *
+	 * @since 11.3
+	 */
+	protected function renderValue($value)
+	{
+		if (is_array($value))
+		{
+			return call_user_func_array(array('JHtml', '_'), $value);
+		}
+		else
+		{
+			return (string) $value;
+		}
 	}
 }

--- a/tests/suite/joomla/html/JGridTest.php
+++ b/tests/suite/joomla/html/JGridTest.php
@@ -96,6 +96,7 @@ class JGridTest extends PHPUnit_Framework_TestCase
 		$table->addColumn('testCol1');
 		$table->addRow(array('class' => 'test1'));
 		$table->setRowCell('testCol1', 'testcontent1', array('class' => '1'));
+
 		$this->assertThat(
 			(string) $table,
 			$this->equalTo($table->toString())


### PR DESCRIPTION
Currently, the output of JGrid is constructed using the setRowCell method either by replacing the content of cell, either by concatenating a new content.

It could be interesting to delay the output using this kind of call:

i.e.
$table->setRowCell('mycolumn', array('grid.boolean', $i));

When the
echo $table
will be done, the class will call at this time JHtml::_('grid.boolean', $i). This will allow template designers to override the output of 'grid.boolean'.
