### PR TITLE
Joomla CMS [#22103] Update /libraries/joomla/form/formfield.php

### DIFF
--- a/libraries/joomla/form/formfield.php
+++ b/libraries/joomla/form/formfield.php
@@ -408,7 +408,7 @@ abstract class JFormField
 		}
 
 		// Clean up any invalid characters.
-		$id = preg_replace('#\W#', '_', $id);
+		$id = preg_replace('#[^\w:\.\-_]#', '_', $id);
 
 		return $id;
 	}


### PR DESCRIPTION
Joomla CMS [#22103] JFormField::getID strips valid characters from id attributes
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=22103
