### PR TITLE
Modified JDaemon test to prevent writing files in global tmp directory.

### DIFF
--- a/tests/suite/joomla/application/cli/JDaemonTest.php
+++ b/tests/suite/joomla/application/cli/JDaemonTest.php
@@ -90,8 +90,15 @@ class JDaemonTest extends JoomlaTestCase
 	 */
 	 public static function tearDownAfterClass()
 	 {
-		 ini_restore('memory_limit');
-		 parent::tearDownAfterClass();
+		$pidPath = JPATH_BASE . '/jdaemontest.pid';
+
+		if (file_exists($pidPath))
+		{
+			unlink($pidPath);
+		}
+
+		ini_restore('memory_limit');
+		parent::tearDownAfterClass();
 	 }
 
 	/**
@@ -260,6 +267,17 @@ class JDaemonTest extends JoomlaTestCase
 	 */
 	public function testWriteProcessIdFile()
 	{
+		$pidPath = JPATH_BASE . '/jdaemontest.pid';
+
+		if (file_exists($pidPath))
+		{
+			unlink($pidPath);
+		}
+
+		// we set a custom process id file path so that we don't interfere
+		// with other tests that are running on a system
+		$this->inspector->set('application_pid_file', $pidPath);
+
 		// Get the current process id and set it to the daemon instance.
 		$pid = (int) posix_getpid();
 		$this->inspector->setClassProperty('processId', $pid);


### PR DESCRIPTION
On the build server we have tests running under two different accounts.  They both try to write to the same pid file and this causes problems.  This modification to the tests fixes that issue.
