### PR TITLE
Removed test because server is not publicly accessible.

### DIFF
--- a/tests/suite/joomla/client/JHttpTest.php
+++ b/tests/suite/joomla/client/JHttpTest.php
@@ -34,13 +34,7 @@ class JHttpTest extends PHPUnit_Framework_TestCase
 				'http://github.com',
 				// Expected hash key for the connection.
 				md5('github.com'.'80')
-			),
-			'Basic test with port' => array(
-				// String url.
-				'http://build.joomla.org:8080',
-				// Expected hash key for the connection.
-				md5('build.joomla.org'.'8080')
-			),
+			)
 		);
 	}
 


### PR DESCRIPTION
build.joomla.org:8080 is not publicly accessible.  As a result the test will fail on most systems.
