### PR TITLE
Support for overriding command and format in JController::getInstance

### DIFF
--- a/libraries/joomla/application/component/controller.php
+++ b/libraries/joomla/application/component/controller.php
@@ -231,8 +231,8 @@ class JController extends JObject
 
 		// Get the environment configuration.
 		$basePath = array_key_exists('base_path', $config) ? $config['base_path'] : JPATH_COMPONENT;
-		$format = JRequest::getWord('format');
-		$command = JRequest::getVar('task', 'display');
+		$format = isset($config['format']) ? $config['format'] : JRequest::getWord('format');
+		$command = isset($config['command']) ? $config['command'] : JRequest::getVar('task', 'display');
 
 		// Check for array format.
 		$filter = JFilterInput::getInstance();


### PR DESCRIPTION
Change to JController to permit more flexibility around where it sets some values from the request and instead provide the ability to set it in the options given to the JController::getInstance call. This enables the ability to create a sub-controller with parameters distinct from the request.
