### PR TITLE
Fix spelling in docblocks and removed @return labels in constructors.

### DIFF
--- a/libraries/joomla/access/rule.php
+++ b/libraries/joomla/access/rule.php
@@ -34,8 +34,6 @@ class JRule
 	 *
 	 * @param   mixed  $identities  A JSON format string (probably from the database) or a named array.
 	 *
-	 * @return  JRule
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($identities)

--- a/libraries/joomla/access/rules.php
+++ b/libraries/joomla/access/rules.php
@@ -36,8 +36,6 @@ class JRules
 	 *
 	 * @param   mixed  $input  A JSON format string (probably from the database) or a nested array.
 	 *
-	 * @return  JRules
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($input = '')

--- a/libraries/joomla/application/application.php
+++ b/libraries/joomla/application/application.php
@@ -154,7 +154,7 @@ class JApplication extends JObject
 	 *
 	 * @param   mixed   $client  A client identifier or name.
 	 * @param   array   $config  An optional associative array of configuration settings.
-	 * @param   strong  $prefix  A prefix for class names
+	 * @param   string  $prefix  A prefix for class names
 	 *
 	 * @return  JApplication A JApplication object.
 	 *

--- a/libraries/joomla/application/categories.php
+++ b/libraries/joomla/application/categories.php
@@ -95,8 +95,6 @@ class JCategories
 	 *
 	 * @param   array  $options  Array of options
 	 *
-	 * @return  JCategories      JCategories object
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options)
@@ -645,8 +643,6 @@ class JCategoryNode extends JObject
 	 *
 	 * @param   array          $category      The category data.
 	 * @param   JCategoryNode  &$constructor  The tree constructor.
-	 *
-	 * @return  JCategoryNode
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/application/cli.php
+++ b/libraries/joomla/application/cli.php
@@ -62,7 +62,7 @@ class JCli
 	 *                              the application's event dispatcher, if it is null then the default event dispatcher
 	 *                              will be created based on the application's loadDispatcher() method.
 	 *
-	 * @return  void
+	 * @return  JCli
 	 *
 	 * @see     loadDispatcher()
 	 * @since   11.1

--- a/libraries/joomla/application/cli.php
+++ b/libraries/joomla/application/cli.php
@@ -62,8 +62,6 @@ class JCli
 	 *                              the application's event dispatcher, if it is null then the default event dispatcher
 	 *                              will be created based on the application's loadDispatcher() method.
 	 *
-	 * @return  JCli
-	 *
 	 * @see     loadDispatcher()
 	 * @since   11.1
 	 */

--- a/libraries/joomla/application/cli/daemon.php
+++ b/libraries/joomla/application/cli/daemon.php
@@ -100,7 +100,7 @@ class JDaemon extends JCli
 	 *                              the application's event dispatcher, if it is null then the default event dispatcher
 	 *                              will be created based on the application's loadDispatcher() method.
 	 *
-	 * @return  void
+	 * @return  JDaemon
 	 *
 	 * @since   11.1
 	 */
@@ -132,7 +132,7 @@ class JDaemon extends JCli
 			ini_set('memory_limit', $this->config->get('max_memory_limit', '256M'));
 		}
 
-		// Flush content immediatly.
+		// Flush content immediately.
 		ob_implicit_flush();
 	}
 
@@ -435,14 +435,14 @@ class JDaemon extends JCli
 		// Change the user id for the process id file if necessary.
 		if ($uid && (fileowner($file) != $uid) && (!@ chown($file, $uid)))
 		{
-			JLog::add('Unable to change user ownership of the proccess id file.', JLog::ERROR);
+			JLog::add('Unable to change user ownership of the process id file.', JLog::ERROR);
 			return false;
 		}
 
 		// Change the group id for the process id file if necessary.
 		if ($gid && (filegroup($file) != $gid) && (!@ chgrp($file, $gid)))
 		{
-			JLog::add('Unable to change group ownership of the proccess id file.', JLog::ERROR);
+			JLog::add('Unable to change group ownership of the process id file.', JLog::ERROR);
 			return false;
 		}
 

--- a/libraries/joomla/application/cli/daemon.php
+++ b/libraries/joomla/application/cli/daemon.php
@@ -100,8 +100,6 @@ class JDaemon extends JCli
 	 *                              the application's event dispatcher, if it is null then the default event dispatcher
 	 *                              will be created based on the application's loadDispatcher() method.
 	 *
-	 * @return  JDaemon
-	 *
 	 * @since   11.1
 	 */
 	public function __construct(JInputCli $input = null, JRegistry $config = null, JDispatcher $dispatcher = null)

--- a/libraries/joomla/application/component/controller.php
+++ b/libraries/joomla/application/component/controller.php
@@ -307,8 +307,6 @@ class JController extends JObject
 	 * Recognized key values include 'name', 'default_task', 'model_path', and
 	 * 'view_path' (this list is not meant to be comprehensive).
 	 *
-	 * @return  JController
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($config = array())

--- a/libraries/joomla/application/component/controller.php
+++ b/libraries/joomla/application/component/controller.php
@@ -256,7 +256,7 @@ class JController extends JObject
 			$file = self::createFileName('controller', array('name' => $type, 'format' => $format));
 			$path = $basePath . '/controllers/' . $file;
 
-			// Reset the task without the contoller context.
+			// Reset the task without the controller context.
 			JRequest::setVar('task', $task);
 		}
 		else

--- a/libraries/joomla/application/component/controlleradmin.php
+++ b/libraries/joomla/application/component/controlleradmin.php
@@ -149,7 +149,7 @@ class JControllerAdmin extends JController
 	}
 
 	/**
-	 * Method to publish a list of taxa
+	 * Method to publish a list of items
 	 *
 	 * @return  void
 	 *
@@ -215,7 +215,7 @@ class JControllerAdmin extends JController
 	/**
 	 * Changes the order of one or more records.
 	 *
-	 * @return  void
+	 * @return  boolean  True on success
 	 *
 	 * @since   11.1
 	 */
@@ -250,7 +250,7 @@ class JControllerAdmin extends JController
 	/**
 	 * Method to save the submitted ordering values for records.
 	 *
-	 * @return  void
+	 * @return  boolean  True on success
 	 *
 	 * @since   11.1
 	 */
@@ -292,7 +292,7 @@ class JControllerAdmin extends JController
 	/**
 	 * Check in of one or more records.
 	 *
-	 * @return  void
+	 * @return  boolean  True on success
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/application/component/controllerform.php
+++ b/libraries/joomla/application/component/controllerform.php
@@ -66,8 +66,6 @@ class JControllerForm extends JController
 	 *
 	 * @param   array  $config  An optional associative array of configuration settings.
 	 *
-	 * @return  JControllerForm  A JControllerForm object
-	 *
 	 * @see     JController
 	 * @since   11.1
 	 */

--- a/libraries/joomla/application/component/helper.php
+++ b/libraries/joomla/application/component/helper.php
@@ -30,7 +30,7 @@ class JComponentHelper
 	 * Get the component information.
 	 *
 	 * @param   string   $option  The component option.
-	 * @param   boolean  $strict  If set and the component does not exist, the enabled attribue will be set to false.
+	 * @param   boolean  $strict  If set and the component does not exist, the enabled attribute will be set to false.
 	 *
 	 * @return  object   An object with the information for the component.
 	 *
@@ -100,7 +100,7 @@ class JComponentHelper
 	 * @param   string  $option  The component option.
 	 * @param   array   $params  The component parameters
 	 *
-	 * @return  void
+	 * @return  object
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/application/component/model.php
+++ b/libraries/joomla/application/component/model.php
@@ -327,7 +327,7 @@ abstract class JModel extends JObject
 	 *
 	 * @param   string  $name    The name of the view
 	 * @param   string  $prefix  The class prefix. Optional.
-	 * @param   array   $config  Configuration settings to pass to JTable::getInsance
+	 * @param   array   $config  Configuration settings to pass to JTable::getInstance
 	 *
 	 * @return  mixed  Model object or boolean false if failed
 	 *
@@ -496,12 +496,12 @@ abstract class JModel extends JObject
 	/**
 	 * Clean the cache
 	 *
-	 * @param   string  $group      The cache group
-	 * @param   string  $client_id  The ID of the client
+	 * @param   string   $group      The cache group
+	 * @param   integer  $client_id  The ID of the client
 	 *
 	 * @return  void
 	 *
-	 * @since    11.1
+	 * @since   11.1
 	 */
 	protected function cleanCache($group = null, $client_id = 0)
 	{

--- a/libraries/joomla/application/component/model.php
+++ b/libraries/joomla/application/component/model.php
@@ -206,8 +206,6 @@ abstract class JModel extends JObject
 	 *
 	 * @param   array  $config  An array of configuration options (name, state, dbo, table_path, ignore_request).
 	 *
-	 * @return  JModel  A JModel object
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($config = array())

--- a/libraries/joomla/application/component/modeladmin.php
+++ b/libraries/joomla/application/component/modeladmin.php
@@ -229,7 +229,7 @@ abstract class JModelAdmin extends JModelForm
 	 * @param   integer  $value  The new value matching an Asset Group ID.
 	 * @param   array    $pks    An array of row IDs.
 	 *
-	 * @return  booelan  True if successful, false otherwise and internal error is set.
+	 * @return  boolean  True if successful, false otherwise and internal error is set.
 	 *
 	 * @since   11.1
 	 */
@@ -433,7 +433,7 @@ abstract class JModelAdmin extends JModelForm
 	 * @param   integer  $value  The new category ID.
 	 * @param   array    $pks    An array of row IDs.
 	 *
-	 * @return  booelan  True if successful, false otherwise and internal error is set.
+	 * @return  boolean  True if successful, false otherwise and internal error is set.
 	 *
 	 * @since	11.1
 	 */
@@ -820,7 +820,7 @@ abstract class JModelAdmin extends JModelForm
 	 */
 	protected function prepareTable(&$table)
 	{
-		// Derived class will provide its own implentation if required.
+		// Derived class will provide its own implementation if required.
 	}
 
 	/**

--- a/libraries/joomla/application/component/modeladmin.php
+++ b/libraries/joomla/application/component/modeladmin.php
@@ -73,8 +73,6 @@ abstract class JModelAdmin extends JModelForm
 	 *
 	 * @param   array  $config  An optional associative array of configuration settings.
 	 *
-	 * @return  JModelAdmin
-	 *
 	 * @see     JController
 	 * @since   11.1
 	 */

--- a/libraries/joomla/application/component/modelform.php
+++ b/libraries/joomla/application/component/modelform.php
@@ -209,7 +209,7 @@ abstract class JModelForm extends JModel
 	/**
 	 * Method to allow derived classes to preprocess the form.
 	 *
-	 * @param   object  $form   A form object.
+	 * @param   JForm   $form   A JForm object.
 	 * @param   mixed   $data   The data expected for the form.
 	 * @param   string  $group  The name of the plugin group to import (defaults to "content").
 	 *
@@ -221,7 +221,7 @@ abstract class JModelForm extends JModel
 	 */
 	protected function preprocessForm(JForm $form, $data, $group = 'content')
 	{
-		// Import the approriate plugin group.
+		// Import the appropriate plugin group.
 		JPluginHelper::importPlugin($group);
 
 		// Get the dispatcher.

--- a/libraries/joomla/application/component/modellist.php
+++ b/libraries/joomla/application/component/modellist.php
@@ -58,8 +58,6 @@ class JModelList extends JModel
 	 *
 	 * @param   array  $config  An optional associative array of configuration settings.
 	 *
-	 * @return  JModelList
-	 *
 	 * @see     JController
 	 * @since   11.1
 	 */

--- a/libraries/joomla/application/component/modellist.php
+++ b/libraries/joomla/application/component/modellist.php
@@ -83,7 +83,7 @@ class JModelList extends JModel
 	/**
 	 * Method to cache the last query constructed.
 	 *
-	 * This method ensures that the query is contructed only once for a given state of the model.
+	 * This method ensures that the query is constructed only once for a given state of the model.
 	 *
 	 * @return  JDatabaseQuery  A JDatabaseQuery object
 	 *

--- a/libraries/joomla/application/component/view.php
+++ b/libraries/joomla/application/component/view.php
@@ -116,8 +116,6 @@ class JView extends JObject
 	 *                          helper_path: the path (optional) of the helper files (defaults to base_path + /helpers/)<br/>
 	 *                          layout: the layout (optional) to use to display the view<br/>
 	 *
-	 * @return  JView
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($config = array())

--- a/libraries/joomla/application/component/view.php
+++ b/libraries/joomla/application/component/view.php
@@ -107,9 +107,9 @@ class JView extends JObject
 	/**
 	 * Constructor
 	 *
-	 * @param   array  $config  A named configuration array for object contruction.<br/>
+	 * @param   array  $config  A named configuration array for object construction.<br/>
 	 *                          name: the name (optional) of the view (defaults to the view class name suffix).<br/>
-	 *                          charset: the characterset to use for display<br/>
+	 *                          charset: the character set to use for display<br/>
 	 *                          escape: the name (optional) of the function to use for escaping strings<br/>
 	 *                          base_path: the parent path (optional) of the views directory (defaults to the component folder)<br/>
 	 *                          template_plath: the path (optional) of the layout directory (defaults to base_path + /views/ + view name<br/>
@@ -283,7 +283,7 @@ class JView extends JObject
 
 		// Assign by string name and mixed value.
 
-		// We use array_key_exists() instead of isset() becuase isset()
+		// We use array_key_exists() instead of isset() because isset()
 		// fails if the value is set to null.
 		if (is_string($arg0) && substr($arg0, 0, 1) != '_' && func_num_args() > 1)
 		{

--- a/libraries/joomla/application/helper.php
+++ b/libraries/joomla/application/helper.php
@@ -299,7 +299,7 @@ class JApplicationHelper
 
 		// Check for a valid XML root tag.
 
-		// Should be 'install', but for backward compatability we will accept 'extension'.
+		// Should be 'install', but for backward compatibility we will accept 'extension'.
 		// Languages use 'metafile' instead
 
 		if ($xml->getName() != 'install' && $xml->getName() != 'extension' && $xml->getName() != 'metafile')

--- a/libraries/joomla/application/input.php
+++ b/libraries/joomla/application/input.php
@@ -62,8 +62,6 @@ class JInput
 	 * @param   array  $source   Source data (Optional, default is $_REQUEST)
 	 * @param   array  $options  Array of configuration parameters (Optional)
 	 *
-	 * @return  JInput
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($source = null, $options = array())

--- a/libraries/joomla/application/input/cli.php
+++ b/libraries/joomla/application/input/cli.php
@@ -43,8 +43,6 @@ class JInputCLI extends JInput
 	 * @param   array  $source   Source data (Optional, default is $_REQUEST)
 	 * @param   array  $options  Array of configuration parameters (Optional)
 	 *
-	 * @return  JInputCLI
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($source = null, $options = array ())

--- a/libraries/joomla/application/input/cli.php
+++ b/libraries/joomla/application/input/cli.php
@@ -43,7 +43,7 @@ class JInputCLI extends JInput
 	 * @param   array  $source   Source data (Optional, default is $_REQUEST)
 	 * @param   array  $options  Array of configuration parameters (Optional)
 	 *
-	 * @return  void
+	 * @return  JInputCLI
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/application/input/cookie.php
+++ b/libraries/joomla/application/input/cookie.php
@@ -26,7 +26,7 @@ class JInputCookie extends JInput
 	 * @param   array  $source   Ignored.
 	 * @param   array  $options  Array of configuration parameters (Optional)
 	 *
-	 * @return  void
+	 * @return  JInputCookie
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/application/input/cookie.php
+++ b/libraries/joomla/application/input/cookie.php
@@ -26,8 +26,6 @@ class JInputCookie extends JInput
 	 * @param   array  $source   Ignored.
 	 * @param   array  $options  Array of configuration parameters (Optional)
 	 *
-	 * @return  JInputCookie
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($source = null, $options = array())

--- a/libraries/joomla/application/menu.php
+++ b/libraries/joomla/application/menu.php
@@ -47,8 +47,6 @@ class JMenu extends JObject
 	 *
 	 * @param   array  $options  An array of configuration options.
 	 *
-	 * @return  JMenu  A JMenu object
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/application/menu.php
+++ b/libraries/joomla/application/menu.php
@@ -143,7 +143,7 @@ class JMenu extends JObject
 	 * @param   integer  $id        The menu item id.
 	 * @param   string   $language  The language cod (since 1.6).
 	 *
-	 * @return  boolean  True, if succesful
+	 * @return  boolean  True, if successful
 	 *
 	 * @since   11.1
 	 */
@@ -188,7 +188,7 @@ class JMenu extends JObject
 	 *
 	 * @param   integer  $id  The item id
 	 *
-	 * @return  mixed  If successfull the active item, otherwise null
+	 * @return  mixed  If successful the active item, otherwise null
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/application/pathway.php
+++ b/libraries/joomla/application/pathway.php
@@ -37,7 +37,7 @@ class JPathway extends JObject
 	 *
 	 * @param   array  $options  The class options.
 	 *
-	 * @return  void
+	 * @return  JPathway
 	 *
 	 * @since   11.1
 	 */
@@ -161,7 +161,7 @@ class JPathway extends JObject
 	 */
 	public function addItem($name, $link = '')
 	{
-		// Initalize variables
+		// Initialize variables
 		$ret = false;
 
 		if ($this->_pathway[] = $this->_makeItem($name, $link))
@@ -185,7 +185,7 @@ class JPathway extends JObject
 	 */
 	public function setItemName($id, $name)
 	{
-		// Initalize variables
+		// Initialize variables
 		$ret = false;
 
 		if (isset($this->_pathway[$id]))

--- a/libraries/joomla/application/pathway.php
+++ b/libraries/joomla/application/pathway.php
@@ -37,8 +37,6 @@ class JPathway extends JObject
 	 *
 	 * @param   array  $options  The class options.
 	 *
-	 * @return  JPathway
-	 *
 	 * @since   11.1
 	 */
 	function __construct($options = array())

--- a/libraries/joomla/application/router.php
+++ b/libraries/joomla/application/router.php
@@ -53,8 +53,6 @@ class JRouter extends JObject
 	 *
 	 * @param   array  $options  Array of options
 	 *
-	 * @return  JRouter
-	 *
 	 * @since 11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/application/router.php
+++ b/libraries/joomla/application/router.php
@@ -53,7 +53,7 @@ class JRouter extends JObject
 	 *
 	 * @param   array  $options  Array of options
 	 *
-	 * @return  void
+	 * @return  JRouter
 	 *
 	 * @since 11.1
 	 */

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -113,7 +113,7 @@ class JWeb
 	 *                          client object.  If the argument is a JWebClient object that object will become
 	 *                          the application's client object, otherwise a default client object is created.
 	 *
-	 * @return  void
+	 * @return  JWeb
 	 *
 	 * @since   11.3
 	 */
@@ -438,7 +438,7 @@ class JWeb
 				}
 				// @codeCoverageIgnoreEnd
 
-				// Attemp to gzip encode the data with an optimal level 4.
+				// Attempt to gzip encode the data with an optimal level 4.
 				$data = $this->getBody();
 				$gzdata = gzencode($data, 4, ($supported[$encoding] == 'gz') ? FORCE_GZIP : FORCE_DEFLATE);
 

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -113,8 +113,6 @@ class JWeb
 	 *                          client object.  If the argument is a JWebClient object that object will become
 	 *                          the application's client object, otherwise a default client object is created.
 	 *
-	 * @return  JWeb
-	 *
 	 * @since   11.3
 	 */
 	public function __construct(JInput $input = null, JRegistry $config = null, JWebClient $client = null)

--- a/libraries/joomla/application/web/webclient.php
+++ b/libraries/joomla/application/web/webclient.php
@@ -113,8 +113,6 @@ class JWebClient
 	 * @param   mixed  $acceptEncoding  The optional client accept encoding string to parse.
 	 * @param   mixed  $acceptLanguage  The optional client accept language string to parse.
 	 *
-	 * @return  JWebClient
-	 *
 	 * @since   11.3
 	 */
 	public function __construct($userAgent = null, $acceptEncoding = null, $acceptLanguage = null)

--- a/libraries/joomla/application/web/webclient.php
+++ b/libraries/joomla/application/web/webclient.php
@@ -277,7 +277,7 @@ class JWebClient
 			}
 		}
 
-		// Mark this dectection routine as run.
+		// Mark this detection routine as run.
 		$this->detection['browser'] = true;;
 	}
 
@@ -295,7 +295,7 @@ class JWebClient
 		// Parse the accepted encodings.
 		$this->encodings = array_map('trim', (array) explode(',', $acceptEncoding));
 
-		// Mark this dectection routine as run.
+		// Mark this detection routine as run.
 		$this->detection['acceptEncoding'] = true;;
 	}
 
@@ -325,7 +325,7 @@ class JWebClient
 		{
 			$this->engine = self::GECKO;
 		}
-		// Sometims Opera browsers don't say Presto.
+		// Sometimes Opera browsers don't say Presto.
 		elseif (stripos($userAgent, 'Opera') !== false || stripos($userAgent, 'Presto') !== false)
 		{
 			$this->engine = self::PRESTO;
@@ -341,7 +341,7 @@ class JWebClient
 			$this->engine = self::AMAYA;
 		}
 
-		// Mark this dectection routine as run.
+		// Mark this detection routine as run.
 		$this->detection['engine'] = true;;
 	}
 
@@ -359,7 +359,7 @@ class JWebClient
 		// Parse the accepted encodings.
 		$this->languages = array_map('trim', (array) explode(',', $acceptLanguage));
 
-		// Mark this dectection routine as run.
+		// Mark this detection routine as run.
 		$this->detection['acceptLanguage'] = true;;
 	}
 
@@ -427,7 +427,7 @@ class JWebClient
 			$this->platform = self::LINUX;
 		}
 
-		// Mark this dectection routine as run.
+		// Mark this detection routine as run.
 		$this->detection['platform'] = true;;
 	}
 }

--- a/libraries/joomla/base/adapter.php
+++ b/libraries/joomla/base/adapter.php
@@ -67,8 +67,6 @@ class JAdapter extends JObject
 	 * @param   string  $classprefix    Class prefix of adapters
 	 * @param   string  $adapterfolder  Name of folder to append to base path
 	 *
-	 * @return  JAdapter  JAdapter object
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($basepath, $classprefix = null, $adapterfolder = null)

--- a/libraries/joomla/base/adapterinstance.php
+++ b/libraries/joomla/base/adapterinstance.php
@@ -41,8 +41,6 @@ class JAdapterInstance extends JObject
 	 * @param   object  &$db      Database object [JDatabase instance]
 	 * @param   array   $options  Configuration Options
 	 *
-	 * @return  JAdapterInstance
-	 *
 	 * @since   11.1
 	 */
 	public function __construct(&$parent, &$db, $options = array())

--- a/libraries/joomla/base/node.php
+++ b/libraries/joomla/base/node.php
@@ -118,7 +118,7 @@ class JNode extends JObject
 	/**
 	 * Test if this node has children
 	 *
-	 * @return   boolean  True if there are chilren
+	 * @return   boolean  True if there are children
 	 *
 	 * @since    11.1
 	 */

--- a/libraries/joomla/base/object.php
+++ b/libraries/joomla/base/object.php
@@ -207,7 +207,7 @@ class JObject
 		{
 			foreach ((array) $properties as $k => $v)
 			{
-				// Use the set function which might be overriden.
+				// Use the set function which might be overridden.
 				$this->set($k, $v);
 			}
 			return true;

--- a/libraries/joomla/base/object.php
+++ b/libraries/joomla/base/object.php
@@ -35,8 +35,6 @@ class JObject
 	 * @param   mixed  $properties  Either and associative array or another
 	 *                              object to set the initial properties of the object.
 	 *
-	 * @return  JObject
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($properties = null)

--- a/libraries/joomla/base/observable.php
+++ b/libraries/joomla/base/observable.php
@@ -45,7 +45,7 @@ class JObservable extends JObject
 	/**
 	 * Constructor
 	 *
-	 * Note: Make Sure it's not directly instansiated
+	 * Note: Make Sure it's not directly instantiated
 	 */
 	public function __construct()
 	{

--- a/libraries/joomla/base/observer.php
+++ b/libraries/joomla/base/observer.php
@@ -31,8 +31,6 @@ abstract class JObserver extends JObject
 	 *
 	 * @param   object  &$subject  The object to observe.
 	 *
-	 * @return  JObserver
-	 *
 	 * @since   11.1
 	 */
 	public function __construct(&$subject)

--- a/libraries/joomla/base/tree.php
+++ b/libraries/joomla/base/tree.php
@@ -39,8 +39,6 @@ class JTree extends JObject
 	/**
 	 * Constructor
 	 *
-	 * @return  JTree
-	 *
 	 * @since   11.1
 	 */
 	function __construct()

--- a/libraries/joomla/cache/storage.php
+++ b/libraries/joomla/cache/storage.php
@@ -65,8 +65,6 @@ class JCacheStorage
 	 *
 	 * @param   array  $options  Optional parameters
 	 *
-	 * @return  JCacheStorage
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/cache/storage.php
+++ b/libraries/joomla/cache/storage.php
@@ -65,7 +65,7 @@ class JCacheStorage
 	 *
 	 * @param   array  $options  Optional parameters
 	 *
-	 * @return  void
+	 * @return  JCacheStorage
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/cache/storage/cachelite.php
+++ b/libraries/joomla/cache/storage/cachelite.php
@@ -36,8 +36,6 @@ class JCacheStorageCachelite extends JCacheStorage
 	 *
 	 * @param   array  $options  Optional parameters.
 	 *
-	 * @return  JCacheStorageCachelite
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/cache/storage/eaccelerator.php
+++ b/libraries/joomla/cache/storage/eaccelerator.php
@@ -24,8 +24,6 @@ class JCacheStorageEaccelerator extends JCacheStorage
 	 *
 	 * @param   array  $options  Optional parameters.
 	 *
-	 * @return  JCacheStorageEaccelerator
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/cache/storage/file.php
+++ b/libraries/joomla/cache/storage/file.php
@@ -31,8 +31,6 @@ class JCacheStorageFile extends JCacheStorage
 	 *
 	 * @param   array  $options  Optional parameters
 	 *
-	 * @return  JCacheStorageFile
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/cache/storage/file.php
+++ b/libraries/joomla/cache/storage/file.php
@@ -31,7 +31,7 @@ class JCacheStorageFile extends JCacheStorage
 	 *
 	 * @param   array  $options  Optional parameters
 	 *
-	 * @return  void
+	 * @return  JCacheStorageFile
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/cache/storage/helpers/helper.php
+++ b/libraries/joomla/cache/storage/helpers/helper.php
@@ -47,8 +47,6 @@ class JCacheStorageHelper
 	 *
 	 * @param   string  $group  The cache data group
 	 *
-	 * @return  JCacheStorageHelper
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($group)

--- a/libraries/joomla/cache/storage/memcache.php
+++ b/libraries/joomla/cache/storage/memcache.php
@@ -42,8 +42,6 @@ class JCacheStorageMemcache extends JCacheStorage
 	 *
 	 * @param   array  $options  Optional parameters.
 	 *
-	 * @return  JCacheStorageMemcache
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/cache/storage/memcache.php
+++ b/libraries/joomla/cache/storage/memcache.php
@@ -89,7 +89,7 @@ class JCacheStorageMemcache extends JCacheStorage
 			return JError::raiseError(404, "Could not connect to memcache server");
 		}
 
-		// Memcahed has no list keys, we do our own accounting, initalise key index
+		// Memcahed has no list keys, we do our own accounting, initialise key index
 		if (self::$_db->get($this->_hash . '-index') === false)
 		{
 			$empty = array();

--- a/libraries/joomla/cache/storage/wincache.php
+++ b/libraries/joomla/cache/storage/wincache.php
@@ -24,8 +24,6 @@ class JCacheStorageWincache extends JCacheStorage
 	 *
 	 * @param   array  $options  Optional parameters.
 	 *
-	 * @return  JCacheStorageWincache
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/client/ftp.php
+++ b/libraries/joomla/client/ftp.php
@@ -146,7 +146,7 @@ class JFTP
 	 *
 	 * @param   array  $options  Associative array of options to set
 	 *
-	 * @return  void
+	 * @return  JFTP
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/client/ftp.php
+++ b/libraries/joomla/client/ftp.php
@@ -146,8 +146,6 @@ class JFTP
 	 *
 	 * @param   array  $options  Associative array of options to set
 	 *
-	 * @return  JFTP
-	 *
 	 * @since   11.1
 	 */
 

--- a/libraries/joomla/client/helper.php
+++ b/libraries/joomla/client/helper.php
@@ -108,7 +108,7 @@ class JClientHelper
 					jimport('joomla.client.ftp');
 					$ftp = JFTP::getInstance($options['host'], $options['port']);
 
-					// Test the conection and try to log in
+					// Test the connection and try to log in
 					if ($ftp->isConnected())
 					{
 						if ($ftp->login($user, $pass))
@@ -205,7 +205,7 @@ class JClientHelper
 	 */
 	public static function setCredentialsFromRequest($client)
 	{
-		// Determine wether FTP credentials have been passed along with the current request
+		// Determine whether FTP credentials have been passed along with the current request
 		$user = JRequest::getString('username', null, 'POST', JREQUEST_ALLOWRAW);
 		$pass = JRequest::getString('password', null, 'POST', JREQUEST_ALLOWRAW);
 		if ($user != '' && $pass != '')

--- a/libraries/joomla/client/http.php
+++ b/libraries/joomla/client/http.php
@@ -49,7 +49,7 @@ class JHttp
 	 *
 	 * @param   array  $options  Array of configuration options for the client.
 	 *
-	 * @return  void
+	 * @return  JHttp
 	 *
 	 * @since   11.1
 	 */
@@ -186,7 +186,7 @@ class JHttp
 	 *
 	 * @param   resource  $connection  The HTTP connection resource.
 	 * @param   string    $method      The HTTP method for sending the request.
-	 * @param   string    $uri         The URI to the resource to request.
+	 * @param   JUri      $uri         The URI to the resource to request.
 	 * @param   array     $data        An array of key => value pairs to send with the request.
 	 * @param   array     $headers     An array of request headers to send with the request.
 	 *

--- a/libraries/joomla/client/http.php
+++ b/libraries/joomla/client/http.php
@@ -49,8 +49,6 @@ class JHttp
 	 *
 	 * @param   array  $options  Array of configuration options for the client.
 	 *
-	 * @return  JHttp
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/client/ldap.php
+++ b/libraries/joomla/client/ldap.php
@@ -103,8 +103,6 @@ class JLDAP extends JObject
 	 *
 	 * @param   object  $configObj  An object of configuration variables
 	 *
-	 * @return  JLDAP
-	 *
 	 * @since   11.1
 	 */
 	function __construct($configObj = null)

--- a/libraries/joomla/client/ldap.php
+++ b/libraries/joomla/client/ldap.php
@@ -103,6 +103,8 @@ class JLDAP extends JObject
 	 *
 	 * @param   object  $configObj  An object of configuration variables
 	 *
+	 * @return  JLDAP
+	 *
 	 * @since   11.1
 	 */
 	function __construct($configObj = null)
@@ -257,7 +259,7 @@ class JLDAP extends JObject
 	}
 
 	/**
-	 * Perform an LDAP search using comma seperated search strings
+	 * Perform an LDAP search using comma separated search strings
 	 *
 	 * @param   string  $search  search string of search values
 	 *

--- a/libraries/joomla/database/database.php
+++ b/libraries/joomla/database/database.php
@@ -314,7 +314,7 @@ abstract class JDatabase implements JDatabaseInterface
 			{
 				$instance = new $class($options);
 			}
-			catch (DatabaseException $e)
+			catch (JDatabaseException $e)
 			{
 
 				// Legacy error handling switch based on the JError::$legacy switch.
@@ -432,7 +432,7 @@ abstract class JDatabase implements JDatabaseInterface
 	 *
 	 * @param   array  $options  List of options used to configure the connection
 	 *
-	 * @return  void
+	 * @return  JDatabase
 	 *
 	 * @since   11.1
 	 */
@@ -1022,7 +1022,7 @@ abstract class JDatabase implements JDatabaseInterface
 	 * Method to get an array of the result set rows from the database query where each row is an object.  The array
 	 * of objects can optionally be keyed by a field name, but defaults to a sequential numeric array.
 	 *
-	 * NOTE: Chosing to key the result array by a non-unique field name can result in unwanted
+	 * NOTE: Choosing to key the result array by a non-unique field name can result in unwanted
 	 * behavior and should be avoided.
 	 *
 	 * @param   string  $key    The name of a field on which to key the result array.
@@ -1130,7 +1130,7 @@ abstract class JDatabase implements JDatabaseInterface
 	 * Method to get an array of the result set rows from the database query where each row is an array.  The array
 	 * of objects can optionally be keyed by a field offset, but defaults to a sequential numeric array.
 	 *
-	 * NOTE: Chosing to key the result array by a non-unique field can result in unwanted
+	 * NOTE: Choosing to key the result array by a non-unique field can result in unwanted
 	 * behavior and should be avoided.
 	 *
 	 * @param   string  $key  The name of a field on which to key the result array.

--- a/libraries/joomla/database/database.php
+++ b/libraries/joomla/database/database.php
@@ -432,8 +432,6 @@ abstract class JDatabase implements JDatabaseInterface
 	 *
 	 * @param   array  $options  List of options used to configure the connection
 	 *
-	 * @return  JDatabase
-	 *
 	 * @since   11.1
 	 */
 	protected function __construct($options)

--- a/libraries/joomla/database/database/mysql.php
+++ b/libraries/joomla/database/database/mysql.php
@@ -56,8 +56,6 @@ class JDatabaseMySQL extends JDatabase
 	 *
 	 * @param   array  $options  Array of database options with keys: host, user, password, database, select.
 	 *
-	 * @return  JDatabaseMySQL
-	 *
 	 * @since   11.1
 	 */
 	protected function __construct($options)

--- a/libraries/joomla/database/database/mysql.php
+++ b/libraries/joomla/database/database/mysql.php
@@ -56,7 +56,7 @@ class JDatabaseMySQL extends JDatabase
 	 *
 	 * @param   array  $options  Array of database options with keys: host, user, password, database, select.
 	 *
-	 * @return  void
+	 * @return  JDatabaseMySQL
 	 *
 	 * @since   11.1
 	 */
@@ -389,7 +389,7 @@ class JDatabaseMySQL extends JDatabase
 	 *
 	 * @param   string  $table  The name of the table.
 	 *
-	 * @return  array  An arry of the column specification for the table.
+	 * @return  array  An array of the column specification for the table.
 	 *
 	 * @since   11.1
 	 * @throws  JDatabaseException

--- a/libraries/joomla/database/database/mysqlexporter.php
+++ b/libraries/joomla/database/database/mysqlexporter.php
@@ -63,8 +63,6 @@ class JDatabaseExporterMySQL
 	 *
 	 * Sets up the default options for the exporter.
 	 *
-	 * @return  JDatabaseExporterMySQL
-	 *
 	 * @since   11.1
 	 */
 	public function __construct()

--- a/libraries/joomla/database/database/mysqli.php
+++ b/libraries/joomla/database/database/mysqli.php
@@ -56,8 +56,6 @@ class JDatabaseMySQLi extends JDatabase
 	 *
 	 * @param   array  $options  List of options used to configure the connection
 	 *
-	 * @return  JDatabaseMySQLi
-	 *
 	 * @since   11.1
 	 */
 	protected function __construct($options)

--- a/libraries/joomla/database/database/mysqli.php
+++ b/libraries/joomla/database/database/mysqli.php
@@ -56,7 +56,7 @@ class JDatabaseMySQLi extends JDatabase
 	 *
 	 * @param   array  $options  List of options used to configure the connection
 	 *
-	 * @return  void
+	 * @return  JDatabaseMySQLi
 	 *
 	 * @since   11.1
 	 */
@@ -418,7 +418,7 @@ class JDatabaseMySQLi extends JDatabase
 	 *
 	 * @param   string  $table  The name of the table.
 	 *
-	 * @return  array  An arry of the column specification for the table.
+	 * @return  array  An array of the column specification for the table.
 	 *
 	 * @since   11.1
 	 * @throws  JDatabaseException

--- a/libraries/joomla/database/database/mysqliexporter.php
+++ b/libraries/joomla/database/database/mysqliexporter.php
@@ -48,7 +48,7 @@ class JDatabaseExporterMySQLi extends JDatabaseExporterMySQL
 	/**
 	 * Sets the database connector to use for exporting structure and/or data from MySQL.
 	 *
-	 * @param   JDatabaseDriverMySQLi  $db  The database connector.
+	 * @param   JDatabaseMySQLi  $db  The database connector.
 	 *
 	 * @return  JDatabaseExporterMySQLi  Method supports chaining.
 	 *

--- a/libraries/joomla/database/database/mysqlimporter.php
+++ b/libraries/joomla/database/database/mysqlimporter.php
@@ -61,8 +61,6 @@ class JDatabaseImporterMySQL
 	 *
 	 * Sets up the default options for the exporter.
 	 *
-	 * @return  JDatabaseImporterMySQL
-	 *
 	 * @since   11.1
 	 */
 	public function __construct()

--- a/libraries/joomla/database/database/sqlsrv.php
+++ b/libraries/joomla/database/database/sqlsrv.php
@@ -69,8 +69,6 @@ class JDatabaseSQLSrv extends JDatabase
 	 *
 	 * @param   array  $options  List of options used to configure the connection
 	 *
-	 * @return  JDatabaseSQLSrv
-	 *
 	 * @since   11.1
 	 */
 	protected function __construct($options)

--- a/libraries/joomla/database/database/sqlsrv.php
+++ b/libraries/joomla/database/database/sqlsrv.php
@@ -69,7 +69,7 @@ class JDatabaseSQLSrv extends JDatabase
 	 *
 	 * @param   array  $options  List of options used to configure the connection
 	 *
-	 * @return  void
+	 * @return  JDatabaseSQLSrv
 	 *
 	 * @since   11.1
 	 */
@@ -217,7 +217,7 @@ class JDatabaseSQLSrv extends JDatabase
 
 		if ($extra)
 		{
-			// We need the below str_replace since the search in sql server doesnt recognize _ character.
+			// We need the below str_replace since the search in sql server doesn't recognize _ character.
 			$result = str_replace('_', '[_]', $result);
 		}
 
@@ -440,7 +440,7 @@ class JDatabaseSQLSrv extends JDatabase
 	 *
 	 * @param   string  $table  The name of the table.
 	 *
-	 * @return  array  An arry of the column specification for the table.
+	 * @return  array  An array of the column specification for the table.
 	 *
 	 * @since   11.1
 	 * @throws  JDatabaseException

--- a/libraries/joomla/database/databasequery.php
+++ b/libraries/joomla/database/databasequery.php
@@ -43,8 +43,6 @@ class JDatabaseQueryElement
 	 * @param   mixed   $elements  String or array.
 	 * @param   string  $glue      The glue for elements.
 	 *
-	 * @return  JDatabaseQueryElement
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($name, $elements, $glue = ',')
@@ -252,7 +250,6 @@ abstract class JDatabaseQuery
 	 *
 	 * @param   JDatabase  $db  The database connector resource.
 	 *
-	 * @return  JDatabaseQuery
 	 * @since   11.1
 	 */
 	public function __construct(JDatabase $db = null)

--- a/libraries/joomla/database/databasequery.php
+++ b/libraries/joomla/database/databasequery.php
@@ -411,7 +411,7 @@ abstract class JDatabaseQuery
 	 *
 	 * @param   string  $field  A value.
 	 *
-	 * @return  string  The required char lenght call.
+	 * @return  string  The required char length call.
 	 *
 	 * @since 11.1
 	 */
@@ -425,7 +425,7 @@ abstract class JDatabaseQuery
 	 *
 	 * @param   string  $clause  Optionally, the name of the clause to clear, or nothing to clear the whole query.
 	 *
-	 * @return  void
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
 	 *
 	 * @since   11.1
 	 */
@@ -515,7 +515,7 @@ abstract class JDatabaseQuery
 	 *
 	 * @param   mixed  $columns  A column name, or array of column names.
 	 *
-	 * @return  JDatabaseQuerySQLAzure  Returns this object to allow chaining.
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
 	 *
 	 * @since   11.1
 	 */
@@ -577,7 +577,7 @@ abstract class JDatabaseQuery
 	 * Returns a PHP date() function compliant date format for the database driver.
 	 *
 	 * This method is provided for use where the query object is passed to a function for modification.
-	 * If you have direct access to the database object, it is recommeneded you use the getDateFormat method directly.
+	 * If you have direct access to the database object, it is recommended you use the getDateFormat method directly.
 	 *
 	 * @return  string  The format string.
 	 *
@@ -639,7 +639,7 @@ abstract class JDatabaseQuery
 	 * Method to escape a string for usage in an SQL statement.
 	 *
 	 * This method is provided for use where the query object is passed to a function for modification.
-	 * If you have direct access to the database object, it is recommeneded you use the escape method directly.
+	 * If you have direct access to the database object, it is recommended you use the escape method directly.
 	 *
 	 * Note that 'e' is an alias for this method as it is in JDatabase.
 	 *
@@ -852,7 +852,7 @@ abstract class JDatabaseQuery
 	 * Get the null or zero representation of a timestamp for the database driver.
 	 *
 	 * This method is provided for use where the query object is passed to a function for modification.
-	 * If you have direct access to the database object, it is recommeneded you use the nullDate method directly.
+	 * If you have direct access to the database object, it is recommended you use the nullDate method directly.
 	 *
 	 * Usage:
 	 * $query->where('modified_date <> '.$query->nullDate());
@@ -930,7 +930,7 @@ abstract class JDatabaseQuery
 	 * Method to quote and optionally escape a string to database requirements for insertion into the database.
 	 *
 	 * This method is provided for use where the query object is passed to a function for modification.
-	 * If you have direct access to the database object, it is recommeneded you use the quote method directly.
+	 * If you have direct access to the database object, it is recommended you use the quote method directly.
 	 *
 	 * Note that 'q' is an alias for this method as it is in JDatabase.
 	 *
@@ -961,7 +961,7 @@ abstract class JDatabaseQuery
 	 * risks and reserved word conflicts.
 	 *
 	 * This method is provided for use where the query object is passed to a function for modification.
-	 * If you have direct access to the database object, it is recommeneded you use the quoteName method directly.
+	 * If you have direct access to the database object, it is recommended you use the quoteName method directly.
 	 *
 	 * Note that 'qn' is an alias for this method as it is in JDatabase.
 	 *

--- a/libraries/joomla/database/table.php
+++ b/libraries/joomla/database/table.php
@@ -78,8 +78,6 @@ abstract class JTable extends JObject
 	 * @param   string  $key    Name of the primary key field in the table.
 	 * @param   object  &$db    JDatabase connector object.
 	 *
-	 * @return  JTable
-	 *
 	 * @since   11.1
 	 */
 	function __construct($table, $key, &$db)

--- a/libraries/joomla/database/table.php
+++ b/libraries/joomla/database/table.php
@@ -109,7 +109,7 @@ abstract class JTable extends JObject
 			$this->_trackAssets = true;
 		}
 
-		// If the acess property exists, set the default.
+		// If the access property exists, set the default.
 		if (property_exists($this, 'access'))
 		{
 			$this->access = (int) JFactory::getConfig()->get('access');
@@ -256,9 +256,9 @@ abstract class JTable extends JObject
 	/**
 	 * Method to return the title to use for the asset table.  In
 	 * tracking the assets a title is kept for each asset so that there is some
-	 * context available in a unified access manager.  Usually this woud just
+	 * context available in a unified access manager.  Usually this would just
 	 * return $this->title or $this->name or whatever is being used for the
-	 * primary name of the row. If this method is not overriden, the asset name is used.
+	 * primary name of the row. If this method is not overridden, the asset name is used.
 	 *
 	 * @return  string  The string to use as the title in the asset table.
 	 *
@@ -1348,7 +1348,7 @@ abstract class JTable extends JObject
 	}
 
 	/**
-	 * Generic check for whether dependancies exist for this object in the database schema
+	 * Generic check for whether dependencies exist for this object in the database schema
 	 *
 	 * Can be overloaded/supplemented by the child class
 	 *

--- a/libraries/joomla/database/table/asset.php
+++ b/libraries/joomla/database/table/asset.php
@@ -57,8 +57,6 @@ class JTableAsset extends JTableNested
 	 *
 	 * @param   database  &$db  A database connector object
 	 *
-	 * @return  JTableAsset
-	 *
 	 * @since  11.1
 	 */
 	public function __construct(&$db)

--- a/libraries/joomla/database/table/category.php
+++ b/libraries/joomla/database/table/category.php
@@ -193,7 +193,7 @@ class JTableCategory extends JTableNested
 	}
 
 	/**
-	 * Overriden JTable::store to set created/modified and user id.
+	 * Overridden JTable::store to set created/modified and user id.
 	 *
 	 * @param   boolean  $updateNulls  True to update fields even if they are null.
 	 *

--- a/libraries/joomla/database/table/category.php
+++ b/libraries/joomla/database/table/category.php
@@ -25,8 +25,6 @@ class JTableCategory extends JTableNested
 	 *
 	 * @param   database  &$db  A database connector object
 	 *
-	 * @return  JTableCategory
-	 *
 	 * @since   11.1
 	 */
 	public function __construct(&$db)

--- a/libraries/joomla/database/table/content.php
+++ b/libraries/joomla/database/table/content.php
@@ -25,8 +25,6 @@ class JTableContent extends JTable
 	 *
 	 * @param   database  &$db  A database connector object
 	 *
-	 * @return  JTableContent
-	 *
 	 * @since   11.1
 	 */
 	function __construct(&$db)

--- a/libraries/joomla/database/table/extension.php
+++ b/libraries/joomla/database/table/extension.php
@@ -22,7 +22,7 @@ jimport('joomla.database.table');
 class JTableExtension extends JTable
 {
 	/**
-	 * Contructor
+	 * Constructor
 	 *
 	 * @param   database  &$db  A database connector object
 	 *

--- a/libraries/joomla/database/table/extension.php
+++ b/libraries/joomla/database/table/extension.php
@@ -26,8 +26,6 @@ class JTableExtension extends JTable
 	 *
 	 * @param   database  &$db  A database connector object
 	 *
-	 * @return  JTableExtension
-	 *
 	 * @since   11.1
 	 */
 	function __construct(&$db)

--- a/libraries/joomla/database/table/language.php
+++ b/libraries/joomla/database/table/language.php
@@ -25,8 +25,6 @@ class JTableLanguage extends JTable
 	 *
 	 * @param   JDatabase  &$db  A database connector object
 	 *
-	 * @return  JTableLanguage
-	 *
 	 * @since   11.1
 	 */
 	public function __construct(&$db)

--- a/libraries/joomla/database/table/menu.php
+++ b/libraries/joomla/database/table/menu.php
@@ -25,8 +25,6 @@ class JTableMenu extends JTableNested
 	 *
 	 * @param   database  &$db  A database connector object
 	 *
-	 * @return  JTableMenu
-	 *
 	 * @since   11.1
 	 */
 	public function __construct(&$db)

--- a/libraries/joomla/database/table/menutype.php
+++ b/libraries/joomla/database/table/menutype.php
@@ -23,8 +23,6 @@ class JTableMenuType extends JTable
 	 *
 	 * @param   database  &$db  A database connector object.
 	 *
-	 * @return  JTableMenuType
-	 *
 	 * @since  11.1
 	 */
 	public function __construct(&$db)

--- a/libraries/joomla/database/table/menutype.php
+++ b/libraries/joomla/database/table/menutype.php
@@ -96,7 +96,7 @@ class JTableMenuType extends JTable
 			$table = JTable::getInstance('Menutype', 'JTable');
 			$table->load($this->id);
 
-			// Verify that no items are cheched out
+			// Verify that no items are checked out
 			$query = $this->_db->getQuery(true);
 			$query->select('id');
 			$query->from('#__menu');
@@ -112,7 +112,7 @@ class JTableMenuType extends JTable
 				return false;
 			}
 
-			// Verify that no module for this menu are cheched out
+			// Verify that no module for this menu are checked out
 			$query = $this->_db->getQuery(true);
 			$query->select('id');
 			$query->from('#__modules');

--- a/libraries/joomla/database/table/module.php
+++ b/libraries/joomla/database/table/module.php
@@ -22,7 +22,7 @@ jimport('joomla.database.tableasset');
 class JTableModule extends JTable
 {
 	/**
-	 * Contructor.
+	 * Constructor.
 	 *
 	 * @param   database  &$db  A database connector object
 	 *

--- a/libraries/joomla/database/table/module.php
+++ b/libraries/joomla/database/table/module.php
@@ -26,8 +26,6 @@ class JTableModule extends JTable
 	 *
 	 * @param   database  &$db  A database connector object
 	 *
-	 * @return  JTableModule
-	 *
 	 * @since   11.1
 	 */
 	public function __construct(&$db)

--- a/libraries/joomla/database/table/session.php
+++ b/libraries/joomla/database/table/session.php
@@ -23,8 +23,6 @@ class JTableSession extends JTable
 	 *
 	 * @param   database  &$db  A database connector object.
 	 *
-	 * @return  JTableSession
-	 *
 	 * @since  11.1
 	 */
 	function __construct(&$db)

--- a/libraries/joomla/database/table/session.php
+++ b/libraries/joomla/database/table/session.php
@@ -69,7 +69,7 @@ class JTableSession extends JTable
 	 *
 	 * @param   boolean  $updateNulls  True to update fields even if they are null.
 	 *
-	 * @return  boolean  True on successs.
+	 * @return  boolean  True on success.
 	 *
 	 * @since   11.1
 	 */
@@ -90,12 +90,12 @@ class JTableSession extends JTable
 	}
 
 	/**
-	 * Destroys the pesisting session
+	 * Destroys the pre-existing session
 	 *
 	 * @param   integer  $userId     Identifier of the user for this session.
-	 * @param   integer  $clientIds  Array of client ids for which session(s) will be destroyed
+	 * @param   array    $clientIds  Array of client ids for which session(s) will be destroyed
 	 *
-	 * @return  boolean  True on successs.
+	 * @return  boolean  True on success.
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/database/table/update.php
+++ b/libraries/joomla/database/table/update.php
@@ -26,8 +26,6 @@ class JTableUpdate extends JTable
 	 *
 	 * @param   database  &$db  A database connector object
 	 *
-	 * @return  JTableUpdate
-	 *
 	 * @since   11.1
 	 */
 	function __construct(&$db)

--- a/libraries/joomla/database/table/update.php
+++ b/libraries/joomla/database/table/update.php
@@ -22,7 +22,7 @@ jimport('joomla.database.table');
 class JTableUpdate extends JTable
 {
 	/**
-	 * Contructor
+	 * Constructor
 	 *
 	 * @param   database  &$db  A database connector object
 	 *

--- a/libraries/joomla/database/table/user.php
+++ b/libraries/joomla/database/table/user.php
@@ -27,7 +27,7 @@ class JTableUser extends JTable
 	var $groups;
 
 	/**
-	 * Contructor
+	 * Constructor
 	 *
 	 * @param   database  &$db  A database connector object.
 	 *
@@ -438,7 +438,7 @@ class JTableUser extends JTable
 			}
 		}
 
-		// If no timestamp value is passed to functon, than current time is used.
+		// If no timestamp value is passed to function, than current time is used.
 		$date = JFactory::getDate($timeStamp);
 
 		// Update the database row for the user.

--- a/libraries/joomla/database/table/user.php
+++ b/libraries/joomla/database/table/user.php
@@ -31,8 +31,6 @@ class JTableUser extends JTable
 	 *
 	 * @param   database  &$db  A database connector object.
 	 *
-	 * @return  JTableUser
-	 *
 	 * @since  11.1
 	 */
 	function __construct(&$db)

--- a/libraries/joomla/database/table/usergroup.php
+++ b/libraries/joomla/database/table/usergroup.php
@@ -25,8 +25,6 @@ class JTableUsergroup extends JTable
 	 *
 	 * @param   database  &$db  A database connector object
 	 *
-	 * @return  JTableUsergroup
-	 *
 	 * @since   11.1
 	 */
 	public function __construct(&$db)

--- a/libraries/joomla/database/table/usergroup.php
+++ b/libraries/joomla/database/table/usergroup.php
@@ -51,7 +51,7 @@ class JTableUsergroup extends JTable
 		}
 
 		// Check for a duplicate parent_id, title.
-		// There is a unique index on the (parend_id, title) field in the table.
+		// There is a unique index on the (parent_id, title) field in the table.
 		$db = $this->getDbo();
 		$query = $db->getQuery(true)
 			->select('COUNT(title)')
@@ -139,7 +139,7 @@ class JTableUsergroup extends JTable
 	}
 
 	/**
-	 * Delete this object and its dependancies
+	 * Delete this object and its dependencies
 	 *
 	 * @param   integer  $oid  The primary key of the user group to delete.
 	 *

--- a/libraries/joomla/database/table/viewlevel.php
+++ b/libraries/joomla/database/table/viewlevel.php
@@ -25,8 +25,6 @@ class JTableViewlevel extends JTable
 	 *
 	 * @param   object  &$db  Database object.
 	 *
-	 * @return  JTableViewlevel
-	 *
 	 * @since   11.1
 	 */
 	public function __construct(&$db)

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -202,8 +202,6 @@ class JDocument extends JObject
 	 *
 	 * @param   array  $options  Associative array of options
 	 *
-	 * @return  JDocument
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/document/error/error.php
+++ b/libraries/joomla/document/error/error.php
@@ -33,8 +33,6 @@ class JDocumentError extends JDocument
 	 *
 	 * @param   array  $options  Associative array of attributes
 	 *
-	 * @return  JDocumentError
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/document/feed/feed.php
+++ b/libraries/joomla/document/feed/feed.php
@@ -41,7 +41,7 @@ class JDocumentFeed extends JDocument
 	public $image = null;
 
 	/**
-	 * Copyright feed elememnt
+	 * Copyright feed element
 	 *
 	 * optional
 	 *

--- a/libraries/joomla/document/feed/feed.php
+++ b/libraries/joomla/document/feed/feed.php
@@ -171,8 +171,6 @@ class JDocumentFeed extends JDocument
 	 *
 	 * @param   array  $options  Associative array of options
 	 *
-	 * @return  JDocumentFeed
-	 *
 	 * @since  11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -55,7 +55,7 @@ class JDocumentHTML extends JDocument
 	public $baseurl = null;
 
 	/**
-	 * Array of template parameterss
+	 * Array of template parameters
 	 *
 	 * @var    array
 	 * @since  11.1

--- a/libraries/joomla/document/json/json.php
+++ b/libraries/joomla/document/json/json.php
@@ -34,8 +34,6 @@ class JDocumentJSON extends JDocument
 	 *
 	 * @param   array  $options  Associative array of options
 	 *
-	 * @return  JDocumentJson
-	 *
 	 * @since  11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/document/opensearch/opensearch.php
+++ b/libraries/joomla/document/opensearch/opensearch.php
@@ -56,8 +56,6 @@ class JDocumentOpensearch extends JDocument
 	 *
 	 * @param   array  $options  Associative array of options
 	 *
-	 * @return  JDocumentOpensearch
-	 *
 	 * @since  11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/document/raw/raw.php
+++ b/libraries/joomla/document/raw/raw.php
@@ -27,8 +27,6 @@ class JDocumentRaw extends JDocument
 	 *
 	 * @param   array  $options  Associative array of options
 	 *
-	 * @return  JDocumentRaw
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/document/renderer.php
+++ b/libraries/joomla/document/renderer.php
@@ -39,8 +39,6 @@ class JDocumentRenderer extends JObject
 	*
 	* @param   object  &$doc  A reference to the JDocument object that instantiated the renderer
 	*
-	* @return  JDocumentRenderer
-	*
 	* @since   11.1
 	*/
 	public function __construct(&$doc)

--- a/libraries/joomla/document/xml/xml.php
+++ b/libraries/joomla/document/xml/xml.php
@@ -33,8 +33,6 @@ class JDocumentXml extends JDocument
 	 *
 	 * @param   array  $options  Associative array of options
 	 *
-	 * @return  JDocumentXml
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -193,8 +193,6 @@ class JBrowser extends JObject
 	 * @param   string  $userAgent  The browser string to parse.
 	 * @param   string  $accept     The HTTP_ACCEPT settings to use.
 	 *
-	 * @return  JBrowser
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($userAgent = null, $accept = null)

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -193,7 +193,7 @@ class JBrowser extends JObject
 	 * @param   string  $userAgent  The browser string to parse.
 	 * @param   string  $accept     The HTTP_ACCEPT settings to use.
 	 *
-	 * @return  void
+	 * @return  JBrowser
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/environment/request.php
+++ b/libraries/joomla/environment/request.php
@@ -159,7 +159,7 @@ class JRequest
 				// Get the variable from the input hash and clean it
 				$var = self::_cleanVar($input[$name], $mask, $type);
 
-				// Handle magic quotes compatability
+				// Handle magic quotes compatibility
 				if (get_magic_quotes_gpc() && ($var != $default) && ($hash != 'FILES'))
 				{
 					$var = self::_stripSlashesRecursive($var);
@@ -362,7 +362,7 @@ class JRequest
 	}
 
 	/**
-	 * Set a variabe in one of the request variables.
+	 * Set a variable in one of the request variables.
 	 *
 	 * @param   string   $name       Name
 	 * @param   string   $value      Value
@@ -502,7 +502,7 @@ class JRequest
 
 		$result = self::_cleanVar($input, $mask);
 
-		// Handle magic quotes compatability
+		// Handle magic quotes compatibility
 		if (get_magic_quotes_gpc() && ($hash != 'FILES'))
 		{
 			$result = self::_stripSlashesRecursive($result);
@@ -538,7 +538,7 @@ class JRequest
 	/**
 	 * Checks for a form token in the request.
 	 *
-	 * Use in conjuction with JHtml::_('form.token').
+	 * Use in conjunction with JHtml::_('form.token').
 	 *
 	 * @param   string  $method  The request method in which to look for the token key.
 	 *
@@ -729,7 +729,7 @@ class JRequest
 	 *
 	 * @param   array  $value  Array or (nested arrays) of strings.
 	 *
-	 * @return  array  The input array with stripshlashes applied to it.
+	 * @return  array  The input array with stripslashes applied to it.
 	 *
 	 * @deprecated  12.1
 	 * @since       11.1

--- a/libraries/joomla/error/profiler.php
+++ b/libraries/joomla/error/profiler.php
@@ -60,8 +60,6 @@ class JProfiler extends JObject
 	 *
 	 * @param   string  $prefix  Prefix for mark messages
 	 *
-	 * @return  void
-	 *
 	 * @since  11.1
 	 */
 	public function __construct($prefix = '')

--- a/libraries/joomla/filesystem/archive/bzip2.php
+++ b/libraries/joomla/filesystem/archive/bzip2.php
@@ -31,7 +31,7 @@ class JArchiveBzip2 extends JObject
 	/**
 	 * Constructor tries to load the bz2 extension if not loaded
 	 *
-	 * @return  void
+	 * @return  JArchiveBzip2
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/filesystem/archive/bzip2.php
+++ b/libraries/joomla/filesystem/archive/bzip2.php
@@ -31,8 +31,6 @@ class JArchiveBzip2 extends JObject
 	/**
 	 * Constructor tries to load the bz2 extension if not loaded
 	 *
-	 * @return  JArchiveBzip2
-	 *
 	 * @since   11.1
 	 */
 	public function __construct()

--- a/libraries/joomla/filesystem/archive/zip.php
+++ b/libraries/joomla/filesystem/archive/zip.php
@@ -462,7 +462,7 @@ class JArchiveZip extends JObject
 				}
 			}
 
-			// If bz2 extention is sucessfully loaded use it
+			// If bz2 extension is successfully loaded use it
 			if (extension_loaded('bz2'))
 			{
 				return bzdecompress(substr($this->_data, $this->_metadata[$key]['_dataStart'], $this->_metadata[$key]['csize']));

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -188,8 +188,8 @@ class JFile
 		{
 			$file = JPath::clean($file);
 
-			// Try making the file writeable first. If it's read-only, it can't be deleted
-			// on Windows, even if the parent folder is writeable
+			// Try making the file writable first. If it's read-only, it can't be deleted
+			// on Windows, even if the parent folder is writable
 			@chmod($file, 0777);
 
 			// In case of restricted permissions we zap it one way or the other

--- a/libraries/joomla/filesystem/path.php
+++ b/libraries/joomla/filesystem/path.php
@@ -61,7 +61,7 @@ class JPath
 	}
 
 	/**
-	 * Chmods files and directories recursivly to given permissions.
+	 * Chmods files and directories recursively to given permissions.
 	 *
 	 * @param   string  $path        Root path to begin changing mode [without trailing slash].
 	 * @param   string  $filemode    Octal representation of the value to change file mode to [null = no change].
@@ -207,7 +207,7 @@ class JPath
 		}
 		else
 		{
-			// Remove double slashes and backslahses and convert all slashes and backslashes to DS
+			// Remove double slashes and backslashes and convert all slashes and backslashes to DS
 			$path = preg_replace('#[/\\\\]+#', $ds, $path);
 		}
 
@@ -288,7 +288,7 @@ class JPath
 
 			// The substr() check added to make sure that the realpath()
 			// results in a directory registered so that
-			// non-registered directores are not accessible via directory
+			// non-registered directories are not accessible via directory
 			// traversal attempts.
 			if (file_exists($fullname) && substr($fullname, 0, strlen($path)) == $path)
 			{

--- a/libraries/joomla/filesystem/stream.php
+++ b/libraries/joomla/filesystem/stream.php
@@ -131,7 +131,7 @@ class JStream extends JObject
 	/**
 	 * Constructor
 	 *
-	 * @param   string  $writeprefix  Prefix of the stream (optional). Unlike the JPATH_*, this has a final path seperator!
+	 * @param   string  $writeprefix  Prefix of the stream (optional). Unlike the JPATH_*, this has a final path separator!
 	 * @param   string  $readprefix   The read prefix (optional).
 	 * @param   array   $context      The context options (optional).
 	 *

--- a/libraries/joomla/filesystem/stream.php
+++ b/libraries/joomla/filesystem/stream.php
@@ -135,8 +135,6 @@ class JStream extends JObject
 	 * @param   string  $readprefix   The read prefix (optional).
 	 * @param   array   $context      The context options (optional).
 	 *
-	 * @return  JStream
-	 *
 	 * @since   11.1
 	 */
 	function __construct($writeprefix = '', $readprefix = '', $context = array())

--- a/libraries/joomla/filesystem/streams/string.php
+++ b/libraries/joomla/filesystem/streams/string.php
@@ -125,7 +125,7 @@ class JStreamString
 	}
 
 	/**
-	 * Method to retrieve informaion from a file resource
+	 * Method to retrieve information from a file resource
 	 *
 	 * @return  array
 	 *
@@ -139,7 +139,7 @@ class JStreamString
 	}
 
 	/**
-	 * Method to rerieve information about a file.
+	 * Method to retrieve information about a file.
 	 *
 	 * @param   string   $path   File path or URL to stat
 	 * @param   integer  $flags  Additional flags set by the streams API

--- a/libraries/joomla/filter/filteroutput.php
+++ b/libraries/joomla/filter/filteroutput.php
@@ -75,7 +75,7 @@ class JFilterOutput
 
 	/**
 	 * This method processes a string and replaces all accented UTF-8 characters by unaccented
-	 * ASCII-7 "equivalents", whitespaces are replaced by hyphens and the string is lowercased.
+	 * ASCII-7 "equivalents", whitespaces are replaced by hyphens and the string is lowercase.
 	 *
 	 * @param   string  $string  String to process
 	 *
@@ -177,7 +177,7 @@ class JFilterOutput
 	}
 
 	/**
-	 * Cleans text of all formating and scripting code
+	 * Cleans text of all formatting and scripting code
 	 *
 	 * @param   string  &$text  Text to clean
 	 *

--- a/libraries/joomla/form/fields/editor.php
+++ b/libraries/joomla/form/fields/editor.php
@@ -136,7 +136,7 @@ class JFormFieldEditor extends JFormField
 				}
 			}
 
-			// Create the JEditor intance based on the given editor.
+			// Create the JEditor instance based on the given editor.
 			$this->editor = JFactory::getEditor($editor ? $editor : null);
 		}
 

--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -32,7 +32,7 @@ class JFormFieldList extends JFormField
 
 	/**
 	 * Method to get the field input markup for a generic list.
-	 * Use the multiple attribue to enable multiselect.
+	 * Use the multiple attribute to enable multiselect.
 	 *
 	 * @return  string  The field input markup.
 	 *

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -78,8 +78,6 @@ class JForm
 	 * @param   string  $name     The name of the form.
 	 * @param   array   $options  An array of form options.
 	 *
-	 * @return  JForm
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($name, array $options = array())

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -78,7 +78,7 @@ class JForm
 	 * @param   string  $name     The name of the form.
 	 * @param   array   $options  An array of form options.
 	 *
-	 * @return  void
+	 * @return  JForm
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/form/formfield.php
+++ b/libraries/joomla/form/formfield.php
@@ -259,7 +259,7 @@ abstract class JFormField
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   object  $form  The JForm object to attach to the form field.
+	 * @param   JForm  $form  The JForm object to attach to the form field.
 	 *
 	 * @return  object  The form field object so that the method can be used in a chain.
 	 *

--- a/libraries/joomla/form/formfield.php
+++ b/libraries/joomla/form/formfield.php
@@ -186,8 +186,6 @@ abstract class JFormField
 	 *
 	 * @param   object  $form  The form to attach to the form field object.
 	 *
-	 * @return  JFormField
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($form = null)

--- a/libraries/joomla/form/rules/color.php
+++ b/libraries/joomla/form/rules/color.php
@@ -21,7 +21,7 @@ jimport('joomla.form.formrule');
 class JFormRuleColor extends JFormRule
 {
 	/**
-	 * Method to test for a valid color in hexadecimaö.
+	 * Method to test for a valid color in hexadecimal.
 	 *
 	 * @param   object  &$element  The JXmlElement object representing the <field /> tag for the form field object.
 	 * @param   mixed   $value     The form field value to validate.

--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -277,7 +277,7 @@ abstract class JHtml
 	 * @param   string   $file            path to file
 	 * @param   boolean  $relative        path to file is relative to /media folder
 	 * @param   boolean  $detect_browser  detect browser to include specific browser js files
-	 * @param   folder   $folder          folder name to search into (images, css, js, ...)
+	 * @param   string   $folder          folder name to search into (images, css, js, ...)
 	 *
 	 * @return  array    files to be included
 	 *
@@ -798,7 +798,7 @@ abstract class JHtml
 	 * @param   string  $format   The date format
 	 * @param   array   $attribs  Additional HTML attributes
 	 *
-	 * @return  void
+	 * @return  string  HTML markup for a calendar field
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/html/html/behavior.php
+++ b/libraries/joomla/html/html/behavior.php
@@ -234,7 +234,7 @@ abstract class JHtmlBehavior
 	 *                             Options for the tooltip can be:
 	 *                             - maxTitleChars  integer   The maximum number of characters in the tooltip title (defaults to 50).
 	 *                             - offsets        object    The distance of your tooltip from the mouse (defaults to {'x': 16, 'y': 16}).
-	 *                             - showDelay      integr    The millisecond delay the show event is fired (defaults to 100).
+	 *                             - showDelay      integer   The millisecond delay the show event is fired (defaults to 100).
 	 *                             - hideDelay      integer   The millisecond delay the hide hide is fired (defaults to 100).
 	 *                             - className      string    The className your tooltip container will get.
 	 *                             - fixed          boolean   If set to true, the toolTip will not follow the mouse.
@@ -271,7 +271,7 @@ abstract class JHtmlBehavior
 		$opt['offset']			= (isset($params['offset']) && (is_array($params['offset']))) ? $params['offset'] : null;
 		if (!isset($opt['offset']))
 		{
-			// Suppporting offsets parameter which was working in mootools 1.2 (Joomla!1.5)
+			// Supporting offsets parameter which was working in mootools 1.2 (Joomla!1.5)
 			$opt['offset']		= (isset($params['offsets']) && (is_array($params['offsets']))) ? $params['offsets'] : null;
 		}
 		$opt['showDelay']		= (isset($params['showDelay'])) ? (int) $params['showDelay'] : null;

--- a/libraries/joomla/html/html/category.php
+++ b/libraries/joomla/html/html/category.php
@@ -91,7 +91,7 @@ abstract class JHtmlCategory
 	 * Returns an array of categories for the given extension.
 	 *
 	 * @param   string  $extension  The extension option.
-	 * @param   array   $config     An array of configuration options. By default, only published and unpulbished categories are returned.
+	 * @param   array   $config     An array of configuration options. By default, only published and unpublished categories are returned.
 	 *
 	 * @return  array   Categories for the extension
 	 *

--- a/libraries/joomla/html/html/email.php
+++ b/libraries/joomla/html/html/email.php
@@ -10,7 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 /**
- * Utility class for cloaking email adresses
+ * Utility class for cloaking email addresses
  *
  * @package     Joomla.Platform
  * @subpackage  HTML

--- a/libraries/joomla/html/html/form.php
+++ b/libraries/joomla/html/html/form.php
@@ -23,7 +23,7 @@ abstract class JHtmlForm
 	 *
 	 * Use in conjunction with JRequest::checkToken
 	 *
-	 * @return  void
+	 * @return  string  A hidden input field with a token
 	 *
 	 * @see     JRequest::checkToken
 	 * @since   11.1

--- a/libraries/joomla/html/html/form.php
+++ b/libraries/joomla/html/html/form.php
@@ -21,7 +21,7 @@ abstract class JHtmlForm
 	/**
 	 * Displays a hidden token field to reduce the risk of CSRF exploits
 	 *
-	 * Use in conjuction with JRequest::checkToken
+	 * Use in conjunction with JRequest::checkToken
 	 *
 	 * @return  void
 	 *

--- a/libraries/joomla/html/html/grid.php
+++ b/libraries/joomla/html/html/grid.php
@@ -251,7 +251,7 @@ abstract class JHtmlGrid
 	}
 	/**
 	 * Method to create a select list of states for filtering
-	 * By default the filter shows only published and unpublishe items
+	 * By default the filter shows only published and unpublished items
 	 *
 	 * @param   string  $filter_state  The initial filter state
 	 * @param   string  $published     The JText string for published
@@ -314,7 +314,7 @@ abstract class JHtmlGrid
 	 * @param   object   &$row     The row object
 	 * @param   boolean  $overlib  True if an overlib with checkout information should be created.
 	 *
-	 * @return  string   HTMl for the icon and ovelib
+	 * @return  string   HTMl for the icon and overlib
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/html/html/image.php
+++ b/libraries/joomla/html/html/image.php
@@ -159,7 +159,7 @@ abstract class JHtmlImage
 			}
 			else
 			{
-				// Compability with previous versions.
+				// Compatibility with previous versions.
 				if (substr($folder, 0, 14) == "/administrator")
 				{
 					$image = substr($folder, 15) . $file;

--- a/libraries/joomla/html/html/list.php
+++ b/libraries/joomla/html/html/list.php
@@ -45,7 +45,7 @@ abstract class JHtmlList
 	 * @param   string  $active      The selected item
 	 * @param   string  $javascript  Alternative javascript
 	 * @param   string  $directory   Directory the images are stored in
-	 * @param   string  $extensions  Allowd extensions
+	 * @param   string  $extensions  Allowed extensions
 	 *
 	 * @return  array  Image names
 	 *
@@ -231,7 +231,7 @@ abstract class JHtmlList
 	 * @param   integer  $nouser      If set include an option to select no user
 	 * @param   string   $javascript  Custom javascript
 	 * @param   string   $order       Specify a field to order by
-	 * @param   string   $reg         Deprecated  Exludes users who are explictly in group 2.
+	 * @param   string   $reg         Deprecated  Excludes users who are explicitly in group 2.
 	 *
 	 * @return  string   The HTML for a list of users list of users
 	 *

--- a/libraries/joomla/html/html/select.php
+++ b/libraries/joomla/html/html/select.php
@@ -67,7 +67,7 @@ abstract class JHtmlSelect
 	 *                               id, string: Value to use as the select element id attribute.
 	 *                               Defaults to the same as the name.
 	 *                               list.select, string|array: Identifies one or more option elements
-	 *                               to be selected, bassed on the option key values.
+	 *                               to be selected, based on the option key values.
 	 * @param   string   $optKey     The name of the object variable for the option value. If
 	 *                               set to null, the index of the value array is used.
 	 * @param   string   $optText    The name of the object variable for the option text.
@@ -132,7 +132,7 @@ abstract class JHtmlSelect
 	 * @param   string  $name     The value of the HTML name attribute
 	 * @param   array   $options  Options, an array of key/value pairs. Valid options are:
 	 *                            Format options, {@see JHtml::$formatOptions}.
-	 *                            Selection options. See {@see JTtmlSelect::options()}.
+	 *                            Selection options. See {@see JHtmlSelect::options()}.
 	 *                            group.id: The property in each group to use as the group id
 	 *                            attribute. Defaults to none.
 	 *                            group.label: The property in each group to use as the group
@@ -577,7 +577,7 @@ abstract class JHtmlSelect
 			}
 			else
 			{
-				// if no string after hypen - take hypen out
+				// if no string after hyphen - take hyphen out
 				$splitText = explode(' - ', $text, 2);
 				$text = $splitText[0];
 				if (isset($splitText[1]))

--- a/libraries/joomla/html/pagination.php
+++ b/libraries/joomla/html/pagination.php
@@ -66,8 +66,6 @@ class JPagination extends JObject
 	 * @param   integer  $limit       The number of items to display per page.
 	 * @param   string   $prefix      The prefix used for request variables.
 	 *
-	 * @return  JPagination
-	 *
 	 * @since   11.1
 	 */
 	function __construct($total, $limitstart, $limit, $prefix = '')
@@ -742,8 +740,6 @@ class JPaginationObject extends JObject
 	 * @param   integer  $prefix  The prefix used for request variables.
 	 * @param   integer  $base    The number of rows as a base offset.
 	 * @param   string   $link    The link URL.
-	 *
-	 * @return  JPaginationObject
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/html/pagination.php
+++ b/libraries/joomla/html/pagination.php
@@ -20,19 +20,19 @@ defined('JPATH_PLATFORM') or die;
 class JPagination extends JObject
 {
 	/**
-	 * @var    integer  The record number to start dislpaying from.
+	 * @var    integer  The record number to start displaying from.
 	 * @since  11.1
 	 */
 	public $limitstart = null;
 
 	/**
-	 * @var integer  Number of rows to display per page.
+	 * @var    integer  Number of rows to display per page.
 	 * @since  11.1
 	 */
 	public $limit = null;
 
 	/**
-	 * @var integer  Total number of rows.
+	 * @var    integer  Total number of rows.
 	 * @since  11.1
 	 */
 	public $total = null;
@@ -66,7 +66,7 @@ class JPagination extends JObject
 	 * @param   integer  $limit       The number of items to display per page.
 	 * @param   string   $prefix      The prefix used for request variables.
 	 *
-	 * @return  void
+	 * @return  JPagination
 	 *
 	 * @since   11.1
 	 */
@@ -743,7 +743,7 @@ class JPaginationObject extends JObject
 	 * @param   integer  $base    The number of rows as a base offset.
 	 * @param   string   $link    The link URL.
 	 *
-	 * @return  void
+	 * @return  JPaginationObject
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/html/pane.php
+++ b/libraries/joomla/html/pane.php
@@ -117,8 +117,6 @@ class JPaneTabs extends JPane
 	 *
 	 * @param   array  $params  Associative array of values
 	 *
-	 * @return  void
-	 *
 	 * @since   11.1
 	 */
 	function __construct($params = array())

--- a/libraries/joomla/html/parameter.php
+++ b/libraries/joomla/html/parameter.php
@@ -54,8 +54,6 @@ class JParameter extends JRegistry
 	 * @param   string  $data  The raw parms text.
 	 * @param   string  $path  Path to the XML setup file.
 	 *
-	 * @return  JParameter
-	 *
 	 * @deprecated  12.1
 	 * @since   11.1
 	 */

--- a/libraries/joomla/html/parameter/element.php
+++ b/libraries/joomla/html/parameter/element.php
@@ -45,7 +45,6 @@ class JElement extends JObject
 	 *
 	 * @param   string  $parent  Element parent
 	 *
-	 * @deprecated    12.1
 	 * @since   11.1
 	 */
 	public function __construct($parent = null)

--- a/libraries/joomla/html/toolbar/button/standard.php
+++ b/libraries/joomla/html/toolbar/button/standard.php
@@ -30,7 +30,7 @@ class JButtonStandard extends JButton
 	 *
 	 * @param   string   $type  Unused string.
 	 * @param   string   $name  The name of the button icon class.
-	 * @param   sring    $text  Button text.
+	 * @param   string    $text  Button text.
 	 * @param   string   $task  Task associated with the button.
 	 * @param   boolean  $list  True to allow lists
 	 *

--- a/libraries/joomla/installer/adapters/component.php
+++ b/libraries/joomla/installer/adapters/component.php
@@ -46,7 +46,7 @@ class JInstallerComponent extends JAdapterInstance
 
 	/**
 	 *
-	 * The list of current files fo the Joomla! CMS adminisrator that are installed and is read
+	 * The list of current files fo the Joomla! CMS administrator that are installed and is read
 	 * from the manifest on disk in the update area to handle doing a diff
 	 * and deleting files that are in the old files list and not in the new
 	 * files list.

--- a/libraries/joomla/installer/adapters/language.php
+++ b/libraries/joomla/installer/adapters/language.php
@@ -562,7 +562,7 @@ class JInstallerLanguage extends JAdapterInstance
 	 * Custom discover method
 	 * Finds language files
 	 *
-	 * @return  void
+	 * @return  boolean  True on success
 	 *
 	 * @since  11.1
 	 */
@@ -608,7 +608,7 @@ class JInstallerLanguage extends JAdapterInstance
 	 * Custom discover install method
 	 * Basically updates the manifest cache and leaves everything alone
 	 *
-	 * @return  integer  The extrension id
+	 * @return  integer  The extension id
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/installer/adapters/library.php
+++ b/libraries/joomla/installer/adapters/library.php
@@ -266,8 +266,8 @@ class JInstallerLibrary extends JAdapterInstance
 			}
 
 			// Check for a valid XML root tag.
-			// TODO: Remove backwards compatability in a future version
-			// Should be 'extension', but for backward compatability we will accept 'install'.
+			// TODO: Remove backwards compatibility in a future version
+			// Should be 'extension', but for backward compatibility we will accept 'install'.
 
 			if ($xml->getName() != 'install' && $xml->getName() != 'extension')
 			{
@@ -340,7 +340,7 @@ class JInstallerLibrary extends JAdapterInstance
 	/**
 	 * Custom discover_install method
 	 *
-	 * @return  void
+	 * @return  boolean  True on success
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/installer/adapters/module.php
+++ b/libraries/joomla/installer/adapters/module.php
@@ -260,7 +260,7 @@ class JInstallerModule extends JAdapterInstance
 			elseif (!$this->parent->getOverwrite())
 			{
 				// Overwrite is set
-				// We didn't have overwrite set, find an udpate function or find an update tag so lets call it safe
+				// We didn't have overwrite set, find an update function or find an update tag so lets call it safe
 				$this->parent
 					->abort(
 						JText::sprintf(
@@ -609,7 +609,7 @@ class JInstallerModule extends JAdapterInstance
 	/**
 	 * Custom discover_install method
 	 *
-	 * @return void
+	 * @return  mixed  Extension ID on success, boolean false on failure
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/installer/adapters/package.php
+++ b/libraries/joomla/installer/adapters/package.php
@@ -269,8 +269,8 @@ class JInstallerPackage extends JAdapterInstance
 
 		/*
 		 * Check for a valid XML root tag.
-		 * @todo: Remove backwards compatability in a future version
-		 * Should be 'extension', but for backward compatability we will accept 'install'.
+		 * @todo: Remove backwards compatibility in a future version
+		 * Should be 'extension', but for backward compatibility we will accept 'install'.
 		 */
 		if ($xml->getName() != 'install' && $xml->getName() != 'extension')
 		{
@@ -321,7 +321,7 @@ class JInstallerPackage extends JAdapterInstance
 	 *
 	 * @param   string   $type    The extension type.
 	 * @param   string   $id      The name of the extension (the element field).
-	 * @param   integer  $client  The appliaction id (0: Joomla CMS site; 1: Joomla CMS administrator).
+	 * @param   integer  $client  The application id (0: Joomla CMS site; 1: Joomla CMS administrator).
 	 * @param   string   $group   The extension group (mainly for plugins).
 	 *
 	 * @return  integer

--- a/libraries/joomla/installer/adapters/plugin.php
+++ b/libraries/joomla/installer/adapters/plugin.php
@@ -154,7 +154,7 @@ class JInstallerPlugin extends JAdapterInstance
 		}
 
 		/*
-		 * Backward Compatability
+		 * Backward Compatibility
 		 * @todo Deprecate in future version
 		 */
 		$type = (string) $xml->attributes()->type;
@@ -225,7 +225,7 @@ class JInstallerPlugin extends JAdapterInstance
 			elseif (!$this->parent->getOverwrite())
 			{
 				// Overwrite is set
-				// We didn't have overwrite set, find an udpate function or find an update tag so lets call it safe
+				// We didn't have overwrite set, find an update function or find an update tag so lets call it safe
 				$this->parent
 					->abort(
 						JText::sprintf(
@@ -594,8 +594,8 @@ class JInstallerPlugin extends JAdapterInstance
 
 		/*
 		 * Check for a valid XML root tag.
-		 * @todo: Remove backwards compatability in a future version
-		 * Should be 'extension', but for backward compatability we will accept 'install'.
+		 * @todo: Remove backwards compatibility in a future version
+		 * Should be 'extension', but for backward compatibility we will accept 'install'.
 		 */
 		if ($xml->getName() != 'install' && $xml->getName() != 'extension')
 		{

--- a/libraries/joomla/installer/adapters/template.php
+++ b/libraries/joomla/installer/adapters/template.php
@@ -138,7 +138,7 @@ class JInstallerTemplate extends JAdapterInstance
 			elseif (!$this->parent->getOverwrite())
 			{
 				// Overwrite is not set
-				// If we didn't have overwrite set, find an udpate function or find an update tag so let's call it safe
+				// If we didn't have overwrite set, find an update function or find an update tag so let's call it safe
 				$this->parent
 					->abort(
 						JText::sprintf(

--- a/libraries/joomla/installer/extension.php
+++ b/libraries/joomla/installer/extension.php
@@ -88,8 +88,6 @@ class JExtension extends JObject
 	 *
 	 * @param   JXMLElement  $element  A JXMLElement from which to load data from
 	 *
-	 * @return  JExtension
-	 *
 	 * @since  11.1
 	 */
 	function __construct(JXMLElement $element = null)

--- a/libraries/joomla/installer/installer.php
+++ b/libraries/joomla/installer/installer.php
@@ -107,8 +107,6 @@ class JInstaller extends JAdapter
 	/**
 	 * Constructor
 	 *
-	 * @return  JInstaller
-	 *
 	 * @since   11.1
 	 */
 	public function __construct()

--- a/libraries/joomla/installer/installer.php
+++ b/libraries/joomla/installer/installer.php
@@ -33,7 +33,7 @@ class JInstaller extends JAdapter
 	protected $_paths = array();
 
 	/**
-	 * True if packakge is an upgrade
+	 * True if package is an upgrade
 	 *
 	 * @var    boolean
 	 * @since  11.1
@@ -1890,8 +1890,8 @@ class JInstaller extends JAdapter
 		}
 
 		// Check for a valid XML root tag.
-		// @todo: Remove backwards compatability in a future version
-		// Should be 'extension', but for backward compatability we will accept 'extension' or 'install'.
+		// @todo: Remove backwards compatibility in a future version
+		// Should be 'extension', but for backward compatibility we will accept 'extension' or 'install'.
 
 		// 1.5 uses 'install'
 		// 1.6 uses 'extension'
@@ -1948,7 +1948,7 @@ class JInstaller extends JAdapter
 	 * @param   array  $old_files  An array of JXMLElement objects that are the old files
 	 * @param   array  $new_files  An array of JXMLElement objects that are the new files
 	 *
-	 * @return  array  An array with the delete files and folders in findDeletedFiles[files] and findDeletedFiles[folders] resepctively
+	 * @return  array  An array with the delete files and folders in findDeletedFiles[files] and findDeletedFiles[folders] respectively
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/installer/librarymanifest.php
+++ b/libraries/joomla/installer/librarymanifest.php
@@ -100,8 +100,6 @@ class JLibraryManifest extends JObject
 	 *
 	 * @param   string  $xmlpath  Path to an XML file to load the manifest from.
 	 *
-	 * @return  JLibraryManifest
-	 *
 	 * @since   11.1
 	 */
 	function __construct($xmlpath = '')

--- a/libraries/joomla/installer/packagemanifest.php
+++ b/libraries/joomla/installer/packagemanifest.php
@@ -77,8 +77,6 @@ class JPackageManifest extends JObject
 	 *
 	 * @param   string  $xmlpath  Path to XML manifest file.
 	 *
-	 * @return  object  JPackageManifest
-	 *
 	 * @since
 	 */
 	function __construct($xmlpath = '')

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -160,8 +160,6 @@ class JLanguage extends JObject
 	 * @param   string   $lang   The language
 	 * @param   boolean  $debug  Indicates if language debugging is enabled.
 	 *
-	 * @return  JLanguage
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($lang = null, $debug = false)

--- a/libraries/joomla/log/log.php
+++ b/libraries/joomla/log/log.php
@@ -137,8 +137,6 @@ class JLog
 	/**
 	 * Constructor.
 	 *
-	 * @return  JLog
-	 *
 	 * @since   11.1
 	 */
 	protected function __construct()

--- a/libraries/joomla/log/log.php
+++ b/libraries/joomla/log/log.php
@@ -277,7 +277,7 @@ class JLog
 
 	/**
 	 * Returns a reference to the a JLog object, only creating it if it doesn't already exist.
-	 * Note: This is principly made available for testing and internal purposes.
+	 * Note: This is principally made available for testing and internal purposes.
 	 *
 	 * @param   JLog  $instance  The logging object instance to be used by the static methods.
 	 *

--- a/libraries/joomla/log/logentry.php
+++ b/libraries/joomla/log/logentry.php
@@ -77,7 +77,7 @@ class JLogEntry
 	 * @param   string  $category  Type of entry
 	 * @param   string  $date      Date of entry (defaults to now if not specified or blank)
 	 *
-	 * @return  void
+	 * @return  JLogEntry
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/log/logentry.php
+++ b/libraries/joomla/log/logentry.php
@@ -77,8 +77,6 @@ class JLogEntry
 	 * @param   string  $category  Type of entry
 	 * @param   string  $date      Date of entry (defaults to now if not specified or blank)
 	 *
-	 * @return  JLogEntry
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($message, $priority = JLog::INFO, $category = '', $date = null)

--- a/libraries/joomla/log/logger.php
+++ b/libraries/joomla/log/logger.php
@@ -35,8 +35,6 @@ abstract class JLogger
 	 *
 	 * @param   array  &$options  Log object options.
 	 *
-	 * @return  JLogger
-	 *
 	 * @since   11.1
 	 */
 	public function __construct(array &$options)

--- a/libraries/joomla/log/logger.php
+++ b/libraries/joomla/log/logger.php
@@ -35,7 +35,7 @@ abstract class JLogger
 	 *
 	 * @param   array  &$options  Log object options.
 	 *
-	 * @return  void
+	 * @return  JLogger
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/log/loggers/database.php
+++ b/libraries/joomla/log/loggers/database.php
@@ -73,8 +73,6 @@ class JLoggerDatabase extends JLogger
 	 *
 	 * @param   array  &$options  Log object options.
 	 *
-	 * @return  JLoggerDatabase
-	 *
 	 * @since   11.1
 	 * @throws  LogException
 	 */

--- a/libraries/joomla/log/loggers/database.php
+++ b/libraries/joomla/log/loggers/database.php
@@ -73,7 +73,7 @@ class JLoggerDatabase extends JLogger
 	 *
 	 * @param   array  &$options  Log object options.
 	 *
-	 * @return  void
+	 * @return  JLoggerDatabase
 	 *
 	 * @since   11.1
 	 * @throws  LogException

--- a/libraries/joomla/log/loggers/formattedtext.php
+++ b/libraries/joomla/log/loggers/formattedtext.php
@@ -69,7 +69,7 @@ class JLoggerFormattedText extends JLogger
 	 *
 	 * @param   array  &$options  Log object options.
 	 *
-	 * @return  void
+	 * @return  JLoggerFormattedText
 	 *
 	 * @since   11.1
 	 */
@@ -194,7 +194,7 @@ class JLoggerFormattedText extends JLogger
 	/**
 	 * Method to generate the log file header.
 	 *
-	 * @return  void
+	 * @return  string  The log file header
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/log/loggers/formattedtext.php
+++ b/libraries/joomla/log/loggers/formattedtext.php
@@ -69,8 +69,6 @@ class JLoggerFormattedText extends JLogger
 	 *
 	 * @param   array  &$options  Log object options.
 	 *
-	 * @return  JLoggerFormattedText
-	 *
 	 * @since   11.1
 	 */
 	public function __construct(array &$options)

--- a/libraries/joomla/log/loggers/syslog.php
+++ b/libraries/joomla/log/loggers/syslog.php
@@ -45,7 +45,7 @@ class JLoggerSysLog extends JLogger
 	 *
 	 * @param   array  &$options  Log object options.
 	 *
-	 * @return  void
+	 * @return  JLoggerSysLog
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/log/loggers/syslog.php
+++ b/libraries/joomla/log/loggers/syslog.php
@@ -45,8 +45,6 @@ class JLoggerSysLog extends JLogger
 	 *
 	 * @param   array  &$options  Log object options.
 	 *
-	 * @return  JLoggerSysLog
-	 *
 	 * @since   11.1
 	 */
 	public function __construct(array &$options)

--- a/libraries/joomla/log/loggers/w3c.php
+++ b/libraries/joomla/log/loggers/w3c.php
@@ -39,8 +39,6 @@ class JLoggerW3C extends JLoggerFormattedText
 	 *
 	 * @param   array  &$options  Log object options.
 	 *
-	 * @return  JLoggerW3C
-	 *
 	 * @since   11.1
 	 */
 	public function __construct(array &$options)

--- a/libraries/joomla/log/loggers/w3c.php
+++ b/libraries/joomla/log/loggers/w3c.php
@@ -39,7 +39,7 @@ class JLoggerW3C extends JLoggerFormattedText
 	 *
 	 * @param   array  &$options  Log object options.
 	 *
-	 * @return  void
+	 * @return  JLoggerW3C
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -447,7 +447,7 @@ class JMail extends PHPMailer
 	 * @param   string  $type        Type of item to approve
 	 * @param   string  $title       Title of item to approve
 	 * @param   string  $author      Author of item to approve
-	 * @param   string  $url         A URL to inclued in the mail
+	 * @param   string  $url         A URL to included in the mail
 	 *
 	 * @return  boolean  True on success
 	 *

--- a/libraries/joomla/plugin/helper.php
+++ b/libraries/joomla/plugin/helper.php
@@ -88,7 +88,7 @@ abstract class JPluginHelper
 
 	/**
 	 * Loads all the plugin files for a particular type if no specific plugin is specified
-	 * otherwise only the specific pugin is loaded.
+	 * otherwise only the specific plugin is loaded.
 	 *
 	 * @param   string       $type        The plugin type, relates to the sub-directory in the plugins directory.
 	 * @param   string       $plugin      The plugin name.
@@ -206,7 +206,7 @@ abstract class JPluginHelper
 	/**
 	 * Loads the published plugins.
 	 *
-	 * @return  void
+	 * @return  array  An array of published plugins
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/plugin/plugin.php
+++ b/libraries/joomla/plugin/plugin.php
@@ -50,8 +50,6 @@ abstract class JPlugin extends JEvent
 	 *                             Recognized key values include 'name', 'group', 'params', 'language'
 	 *                             (this list is not meant to be comprehensive).
 	 *
-	 * @return  JPlugin
-	 *
 	 * @since   11.1
 	 */
 	public function __construct(&$subject, $config = array())

--- a/libraries/joomla/registry/registry.php
+++ b/libraries/joomla/registry/registry.php
@@ -34,8 +34,6 @@ class JRegistry
 	 *
 	 * @param   mixed  $data  The data to bind to the new JRegistry object.
 	 *
-	 * @return  JRegistry
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($data = null)

--- a/libraries/joomla/registry/registry.php
+++ b/libraries/joomla/registry/registry.php
@@ -34,7 +34,7 @@ class JRegistry
 	 *
 	 * @param   mixed  $data  The data to bind to the new JRegistry object.
 	 *
-	 * @return  void
+	 * @return  JRegistry
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -837,7 +837,7 @@ class JSession extends JObject
 			$this->set('session.client.forwarded', $_SERVER['HTTP_X_FORWARDED_FOR']);
 		}
 
-		// Check for client adress
+		// Check for client address
 		if (in_array('fix_adress', $this->_security) && isset($_SERVER['REMOTE_ADDR']))
 		{
 			$ip = $this->get('session.client.address');

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -83,8 +83,6 @@ class JSession extends JObject
 	 * @param   string  $store    The type of storage for the session.
 	 * @param   array   $options  Optional parameters
 	 *
-	 * @return  JSession
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($store = 'none', $options = array())

--- a/libraries/joomla/session/storage.php
+++ b/libraries/joomla/session/storage.php
@@ -24,8 +24,6 @@ abstract class JSessionStorage extends JObject
 	 *
 	 * @param   array  $options  Optional parameters.
 	 *
-	 * @return  JSessionStorage
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/session/storage.php
+++ b/libraries/joomla/session/storage.php
@@ -36,8 +36,8 @@ abstract class JSessionStorage extends JObject
 	/**
 	 * Returns a session storage handler object, only creating it if it doesn't already exist.
 	 *
-	 * @param   name   $name     The session store to instantiate
-	 * @param   array  $options  Array of options
+	 * @param   string  $name     The session store to instantiate
+	 * @param   array   $options  Array of options
 	 *
 	 * @return  JSessionStorage
 	 *

--- a/libraries/joomla/session/storage/apc.php
+++ b/libraries/joomla/session/storage/apc.php
@@ -24,8 +24,6 @@ class JSessionStorageApc extends JSessionStorage
 	 *
 	 * @param   array  $options  Optional parameters
 	 *
-	 * @return  JSessionStorageApc
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/session/storage/eaccelerator.php
+++ b/libraries/joomla/session/storage/eaccelerator.php
@@ -24,8 +24,6 @@ class JSessionStorageEaccelerator extends JSessionStorage
 	 *
 	 * @param   array  $options  Optional parameters.
 	 *
-	 * @return  JSessionStorageEaccelerator
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/session/storage/memcache.php
+++ b/libraries/joomla/session/storage/memcache.php
@@ -50,8 +50,6 @@ class JSessionStorageMemcache extends JSessionStorage
 	 *
 	 * @param   array  $options  Optional parameters.
 	 *
-	 * @return  JSessionStorageMemcache
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/session/storage/wincache.php
+++ b/libraries/joomla/session/storage/wincache.php
@@ -24,8 +24,6 @@ class JSessionStorageWincache extends JSessionStorage
 	 *
 	 * @param   array  $options  Optional parameters.
 	 *
-	 * @return  JSessionStorageWincache
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/session/storage/xcache.php
+++ b/libraries/joomla/session/storage/xcache.php
@@ -23,8 +23,6 @@ class JSessionStorageXcache extends JSessionStorage
 	 *
 	 * @param   array  $options  Optional parameters.
 	 *
-	 * @return  JSessionStorageXcache
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($options = array())

--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
 // Check if mbstring extension is loaded and attempt to load it if not present except for windows
 if (extension_loaded('mbstring') || ((!strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && dl('mbstring.so'))))
 {
-	// Make sure to surpress the output in case ini_set is disabled
+	// Make sure to suppress the output in case ini_set is disabled
 	@ini_set('mbstring.internal_encoding', 'UTF-8');
 	@ini_set('mbstring.http_input', 'UTF-8');
 	@ini_set('mbstring.http_output', 'UTF-8');
@@ -127,7 +127,7 @@ abstract class JString
 	 * Find position of first occurrence of a string.
 	 *
 	 * @param   string   $str     String being examined
-	 * @param   string   $search  String being searced for
+	 * @param   string   $search  String being searched for
 	 * @param   integer  $offset  Optional, specifies the position from which the search should be performed
 	 *
 	 * @return  mixed  Number of characters before the first match or FALSE on failure
@@ -296,7 +296,7 @@ abstract class JString
 
 	/**
 	 * UTF-8/LOCALE aware alternative to strcasecmp
-	 * A case insensivite string comparison
+	 * A case insensitive string comparison
 	 *
 	 * @param   string  $str1    string 1 to compare
 	 * @param   string  $str2    string 2 to compare
@@ -334,7 +334,7 @@ abstract class JString
 				$encoding = 'nonrecodable';
 			}
 
-			// if we sucesfuly set encoding it to utf-8 or encoding is sth weird don't recode
+			// if we successfully set encoding it to utf-8 or encoding is sth weird don't recode
 			if ($encoding == 'UTF-8' || $encoding == 'nonrecodable')
 			{
 				return strcoll(utf8_strtolower($str1), utf8_strtolower($str2));
@@ -393,7 +393,7 @@ abstract class JString
 				$encoding = 'nonrecodable';
 			}
 
-			// If we sucesfuly set encoding it to utf-8 or encoding is sth weird don't recode
+			// If we successfully set encoding it to utf-8 or encoding is sth weird don't recode
 			if ($encoding == 'UTF-8' || $encoding == 'nonrecodable')
 			{
 				return strcoll($str1, $str2);
@@ -892,7 +892,7 @@ abstract class JString
 			'%5D');
 		$replacements = array('!', '*', "'", "(", ")", ";", ":", "@", "&", "=", "$", ",", "/", "?", "%", "#", "[", "]");
 		// Create encoded URL with special URL characters decoded so it can be parsed
-		// All other charcters will be encoded
+		// All other characters will be encoded
 		$encodedURL = str_replace($entities, $replacements, urlencode($url));
 		// Parse the encoded URL
 		$encodedParts = parse_url($encodedURL);

--- a/libraries/joomla/updater/updater.php
+++ b/libraries/joomla/updater/updater.php
@@ -29,8 +29,6 @@ class JUpdater extends JAdapter
 	/**
 	 * Constructor
 	 *
-	 * @return  JUpdater
-	 *
 	 * @since   11.1
 	 */
 	public function __construct()

--- a/libraries/joomla/user/authentication.php
+++ b/libraries/joomla/user/authentication.php
@@ -88,8 +88,6 @@ class JAuthentication extends JObservable
 	/**
 	 * Constructor
 	 *
-	 * @return  JAuthentication
-	 *
 	 * @since   11.1
 	 */
 	public function __construct()
@@ -346,8 +344,6 @@ class JAuthenticationResponse extends JObject
 
 	/**
 	 * Constructor
-	 *
-	 * @return  JAuthenticationResponse
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/user/authentication.php
+++ b/libraries/joomla/user/authentication.php
@@ -32,7 +32,7 @@ define('JAUTHENTICATE_STATUS_CANCEL', 2);
 define('JAUTHENTICATE_STATUS_FAILURE', 4);
 
 /**
- * Authenthication class, provides an interface for the Joomla authentication system
+ * Authentication class, provides an interface for the Joomla authentication system
  *
  * @package     Joomla.Platform
  * @subpackage  User
@@ -128,7 +128,7 @@ class JAuthentication extends JObservable
 	}
 
 	/**
-	 * Finds out if a set of login credentials are valid by asking all obvserving
+	 * Finds out if a set of login credentials are valid by asking all observing
 	 * objects to run their respective authentication routines.
 	 *
 	 * @param   array  $credentials  Array holding the user credentials.
@@ -147,11 +147,11 @@ class JAuthentication extends JObservable
 		// Get plugins
 		$plugins = JPluginHelper::getPlugin('authentication');
 
-		// Create authencication response
+		// Create authentication response
 		$response = new JAuthenticationResponse;
 
 		/*
-		 * Loop through the plugins and check of the creditials can be used to authenticate
+		 * Loop through the plugins and check of the credentials can be used to authenticate
 		 * the user
 		 *
 		 * Any errors raised in the plugin should be returned via the JAuthenticationResponse

--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -313,7 +313,7 @@ abstract class JUserHelper
 	 * @param   string   $salt          The salt to use to encrypt the password. []
 	 *                                  If not present, a new salt will be
 	 *                                  generated.
-	 * @param   string   $encryption    The kind of pasword encryption to use.
+	 * @param   string   $encryption    The kind of password encryption to use.
 	 *                                  Defaults to md5-hex.
 	 * @param   boolean  $show_encrypt  Some password systems prepend the kind of
 	 *                                  encryption to the crypted password ({SHA},
@@ -414,7 +414,7 @@ abstract class JUserHelper
 	 * of an existing password, or for encryption types that use the plaintext
 	 * in the generation of the salt.
 	 *
-	 * @param   string  $encryption  The kind of pasword encryption to use.
+	 * @param   string  $encryption  The kind of password encryption to use.
 	 *                               Defaults to md5-hex.
 	 * @param   string  $seed        The seed to get the salt from (probably a
 	 *                               previously generated password). Defaults to

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -196,8 +196,6 @@ class JUser extends JObject
 	 *
 	 * @param   integer  $identifier  The primary key of the user to load (optional).
 	 *
-	 * @return  JUser
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($identifier = 0)

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -816,7 +816,7 @@ class JUser extends JObject
 				$my->setParameters($registry);
 			}
 
-			// Fire the onAftereStoreUser event
+			// Fire the onUserAfterSave event
 			$dispatcher->trigger('onUserAfterSave', array($this->getProperties(), $isNew, $result, $this->getError()));
 		}
 		catch (Exception $e)

--- a/libraries/joomla/utilities/arrayhelper.php
+++ b/libraries/joomla/utilities/arrayhelper.php
@@ -161,7 +161,7 @@ class JArrayHelper
 	 * Utility function to map an object to an array
 	 *
 	 * @param   object   $p_obj    The source object
-	 * @param   boolean  $recurse  True to recurve through multi-level objects
+	 * @param   boolean  $recurse  True to recurse through multi-level objects
 	 * @param   string   $regex    An optional regular expression to match on field names
 	 *
 	 * @return  array    The array mapped from the given object
@@ -184,7 +184,7 @@ class JArrayHelper
 	 * Utility function to map an object or array to an array
 	 *
 	 * @param   mixed    $item     The source object or array
-	 * @param   boolean  $recurse  True to recurve through multi-level objects
+	 * @param   boolean  $recurse  True to recurse through multi-level objects
 	 * @param   string   $regex    An optional regular expression to match on field names
 	 *
 	 * @return  array  The array mapped from the given object

--- a/libraries/joomla/utilities/date.php
+++ b/libraries/joomla/utilities/date.php
@@ -82,7 +82,6 @@ class JDate extends DateTime
 	 * @param   string  $date  String in a format accepted by strtotime(), defaults to "now".
 	 * @param   mixed   $tz    Time zone to be used for the date.
 	 *
-	 * @return  JDate
 	 * @since   11.1
 	 *
 	 * @throws  JException

--- a/libraries/joomla/utilities/date.php
+++ b/libraries/joomla/utilities/date.php
@@ -82,7 +82,7 @@ class JDate extends DateTime
 	 * @param   string  $date  String in a format accepted by strtotime(), defaults to "now".
 	 * @param   mixed   $tz    Time zone to be used for the date.
 	 *
-	 * @return  void
+	 * @return  JDate
 	 * @since   11.1
 	 *
 	 * @throws  JException
@@ -221,7 +221,7 @@ class JDate extends DateTime
 	 * @param   string  $date  String in a format accepted by strtotime(), defaults to "now".
 	 * @param   mixed   $tz    Time zone to be used for the date.
 	 *
-	 * @return  void
+	 * @return  JDate
 	 *
 	 * @since   11.3
 	 * @throws  JException
@@ -235,7 +235,7 @@ class JDate extends DateTime
 	 * Translates day of week number to a string.
 	 *
 	 * @param   integer  $day   The numeric day of the week.
-	 * @param   boolean  $abbr  Return the abreviated day string?
+	 * @param   boolean  $abbr  Return the abbreviated day string?
 	 *
 	 * @return  string  The day of the week.
 	 *
@@ -311,7 +311,7 @@ class JDate extends DateTime
 
 		if ($translate)
 		{
-			// Manually modify the month and day strings in the formated time.
+			// Manually modify the month and day strings in the formatted time.
 			if (strpos($return, self::DAY_ABBR) !== false)
 			{
 				$return = str_replace(self::DAY_ABBR, $this->dayToString(parent::format('w'), true), $return);
@@ -359,7 +359,7 @@ class JDate extends DateTime
 	 * Translates month number to a string.
 	 *
 	 * @param   integer  $month  The numeric month of the year.
-	 * @param   boolean  $abbr   If true, return the abreviated month string
+	 * @param   boolean  $abbr   If true, return the abbreviated month string
 	 *
 	 * @return  string  The month of the year.
 	 *

--- a/libraries/joomla/utilities/simplecrypt.php
+++ b/libraries/joomla/utilities/simplecrypt.php
@@ -31,8 +31,6 @@ class JSimpleCrypt extends JObject
 	 *
 	 * @param   string  $key  Optional encryption key
 	 *
-	 * @return  JSimpleCrypt
-	 *
 	 * @since   11.1
 	 */
 	public function __construct($key = null)

--- a/libraries/joomla/utilities/simplecrypt.php
+++ b/libraries/joomla/utilities/simplecrypt.php
@@ -10,7 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 /**
- * JSimpleCrypt is a very simple encryption algorithm for encyrpting/decrypting strings
+ * JSimpleCrypt is a very simple encryption algorithm for encrypting/decrypting strings
  *
  * @package     Joomla.Platform
  * @subpackage  Utilities
@@ -31,7 +31,7 @@ class JSimpleCrypt extends JObject
 	 *
 	 * @param   string  $key  Optional encryption key
 	 *
-	 * @return  void
+	 * @return  JSimpleCrypt
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/utilities/simplexml.php
+++ b/libraries/joomla/utilities/simplexml.php
@@ -26,7 +26,7 @@ defined('JPATH_PLATFORM') or die;
  * 		The access to the root node has to be explicit in
  * 		JSimpleXML, not implicit as with PHP5. Write
  * 		$xml->document->node instead of $xml->node
- * 		You cannot acces CDATA using array syntax. Use the method data() instead
+ * 		You cannot access CDATA using array syntax. Use the method data() instead
  * 		You cannot access attributes directly with array syntax. Use attributes()
  * 		to read them.
  * 		Comments are ignored.

--- a/libraries/joomla/utilities/simplexml.php
+++ b/libraries/joomla/utilities/simplexml.php
@@ -112,8 +112,6 @@ class JSimpleXML extends JObject
 	 *
 	 * @param   array  $options  Options
 	 *
-	 * @return  mixed  Boolean false if xml_parser_create is not defined.
-	 *
 	 * @deprecated    12.1   Use SimpleXML instead.
 	 * @see           http://www.php.net/manual/en/book.simplexml.php
 	 * @since    11.1
@@ -509,8 +507,6 @@ class JSimpleXMLElement extends JObject
 	 * @param   string   $name   The name of the element.
 	 * @param   array    $attrs  A key-value array (optional) of the attributes for the element.
 	 * @param   integer  $level  The level (optional) of the element.
-	 *
-	 * @return  JSimpleXMLElement
 	 *
 	 * @deprecated  12.1 Use SimpleXMLElement
 	 * @since   11.1

--- a/libraries/joomla/utilities/xmlelement.php
+++ b/libraries/joomla/utilities/xmlelement.php
@@ -70,7 +70,7 @@ class JXMLElement extends SimpleXMLElement
 	 * Return a well-formed XML string based on SimpleXML element
 	 *
 	 * @param   boolean  $compressed  Should we use indentation and newlines ?
-	 * @param   integer  $indent      Indentaion level.
+	 * @param   integer  $indent      Indention level.
 	 * @param   integer  $level       The level within the document which informs the indentation.
 	 *
 	 * @return  string


### PR DESCRIPTION
Using the code inspector in PhpStorm, evaluated the following conditions from the results:
- Spelling errors (specifically in code comments and doc blocks)
- A method declared void should not return anything
- Doc block doesn't match method declaration

There was also an instance of DatabaseException that I saw while looking through the results that I switched to JDatabaseException.
