### PR TITLE
Fix JDatabase::getConnectors and add a databaseconnection field

### DIFF
--- a/libraries/joomla/database/database.php
+++ b/libraries/joomla/database/database.php
@@ -173,26 +173,28 @@ abstract class JDatabase implements JDatabaseInterface
 		$connectors = array();
 
 		// Get a list of types.
-		$types = JFolder::folders(dirname(__FILE__));
+		$types = JFolder::files(dirname(__FILE__).'/database');
 
 		// Loop through the types and find the ones that are available.
 		foreach ($types as $type)
 		{
-			// Ignore some folders.
-			if (($type == 'database') || ($type == 'table') || ($type == '.') || ($type == '..'))
+			// Ignore some files.
+			if (($type == 'index.html') || stripos($type,'importer') || stripos($type,'exporter') || stripos($type,'query') || stripos($type,'exception'))
 			{
 				continue;
 			}
 
 			// Derive the class name from the type.
-			$class = 'JDatabaseDriver' . ucfirst(trim($type));
+			$class = str_ireplace(array('.php', 'sql'), array('', 'SQL'), 'JDatabase' . ucfirst(trim($type)));
+
 
 			// If the class doesn't exist, let's look for it and register it.
 			if (!class_exists($class))
 			{
 
+
 				// Derive the file path for the driver class.
-				$path = dirname(__FILE__) . '/' . $type . '/driver.php';
+				$path = dirname(__FILE__) . '/database/' . $type;
 
 				// If the file exists register the class with our class loader.
 				if (file_exists($path))
@@ -215,8 +217,8 @@ abstract class JDatabase implements JDatabaseInterface
 			// Sweet!  Our class exists, so now we just need to know if it passes it's test method.
 			if (call_user_func_array(array($class, 'test'), array()))
 			{
-				$connectors[] = $type;
-			}
+				// Connector names should not have file extensions.
+				$connectors[] = str_ireplace('.php','',$type);			}
 		}
 
 		return $connectors;

--- a/libraries/joomla/database/database.php
+++ b/libraries/joomla/database/database.php
@@ -218,7 +218,8 @@ abstract class JDatabase implements JDatabaseInterface
 			if (call_user_func_array(array($class, 'test'), array()))
 			{
 				// Connector names should not have file extensions.
-				$connectors[] = str_ireplace('.php','',$type);			}
+				$connectors[] = str_ireplace('.php','',$type);			
+			}
 		}
 
 		return $connectors;

--- a/libraries/joomla/form/fields/databaseconnection.php
+++ b/libraries/joomla/form/fields/databaseconnection.php
@@ -1,0 +1,81 @@
+<?php
+/**
+* @package     Joomla.Platform
+* @subpackage  Form
+*
+* @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+* @license     GNU General Public License version 2 or later; see LICENSE
+*/
+
+defined('JPATH_PLATFORM') or die();
+
+jimport('joomla.database.database');
+jimport('joomla.html.html');
+jimport('joomla.form.formfield');
+jimport('joomla.form.helper');
+JFormHelper::loadFieldClass('list');
+
+/**
+* Form Field class for the Joomla Platform.
+* Provides a list of available database connections, optionally limiting to
+* a given list.
+*
+* @package     Joomla.Platform
+* @subpackage  Form
+* @see         JDatabase
+* @since       11.3
+*/
+class JFormFieldDatabaseConnection extends JFormFieldList
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var    string
+	 * @since  11.3
+	 */
+	public $type = 'DatabaseConnection';
+
+	/**
+	 * Method to get the list of database options.
+	 * 
+	 * This method produces a drop down list of available databases supported
+	 * by JDatabase drivers that are also supported by the application. 
+	 *
+	 * @return  array    The field option objects.
+	 *
+	 * @since   11.3
+	 * @see		JDatabase
+	 */
+	protected function getOptions()
+	{
+		// Initialize variables.
+		// This gets the connectors available in the platform and supported by the server.
+		$available = JDatabase::getConnectors();
+		
+		/**
+		 * This gets the list of database types supported by the application. 
+		 * This should be entered in the form definition as a comma separated list.
+		 * If no supported databases are listed, it is assumed all available databases
+		 * are supported.
+		 */
+		$supported =  $this->element['supported'];
+		if (!empty($supported))
+		{
+			$supported =  explode (',',$supported);
+			foreach ($supported as $support)
+			{
+				if (in_array($support,$available))
+				{
+					$options[$support] = $support;
+				}
+			}
+		}
+		// This will come into play if an application is installed that requires 
+		// a database that is not available on the server.
+		if (empty($options))
+		{
+			$options[''] = JText::_('JNONE');
+		}
+		return $options;
+	}	
+}

--- a/libraries/joomla/form/fields/databaseconnection.php
+++ b/libraries/joomla/form/fields/databaseconnection.php
@@ -51,7 +51,7 @@ class JFormFieldDatabaseConnection extends JFormFieldList
 		// Initialize variables.
 		// This gets the connectors available in the platform and supported by the server.
 		$available = JDatabase::getConnectors();
-		
+
 		/**
 		 * This gets the list of database types supported by the application. 
 		 * This should be entered in the form definition as a comma separated list.
@@ -64,9 +64,10 @@ class JFormFieldDatabaseConnection extends JFormFieldList
 			$supported =  explode (',',$supported);
 			foreach ($supported as $support)
 			{
+				$support = $support;
 				if (in_array($support,$available))
 				{
-					$options[$support] = $support;
+					$options[$support] = ucfirst($support);
 				}
 			}
 		}
@@ -79,3 +80,4 @@ class JFormFieldDatabaseConnection extends JFormFieldList
 		return $options;
 	}	
 }
+

--- a/libraries/joomla/form/fields/databaseconnection.php
+++ b/libraries/joomla/form/fields/databaseconnection.php
@@ -64,7 +64,6 @@ class JFormFieldDatabaseConnection extends JFormFieldList
 			$supported =  explode (',',$supported);
 			foreach ($supported as $support)
 			{
-				$support = $support;
 				if (in_array($support,$available))
 				{
 					$options[$support] = ucfirst($support);

--- a/tests/suite/joomla/form/fields/JFormFieldDatabaseConnectionTest.php
+++ b/tests/suite/joomla/form/fields/JFormFieldDatabaseConnectionTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Form
+ *
+ * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Test class for JForm.
+ *
+ * @package		Joomla.UnitTest
+ * @subpackage  Form
+ */
+class JFormFieldDatabaseConnectionTest extends JoomlaTestCase
+{
+	/**
+	 * Sets up dependancies for the test.
+	 */
+	protected function setUp()
+	{
+		jimport('joomla.form.form');
+		jimport('joomla.form.formfield');
+		require_once JPATH_PLATFORM.'/joomla/form/fields/databaseconnection.php';
+		include_once dirname(dirname(__FILE__)).'/inspectors.php';
+	}
+
+	/**
+	 * Test the getInput method.
+	 */
+	public function testGetInput()
+	{
+		$form = new JFormInspector('form1');
+
+		$this->assertThat(
+			$form->load('<form><field name="databaseconnection" type="databaseconnection" /></form>'),
+			$this->isTrue(),
+			'Line:'.__LINE__.' XML string should load successfully.'
+		);
+
+		$field = new JFormFieldDatabaseconnection($form);
+
+		$this->assertThat(
+			$field->setup($form->getXml()->field, 'value'),
+			$this->isTrue(),
+			'Line:'.__LINE__.' The setup method should return true.'
+		);
+
+		$this->markTestIncomplete('Problems encountered in next assertion');
+
+		$this->assertThat(
+			strlen($field->input),
+			$this->greaterThan(0),
+			'Line:'.__LINE__.' The getInput method should return something without error.'
+		);
+
+		// TODO: Should check all the attributes have come in properly.
+	}
+}


### PR DESCRIPTION
This addresses some problems in getConnectors which made it not work with the current file structure in the database folder and with the newer naming conventions for the database class. 
It also adds a new field that uses getConnectors to dynamically create a list of available database connection/driver combinations optionally constrained to a list of supported databases for the application.

This will be important for multidatabase support since not all servers will support all databases and not all applications will support all available drivers.
