### PR TITLE
JModellist: Replacing !empty() with isset() for performance

### DIFF
--- a/libraries/joomla/application/component/modellist.php
+++ b/libraries/joomla/application/component/modellist.php
@@ -118,7 +118,7 @@ class JModelList extends JModel
 		$store = $this->getStoreId();
 
 		// Try to load the data from internal storage.
-		if (!empty($this->cache[$store]))
+		if (isset($this->cache[$store]))
 		{
 			return $this->cache[$store];
 		}
@@ -168,7 +168,7 @@ class JModelList extends JModel
 		$store = $this->getStoreId('getPagination');
 
 		// Try to load the data from internal storage.
-		if (!empty($this->cache[$store]))
+		if (isset($this->cache[$store]))
 		{
 			return $this->cache[$store];
 		}
@@ -221,7 +221,7 @@ class JModelList extends JModel
 		$store = $this->getStoreId('getTotal');
 
 		// Try to load the data from internal storage.
-		if (!empty($this->cache[$store]))
+		if (isset($this->cache[$store]))
 		{
 			return $this->cache[$store];
 		}
@@ -255,7 +255,7 @@ class JModelList extends JModel
 		$store = $this->getStoreId('getstart');
 
 		// Try to load the data from internal storage.
-		if (!empty($this->cache[$store]))
+		if (isset($this->cache[$store]))
 		{
 			return $this->cache[$store];
 		}


### PR DESCRIPTION
JModellist uses !empty() to check for cached data. If the query returned an empty result, the array key is set, but the variable is empty, thus the caching does not take effect and the query is executed again when the function is called again. Using isset() instead only checks if the variable has already been set (=the query has been executed) and then returns that result, regardless if that result is empty or not.
