### PR TITLE
Coding standards: Constructor and destructor comments must not have a @return tag.

### DIFF
--- a/build/phpcs/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/build/phpcs/Joomla/Sniffs/Commenting/FunctionCommentSniff.php
@@ -302,6 +302,15 @@ class Joomla_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer_S
             	}
             }
         }
+        else
+        {
+        	if ($this->commentParser->getReturn() != null)
+        	{
+        		$error    = 'Constructor and destructor comments must not have a @return tag';
+        		$errorPos = ($this->commentParser->getReturn()->getLine() + $commentStart);
+        		$this->currentFile->addError($error, $errorPos, 'UselessReturn');
+        	}
+        }
     }//end processReturn()
 
 

--- a/libraries/joomla/client/ftp.php
+++ b/libraries/joomla/client/ftp.php
@@ -186,8 +186,6 @@ class JFTP
 	 *
 	 * Closes an existing connection, if we have one
 	 *
-	 * @return  void
-	 *
 	 * @since   11.1
 	 */
 	public function __destruct()

--- a/libraries/joomla/client/http.php
+++ b/libraries/joomla/client/http.php
@@ -63,8 +63,6 @@ class JHttp
 	/**
 	 * Destructor.
 	 *
-	 * @return  void
-	 *
 	 * @since   11.1
 	 */
 	public function __destruct()

--- a/libraries/joomla/database/database/mysql.php
+++ b/libraries/joomla/database/database/mysql.php
@@ -119,8 +119,6 @@ class JDatabaseMySQL extends JDatabase
 	/**
 	 * Destructor.
 	 *
-	 * @return  void
-	 *
 	 * @since   11.1
 	 */
 	public function __destruct()

--- a/libraries/joomla/database/database/mysqli.php
+++ b/libraries/joomla/database/database/mysqli.php
@@ -151,8 +151,6 @@ class JDatabaseMySQLi extends JDatabase
 	/**
 	 * Destructor.
 	 *
-	 * @return  void
-	 *
 	 * @since   11.1
 	 */
 	public function __destruct()

--- a/libraries/joomla/database/database/sqlsrv.php
+++ b/libraries/joomla/database/database/sqlsrv.php
@@ -140,8 +140,6 @@ class JDatabaseSQLSrv extends JDatabase
 	/**
 	 * Destructor.
 	 *
-	 * @return  void
-	 *
 	 * @since   11.1
 	 */
 	public function __destruct()

--- a/libraries/joomla/filesystem/stream.php
+++ b/libraries/joomla/filesystem/stream.php
@@ -148,8 +148,6 @@ class JStream extends JObject
 	/**
 	 * Destructor
 	 *
-	 * @return  void
-	 *
 	 * @since   11.1
 	 */
 	function __destruct()

--- a/libraries/joomla/html/toolbar/button/standard.php
+++ b/libraries/joomla/html/toolbar/button/standard.php
@@ -30,7 +30,7 @@ class JButtonStandard extends JButton
 	 *
 	 * @param   string   $type  Unused string.
 	 * @param   string   $name  The name of the button icon class.
-	 * @param   string    $text  Button text.
+	 * @param   string   $text  Button text.
 	 * @param   string   $task  Task associated with the button.
 	 * @param   boolean  $list  True to allow lists
 	 *

--- a/libraries/joomla/log/loggers/formattedtext.php
+++ b/libraries/joomla/log/loggers/formattedtext.php
@@ -110,8 +110,6 @@ class JLoggerFormattedText extends JLogger
 	/**
 	 * Destructor.
 	 *
-	 * @return  void
-	 *
 	 * @since   11.1
 	 */
 	public function __destruct()

--- a/libraries/joomla/log/loggers/syslog.php
+++ b/libraries/joomla/log/loggers/syslog.php
@@ -96,8 +96,6 @@ class JLoggerSysLog extends JLogger
 	/**
 	 * Destructor.
 	 *
-	 * @return  void
-	 *
 	 * @since   11.1
 	 */
 	public function __destruct()


### PR DESCRIPTION
This was ment to be added to #462... You are merging too fast ;)
- Removes the `@return` tags from class destructors.
- Fixes the function comment sniff to detect a `@return` tag in class constructors and destructors docblocks.
