### PR TITLE
Add JForm field type 'Image'

### DIFF
--- a/libraries/joomla/form/fields/image.php
+++ b/libraries/joomla/form/fields/image.php
@@ -34,6 +34,7 @@ class JFormFieldImage extends JFormField
 	 * Use attributes to identify specific fields
 	 *
 	 * @return  string  The field input markup.
+	 *
 	 * @since   11.3
 	 */
 	protected function getInput()
@@ -64,6 +65,5 @@ class JFormFieldImage extends JFormField
 					' id="' . $this->id . '"' . $attr . ' />';
 
 		return implode("\n", $html);
-		
 	}
 }

--- a/libraries/joomla/form/fields/image.php
+++ b/libraries/joomla/form/fields/image.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Form
+ *
+ * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+jimport('joomla.form.formfield');
+
+/**
+ * Form Field class for the Joomla Platform.
+ * Provides an embedded Image preview
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Form
+ * @since       11.3
+ */
+class JFormFieldImage extends JFormField
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var    string
+	 * @since  11.3
+	 */
+	protected $type = 'Image';
+
+	/**
+	 * Method to get the field input markup for the image.
+	 * Use attributes to identify specific fields
+	 *
+	 * @return  string  The field input markup.
+	 * @since   11.3
+	 */
+	protected function getInput()
+	{
+		// Initialize attributes
+		$attr = '';
+
+		// Initialize some field attributes.
+		$attr .= $this->element['class'] ? ' class="'.(string) $this->element['class'].'"' : '';
+
+		// Initialize JavaScript field attributes.
+		$attr .= $this->element['onclick'] ? ' onclick="'.(string) $this->element['onclick'].'"' : '';
+
+		// Set directory
+		$directory = (string) $this->element['directory'];
+
+		// Compile source
+		$src = JURI::base(true) . '/' . $directory . '/' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8');
+
+		$html = array();
+
+		// The image container and tag
+		$html[] = '<div class="fltlft">';
+		$html[] = ' <img src="'. $src .'"'.
+					' id="'. $this->id .'"'.$attr.' />';
+		$html[] = '</div>';
+
+		return implode("\n", $html);
+	}
+}

--- a/libraries/joomla/form/fields/image.php
+++ b/libraries/joomla/form/fields/image.php
@@ -61,7 +61,7 @@ class JFormFieldImage extends JFormField
 		$html = array();
 
 		// The image container and tag
-		$html[] = ' <img src="' . $src . '"'.
+		$html[] = ' <img src="' . $src . '"' .
 					' id="' . $this->id . '"' . $attr . ' />';
 
 		return implode("\n", $html);

--- a/libraries/joomla/form/fields/image.php
+++ b/libraries/joomla/form/fields/image.php
@@ -42,14 +42,14 @@ class JFormFieldImage extends JFormField
 		$attr = '';
 
 		// Initialize some field attributes.
-		$attr .= $this->element['class'] ? ' class="'.(string) $this->element['class'].'"' : '';
-		$attr .= $this->element['alt'] ? ' alt="'.(string) $this->element['alt'].'"' : '';
-		$attr .= $this->element['title'] ? ' title="'.(string) $this->element['title'].'"' : '';
-		$attr .= $this->element['width'] ? ' width="'.(string) $this->element['width'].'"' : '';
-		$attr .= $this->element['height'] ? ' height="'.(string) $this->element['height'].'"' : '';
-		
+		$attr .= $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$attr .= $this->element['alt'] ? ' alt="' . (string) $this->element['alt'] . '"' : '';
+		$attr .= $this->element['title'] ? ' title="' . (string) $this->element['title'] . '"' : '';
+		$attr .= $this->element['width'] ? ' width="' . (string) $this->element['width'] . '"' : '';
+		$attr .= $this->element['height'] ? ' height="' . (string) $this->element['height'] . '"' : '';
+
 		// Initialize JavaScript field attributes.
-		$attr .= $this->element['onclick'] ? ' onclick="'.(string) $this->element['onclick'].'"' : '';
+		$attr .= $this->element['onclick'] ? ' onclick="' . (string) $this->element['onclick'] . '"' : '';
 
 		// Set directory
 		$directory = (string) $this->element['directory'];
@@ -60,9 +60,10 @@ class JFormFieldImage extends JFormField
 		$html = array();
 
 		// The image container and tag
-		$html[] = ' <img src="'. $src .'"'.
-					' id="'. $this->id .'"'.$attr.' />';
+		$html[] = ' <img src="' . $src . '"'.
+					' id="' . $this->id . '"' . $attr . ' />';
 
 		return implode("\n", $html);
+		
 	}
 }

--- a/libraries/joomla/form/fields/image.php
+++ b/libraries/joomla/form/fields/image.php
@@ -43,7 +43,11 @@ class JFormFieldImage extends JFormField
 
 		// Initialize some field attributes.
 		$attr .= $this->element['class'] ? ' class="'.(string) $this->element['class'].'"' : '';
-
+		$attr .= $this->element['alt'] ? ' alt="'.(string) $this->element['alt'].'"' : '';
+		$attr .= $this->element['title'] ? ' title="'.(string) $this->element['title'].'"' : '';
+		$attr .= $this->element['width'] ? ' width="'.(string) $this->element['width'].'"' : '';
+		$attr .= $this->element['height'] ? ' height="'.(string) $this->element['height'].'"' : '';
+		
 		// Initialize JavaScript field attributes.
 		$attr .= $this->element['onclick'] ? ' onclick="'.(string) $this->element['onclick'].'"' : '';
 
@@ -51,15 +55,13 @@ class JFormFieldImage extends JFormField
 		$directory = (string) $this->element['directory'];
 
 		// Compile source
-		$src = JURI::base(true) . '/' . $directory . '/' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8');
+		$src = JURI::root(true) . '/' . $directory . '/' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8');
 
 		$html = array();
 
 		// The image container and tag
-		$html[] = '<div class="fltlft">';
 		$html[] = ' <img src="'. $src .'"'.
 					' id="'. $this->id .'"'.$attr.' />';
-		$html[] = '</div>';
 
 		return implode("\n", $html);
 	}


### PR DESCRIPTION
Images is used for a variety of purposes, so the platform should have at least some basic capability to show an image within a form.
This new form field type is very basic, but yet it should be powerfull enough to support showing an images within any form.
