### PR TITLE
JUpdater does not work for components

### DIFF
--- a/docs/manual/appendices/changelog.xml
+++ b/docs/manual/appendices/changelog.xml
@@ -1137,6 +1137,9 @@ http://groups.google.com/group/joomla-dev-framework/browse_thread/thread/2bbd283
 )</para>
 				<para>The function getUserState in the JApplication class is missing the $default parameter</para>
 			</listitem>
+			<listitem>
+				<para>JUpdater does not work for components if their XML update element did not explicitly include a folder and client_id child node</para>
+			</listitem>
     </itemizedlist>
   </sect1>
 </appendix>

--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -43,6 +43,8 @@ class JUpdaterExtension extends JUpdateAdapter
 				$this->current_update = JTable::getInstance('update');
 				$this->current_update->update_site_id = $this->_update_site_id;
 				$this->current_update->detailsurl = $this->_url;
+				$this->current_update->folder = "";
+				$this->current_update->client_id = 1;
 				break;
 			// Don't do anything
 			case 'UPDATES':


### PR DESCRIPTION
JUpdater does not work for components if their XML update element did not explicitly include a folder and client_id child node. This is undesirable, because it is always folder="" and client_id=1 for components. The workaround is to set these values as defaults in JUpdaterExtension. Plugins, modules and templates don't have a problem, as they do specify those elements when necessary.

This pull request is a follow-up to the Joomla! CMS tracker item #27023 (http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=27023) and the related discussion on the Joomla! Dev General list (https://groups.google.com/forum/#!topic/joomla-dev-general/R4g0-Q2pWXk)
