### PR TITLE
Add variable type context to JDatabase getQuery method and JTable _db property.

### DIFF
--- a/libraries/joomla/database/database.php
+++ b/libraries/joomla/database/database.php
@@ -650,11 +650,11 @@ abstract class JDatabase implements JDatabaseInterface
 	}
 
 	/**
-	 * Get the current or query, or new JDatabaseQuery object.
+	 * Get the current query object or a new JDatabaseQuery object.
 	 *
-	 * @param   boolean  $new  False to return the last query set, True to return a new JDatabaseQuery object.
+	 * @param   boolean  $new  False to return the current query object, True to return a new JDatabaseQuery object.
 	 *
-	 * @return  mixed  The current value of the internal SQL variable or a new JDatabaseQuery object.
+	 * @return  JDatabaseQuery  The current query object or a new object extending the JDatabaseQuery class.
 	 *
 	 * @since   11.1
 	 * @throws  JDatabaseException

--- a/libraries/joomla/database/table.php
+++ b/libraries/joomla/database/table.php
@@ -41,7 +41,7 @@ abstract class JTable extends JObject
 	/**
 	 * JDatabase connector object.
 	 *
-	 * @var    object
+	 * @var    JDatabase
 	 * @since  11.1
 	 */
 	protected $_db;


### PR DESCRIPTION
I know this is technically not correct as the classes mentioned are not used but the extending classes but... it would make the following auto complete available in modern IDEs for the base classes - you decide ;)

``` php
<?php
class MyTable extends JTable 
{
    function foo() 
    {
        $query = $this->_db->//-- Auto complete for JDatabase

        $query = $this->_db->getQuery(true)

        $query->//--Auto complete for JDatabaseQuery
    }
}
```
