### PR TITLE
Fix to check document has a setHeadData function

### DIFF
--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -462,7 +462,7 @@ class JCache extends JObject
 		{
 			$document->mergeHeadData($data['head']);
 		}
-		elseif (isset($data['head']))
+		elseif (isset($data['head']) && method_exists($document, 'setHeadData'))
 		{
 			$document->setHeadData($data['head']);
 		}


### PR DESCRIPTION
This adds a check to see if the current JDocument instance features a setHeadData function ahead of attempting to call it. This should fix some cases where caching is attempted with head data for document types that don't support that functionality for what ever reasons. This is potentially a bug elsewhere in the code however the platform should ignore these requests instead of blindly attempting to call a function that doesn't exist.
