### PR TITLE
JHtmlNumber and tests fail on 32 bit systems

### DIFF
--- a/libraries/joomla/html/html/number.php
+++ b/libraries/joomla/html/html/number.php
@@ -35,6 +35,8 @@ abstract class JHtmlNumber
 	 */
 	public static function bytes($bytes, $unit = 'auto', $precision = 2)
 	{
+		// No explicit casting $bytes to integer here, since it might overflow
+		// on 32-bit systems
 		$precision = (int) $precision;
 
 		if (empty($bytes))

--- a/libraries/joomla/html/html/number.php
+++ b/libraries/joomla/html/html/number.php
@@ -35,7 +35,6 @@ abstract class JHtmlNumber
 	 */
 	public static function bytes($bytes, $unit = 'auto', $precision = 2)
 	{
-		$bytes = (int) $bytes;
 		$precision = (int) $precision;
 
 		if (empty($bytes))


### PR DESCRIPTION
By removing the explicit cast we allow PHP to automatically convert to float when needed in order to avoid overflowing on 32-bit systems.

Fixes #443
