### PR TITLE
Fixing docblock in JButton

### DIFF
--- a/libraries/joomla/html/toolbar/button.php
+++ b/libraries/joomla/html/toolbar/button.php
@@ -38,11 +38,8 @@ abstract class JButton extends JObject
 
 	/**
 	 * Constructor
-<<<<<<< HEAD
 	 *
 	 * @param   object  $parent  The parent
-=======
->>>>>>> 1739596a2e65b7143de644b4e755263ae63d6cd5
 	 */
 	public function __construct($parent = null)
 	{


### PR DESCRIPTION
Closes #457 - removes left-over merge text.
