### PR TITLE
Adding a true autoloader to the Joomla Platform.

### DIFF
--- a/libraries/import.php
+++ b/libraries/import.php
@@ -47,6 +47,9 @@ if (!class_exists('JLoader'))
 	require_once JPATH_PLATFORM . '/loader.php';
 }
 
+// Setup the autoloaders.
+JLoader::setup();
+
 /**
  * Import the base Joomla Platform libraries.
  */

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -8,10 +8,6 @@
 
 defined('JPATH_PLATFORM') or die;
 
-// Register relevant autoload methods.
-spl_autoload_register(array('JLoader', 'load'));
-spl_autoload_register(array('JLoader', 'autoload'));
-
 /**
  * Static class to handle loading of libraries.
  *
@@ -35,74 +31,6 @@ abstract class JLoader
 	 * @since  11.1
 	 */
 	protected static $classes = array();
-
-	/**
-	 * Loads a class from specified directories.
-	 *
-	 * @param   string   $key   The class name to look for (dot notation).
-	 * @param   string   $base  Search this directory for the class.
-	 *
-	 * @return  boolean  True on success.
-	 *
-	 * @since   11.1
-	 */
-	public static function import($key, $base = null)
-	{
-		// Only import the library if not already attempted.
-		if (!isset(self::$imported[$key]))
-		{
-			// Setup some variables.
-			$success = false;
-			$parts = explode('.', $key);
-			$class = array_pop($parts);
-			$base = (!empty($base)) ? $base : dirname(__FILE__);
-			$path = str_replace('.', DS, $key);
-
-			// Handle special case for helper classes.
-			if ($class == 'helper')
-			{
-				$class = ucfirst(array_pop($parts)) . ucfirst($class);
-			}
-			// Standard class.
-			else
-			{
-				$class = ucfirst($class);
-			}
-
-			// If we are importing a library from the Joomla namespace set the class to autoload.
-			if (strpos($path, 'joomla') === 0)
-			{
-
-				// Since we are in the Joomla namespace prepend the classname with J.
-				$class = 'J' . $class;
-
-				// Only register the class for autoloading if the file exists.
-				if (is_file($base . '/' . $path . '.php'))
-				{
-					self::$classes[strtolower($class)] = $base . '/' . $path . '.php';
-					$success = true;
-				}
-			}
-			/*
-			 * If we are not importing a library from the Joomla namespace directly include the
-			 * file since we cannot assert the file/folder naming conventions.
-			 */
-			else
-			{
-
-				// If the file exists attempt to include it.
-				if (is_file($base . '/' . $path . '.php'))
-				{
-					$success = (bool) include_once $base . '/' . $path . '.php';
-				}
-			}
-
-			// Add the import key to the memory cache container.
-			self::$imported[$key] = $success;
-		}
-
-		return self::$imported[$key];
-	}
 
 	/**
 	 * Method to discover classes of a given type in a given path.
@@ -170,30 +98,71 @@ abstract class JLoader
 	}
 
 	/**
-	 * Directly register a class to the autoload list.
+	 * Loads a class from specified directories.
 	 *
-	 * @param   string   $class  The class name to register.
-	 * @param   string   $path   Full path to the file that holds the class to register.
-	 * @param   boolean  $force  True to overwrite the autoload path value for the class if it already exists.
+	 * @param   string   $key   The class name to look for (dot notation).
+	 * @param   string   $base  Search this directory for the class.
 	 *
-	 * @return  void
+	 * @return  boolean  True on success.
 	 *
 	 * @since   11.1
 	 */
-	public static function register($class, $path, $force = true)
+	public static function import($key, $base = null)
 	{
-		// Sanitize class name.
-		$class = strtolower($class);
-
-		// Only attempt to register the class if the name and file exist.
-		if (!empty($class) && is_file($path))
+		// Only import the library if not already attempted.
+		if (!isset(self::$imported[$key]))
 		{
-			// Register the class with the autoloader if not already registered or the force flag is set.
-			if (empty(self::$classes[$class]) || $force)
+			// Setup some variables.
+			$success = false;
+			$parts = explode('.', $key);
+			$class = array_pop($parts);
+			$base = (!empty($base)) ? $base : dirname(__FILE__);
+			$path = str_replace('.', DS, $key);
+
+			// Handle special case for helper classes.
+			if ($class == 'helper')
 			{
-				self::$classes[$class] = $path;
+				$class = ucfirst(array_pop($parts)) . ucfirst($class);
 			}
+			// Standard class.
+			else
+			{
+				$class = ucfirst($class);
+			}
+
+			// If we are importing a library from the Joomla namespace set the class to autoload.
+			if (strpos($path, 'joomla') === 0)
+			{
+
+				// Since we are in the Joomla namespace prepend the classname with J.
+				$class = 'J' . $class;
+
+				// Only register the class for autoloading if the file exists.
+				if (is_file($base . '/' . $path . '.php'))
+				{
+					self::$classes[strtolower($class)] = $base . '/' . $path . '.php';
+					$success = true;
+				}
+			}
+			/*
+			 * If we are not importing a library from the Joomla namespace directly include the
+			* file since we cannot assert the file/folder naming conventions.
+			*/
+			else
+			{
+
+				// If the file exists attempt to include it.
+				if (is_file($base . '/' . $path . '.php'))
+				{
+					$success = (bool) include_once $base . '/' . $path . '.php';
+				}
+			}
+
+			// Add the import key to the memory cache container.
+			self::$imported[$key] = $success;
 		}
+
+		return self::$imported[$key];
 	}
 
 	/**
@@ -227,22 +196,59 @@ abstract class JLoader
 	}
 
 	/**
+	 * Directly register a class to the autoload list.
+	 *
+	 * @param   string   $class  The class name to register.
+	 * @param   string   $path   Full path to the file that holds the class to register.
+	 * @param   boolean  $force  True to overwrite the autoload path value for the class if it already exists.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.1
+	 */
+	public static function register($class, $path, $force = true)
+	{
+		// Sanitize class name.
+		$class = strtolower($class);
+
+		// Only attempt to register the class if the name and file exist.
+		if (!empty($class) && is_file($path))
+		{
+			// Register the class with the autoloader if not already registered or the force flag is set.
+			if (empty(self::$classes[$class]) || $force)
+			{
+				self::$classes[$class] = $path;
+			}
+		}
+	}
+
+	/**
+	 * Method to setup the autoloaders for the Joomla Platform.  Since the SPL autoloaders are
+	 * called in a queue we will add our explicit, class-registration based loader first, then
+	 * fall back on the autoloader based on conventions.  This will allow people to register a
+	 * class in a specific location and override platform libraries as was previously possible.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public static function setup()
+	{
+		spl_autoload_register(array('JLoader', 'load'));
+		spl_autoload_register(array('JLoader', '_autoload'));
+	}
+
+	/**
 	 * Autoload a Joomla Platform class based on name.
 	 *
 	 * @param   string   $class  The class to be loaded.
 	 *
-	 * @return  boolean  True on success
+	 * @return  void
 	 *
 	 * @since   11.3
 	 */
-	public static function autoload($class)
+	private static function _autoload($class)
 	{
-		// If the class already exists do nothing.
-		if (class_exists($class))
-		{
-			return true;
-		}
-
 		// Only attempt autoloading if we are dealing with a Joomla Platform class.
 		if ($class[0] == 'J')
 		{
@@ -255,15 +261,12 @@ abstract class JLoader
 			// Generate the path based on the class name parts.
 			$path = JPATH_PLATFORM . '/joomla/' . implode('/', array_map('strtolower', $parts)) . '.php';
 
-			// Load the file.
+			// Load the file if it exists.
 			if (file_exists($path))
 			{
-				include_once $path;
-				return true;
+				include $path;
 			}
 		}
-
-		return false;
 	}
 }
 

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -8,8 +8,9 @@
 
 defined('JPATH_PLATFORM') or die;
 
-// Register JLoader::load as an autoload class handler.
+// Register relevant autoload methods.
 spl_autoload_register(array('JLoader', 'load'));
+spl_autoload_register(array('JLoader', 'autoload'));
 
 /**
  * Static class to handle loading of libraries.
@@ -220,6 +221,46 @@ abstract class JLoader
 		{
 			include_once self::$classes[$class];
 			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Autoload a Joomla Platform class based on name.
+	 *
+	 * @param   string   $class  The class to be loaded.
+	 *
+	 * @return  boolean  True on success
+	 *
+	 * @since   11.3
+	 */
+	public static function autoload($class)
+	{
+		// If the class already exists do nothing.
+		if (class_exists($class))
+		{
+			return true;
+		}
+
+		// Only attempt autoloading if we are dealing with a Joomla Platform class.
+		if ($class[0] == 'J')
+		{
+			// Split the class name (without the J) into parts separated by camelCase.
+			$parts = preg_split('/(?<=[a-z])(?=[A-Z])/x',substr($class, 1));
+
+			// If there is only one part we want to duplicate that part for generating the path.
+			$parts = (count($parts) === 1) ? array($parts[0], $parts[0]) : $parts;
+
+			// Generate the path based on the class name parts.
+			$path = JPATH_PLATFORM . '/joomla/' . implode('/', array_map('strtolower', $parts)) . '.php';
+
+			// Load the file.
+			if (file_exists($path))
+			{
+				include_once $path;
+				return true;
+			}
 		}
 
 		return false;


### PR DESCRIPTION
As of now there is no such thing as a true autoloader for the Joomla Platform.  What we have is a way to explicitly register files with a loader class to be lazy-loaded when necessary.

This pull request adds another method to the SPL autoloader queue that would provide true autoloading functionality for classes that follow a given naming convention for files and class names without having to use `jimport()` or `JLoader` explicitly.

To leverage the autoloader the following conventions must be met:

**Class Names**
- All class names must be prefixed with an upper-case **J** to indicate that the class file will be found within the `libraries/joomla` folder.
-  All class names must be in camel case where the first character after the **J** prefix is upper-case.  For example: `JClass` or `JClassExtended`

**Class File Paths**
- The first _sections_ of a class name indicate the folder path for the class file, and the final _section_ of the class name indicates the class file name.  For the example `JClassExtended` **J** indicates a Joomla library, **Class** indicates the folder path, and **Extended** indicates the file name for the class.  Therefore within `libraries/joomla/class/extended.php` you will find the class `JClassExtended` defined.
- If there is only one section of the class name then that section is used both for a folder path and class file name.  For example `JRegistry` is found defined in the file `libraries/joomla/registry/registry.php`.
## Backward Compatability

The implementation of this new autoloader is supplemental to the current lazy-loading system and should have no impact on backward compatability.  In point of fact, the current lazy-loading system is called first by the SPL autoloading queue, then if the file is not found the new autoloader mechanism is called.  This should make it easy to transition libraries into the appropriate conventions over time without any impact to third party developers or downstream software.
## Further Example

As it happens, the Registry package is a perfect case study for the new autoloader.  With the autoloader enabled, there is no need to ever explicitly call `jimport('joomla.registry.registry');` because the classes already follow this convention perfectly.  You would just simply use JRegistry as if it is already loaded.  The class name to file path mapping is shown below:

`JRegistry` => `libraries/joomla/registry/registry.php`
`JRegistryFormat` => `libraries/joomla/registry/format.php`
`JRegistryFormatINI` => `libraries/joomla/registry/format/ini.php`
`JRegistryFormatJSON` => `libraries/joomla/registry/format/json.php`
`JRegistryFormatPHP` => `libraries/joomla/registry/format/php.php`
`JRegistryFormatXML` => `libraries/joomla/registry/format/xml.php`

_It should be noted that the autoloader gracefully handles when a segment is all caps as in the case above.  The important bit is the transition from lowercase to uppercase._
