### PR TITLE
Changing all cases of static instance variables

### DIFF
--- a/libraries/joomla/application/application.php
+++ b/libraries/joomla/application/application.php
@@ -85,6 +85,12 @@ class JApplication extends JObject
 	public $input = null;
 
 	/**
+	 * @var    array  JApplication instances container.
+	 * @since  11.3
+	 */
+	protected static $instances = array();
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param   array  $config  A configuration array including optional elements such as session
@@ -162,14 +168,7 @@ class JApplication extends JObject
 	 */
 	public static function getInstance($client, $config = array(), $prefix = 'J')
 	{
-		static $instances;
-
-		if (!isset($instances))
-		{
-			$instances = array();
-		}
-
-		if (empty($instances[$client]))
+		if (empty(self::$instances[$client]))
 		{
 			// Load the router object.
 			jimport('joomla.application.helper');
@@ -190,10 +189,10 @@ class JApplication extends JObject
 				return $error;
 			}
 
-			$instances[$client] = &$instance;
+			self::$instances[$client] = &$instance;
 		}
 
-		return $instances[$client];
+		return self::$instances[$client];
 	}
 
 	/**

--- a/libraries/joomla/application/component/controller.php
+++ b/libraries/joomla/application/component/controller.php
@@ -146,6 +146,12 @@ class JController extends JObject
 	protected $taskMap;
 
 	/**
+	 * @var    JController  JController instance container.
+	 * @since  11.3
+	 */
+	protected static $instance;
+
+	/**
 	 * Adds to the stack of model paths in LIFO order.
 	 *
 	 * @param   mixed   $path    The directory (string), or list of directories (array) to add.
@@ -222,11 +228,9 @@ class JController extends JObject
 	 */
 	public static function getInstance($prefix, $config = array())
 	{
-		static $instance;
-
-		if (!empty($instance))
+		if (is_object(self::$instance))
 		{
-			return $instance;
+			return self::$instance;
 		}
 
 		// Get the environment configuration.
@@ -290,14 +294,14 @@ class JController extends JObject
 		// Instantiate the class.
 		if (class_exists($class))
 		{
-			$instance = new $class($config);
+			self::$instance = new $class($config);
 		}
 		else
 		{
 			throw new Exception(JText::sprintf('JLIB_APPLICATION_ERROR_INVALID_CONTROLLER_CLASS', $class));
 		}
 
-		return $instance;
+		return self::$instance;
 	}
 
 	/**

--- a/libraries/joomla/application/menu.php
+++ b/libraries/joomla/application/menu.php
@@ -43,6 +43,12 @@ class JMenu extends JObject
 	protected $_active = 0;
 
 	/**
+	 * @var    array  JMenu instances container.
+	 * @since  11.3
+	 */
+	protected static $instances = array();
+
+	/**
 	 * Class constructor
 	 *
 	 * @param   array  $options  An array of configuration options.
@@ -80,14 +86,7 @@ class JMenu extends JObject
 	 */
 	public static function getInstance($client, $options = array())
 	{
-		static $instances;
-
-		if (!isset($instances))
-		{
-			$instances = array();
-		}
-
-		if (empty($instances[$client]))
+		if (empty(self::$instances[$client]))
 		{
 			//Load the router object
 			$info = JApplicationHelper::getClientInfo($client, true);
@@ -109,10 +108,10 @@ class JMenu extends JObject
 				return $error;
 			}
 
-			$instances[$client] = & $instance;
+			self::$instances[$client] = & $instance;
 		}
 
-		return $instances[$client];
+		return self::$instances[$client];
 	}
 
 	/**

--- a/libraries/joomla/application/pathway.php
+++ b/libraries/joomla/application/pathway.php
@@ -33,6 +33,12 @@ class JPathway extends JObject
 	protected $_count = 0;
 
 	/**
+	 * @var    array  JPathway instances container.
+	 * @since  11.3
+	 */
+	protected static $instances = array();
+
+	/**
 	 * Class constructor
 	 *
 	 * @param   array  $options  The class options.
@@ -57,14 +63,7 @@ class JPathway extends JObject
 	 */
 	public static function getInstance($client, $options = array())
 	{
-		static $instances;
-
-		if (!isset($instances))
-		{
-			$instances = array();
-		}
-
-		if (empty($instances[$client]))
+		if (empty(self::$instances[$client]))
 		{
 			//Load the router object
 			$info = JApplicationHelper::getClientInfo($client, true);
@@ -84,10 +83,10 @@ class JPathway extends JObject
 				return $error;
 			}
 
-			$instances[$client] = & $instance;
+			self::$instances[$client] = & $instance;
 		}
 
-		return $instances[$client];
+		return self::$instances[$client];
 	}
 
 	/**

--- a/libraries/joomla/application/router.php
+++ b/libraries/joomla/application/router.php
@@ -49,6 +49,12 @@ class JRouter extends JObject
 	protected $_rules = array('build' => array(), 'parse' => array());
 
 	/**
+	 * @var    array  JRouter instances container.
+	 * @since  11.3
+	 */
+	protected static $instances = array();
+
+	/**
 	 * Class constructor
 	 *
 	 * @param   array  $options  Array of options
@@ -80,14 +86,7 @@ class JRouter extends JObject
 	 */
 	public static function getInstance($client, $options = array())
 	{
-		static $instances;
-
-		if (!isset($instances))
-		{
-			$instances = array();
-		}
-
-		if (empty($instances[$client]))
+		if (empty(self::$instances[$client]))
 		{
 			// Load the router object
 			$info = JApplicationHelper::getClientInfo($client, true);
@@ -107,10 +106,10 @@ class JRouter extends JObject
 				return $error;
 			}
 
-			$instances[$client] = & $instance;
+			self::$instances[$client] = & $instance;
 		}
 
-		return $instances[$client];
+		return self::$instances[$client];
 	}
 
 	/**

--- a/libraries/joomla/client/ftp.php
+++ b/libraries/joomla/client/ftp.php
@@ -142,6 +142,12 @@ class JFTP
 	var $_lineEndings = array('UNIX' => "\n", 'MAC' => "\r", 'WIN' => "\r\n");
 
 	/**
+	 * @var    array  JFTP instances container.
+	 * @since  11.3
+	 */
+	protected static $instances = array();
+
+	/**
 	 * JFTP object constructor
 	 *
 	 * @param   array  $options  Associative array of options to set
@@ -217,31 +223,29 @@ class JFTP
 	 */
 	public function getInstance($host = '127.0.0.1', $port = '21', $options = null, $user = null, $pass = null)
 	{
-		static $instances = array();
-
 		$signature = $user . ':' . $pass . '@' . $host . ":" . $port;
 
 		// Create a new instance, or set the options of an existing one
-		if (!isset($instances[$signature]) || !is_object($instances[$signature]))
+		if (!isset(self::$instances[$signature]) || !is_object(self::$instances[$signature]))
 		{
-			$instances[$signature] = new JFTP($options);
+			self::$instances[$signature] = new JFTP($options);
 		}
 		else
 		{
-			$instances[$signature]->setOptions($options);
+			self::$instances[$signature]->setOptions($options);
 		}
 
 		// Connect to the server, and login, if requested
-		if (!$instances[$signature]->isConnected())
+		if (!self::$instances[$signature]->isConnected())
 		{
-			$return = $instances[$signature]->connect($host, $port);
+			$return = self::$instances[$signature]->connect($host, $port);
 			if ($return && $user !== null && $pass !== null)
 			{
-				$instances[$signature]->login($user, $pass);
+				self::$instances[$signature]->login($user, $pass);
 			}
 		}
 
-		return $instances[$signature];
+		return self::$instances[$signature];
 	}
 
 	/**

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -198,6 +198,12 @@ class JDocument extends JObject
 	public static $_buffer = null;
 
 	/**
+	 * @var    array  JDocument instances container.
+	 * @since  11.3
+	 */
+	protected static $instances = array();
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param   array  $options  Associative array of options
@@ -257,16 +263,9 @@ class JDocument extends JObject
 	 */
 	public static function getInstance($type = 'html', $attributes = array())
 	{
-		static $instances;
-
-		if (!isset($instances))
-		{
-			$instances = array();
-		}
-
 		$signature = serialize(array($type, $attributes));
 
-		if (empty($instances[$signature]))
+		if (empty(self::$instances[$signature]))
 		{
 			$type = preg_replace('/[^A-Z0-9_\.-]/i', '', $type);
 			$path = dirname(__FILE__) . '/' . $type . '/' . $type . '.php';
@@ -296,7 +295,7 @@ class JDocument extends JObject
 			}
 
 			$instance = new $class($attributes);
-			$instances[$signature] = &$instance;
+			self::$instances[$signature] = &$instance;
 
 			if (!is_null($ntype))
 			{
@@ -305,7 +304,7 @@ class JDocument extends JObject
 			}
 		}
 
-		return $instances[$signature];
+		return self::$instances[$signature];
 	}
 
 	/**

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -193,6 +193,12 @@ class JBrowser extends JObject
 	protected $_images = array('jpeg', 'gif', 'png', 'pjpeg', 'x-png', 'bmp');
 
 	/**
+	 * @var    array  JBrowser instances container.
+	 * @since  11.3
+	 */
+	protected static $instances = array();
+
+	/**
 	 * Create a browser instance (constructor).
 	 *
 	 * @param   string  $userAgent  The browser string to parse.
@@ -218,21 +224,14 @@ class JBrowser extends JObject
 	 */
 	static public function getInstance($userAgent = null, $accept = null)
 	{
-		static $instances;
-
-		if (!isset($instances))
-		{
-			$instances = array();
-		}
-
 		$signature = serialize(array($userAgent, $accept));
 
-		if (empty($instances[$signature]))
+		if (empty(self::$instances[$signature]))
 		{
-			$instances[$signature] = new JBrowser($userAgent, $accept);
+			self::$instances[$signature] = new JBrowser($userAgent, $accept);
 		}
 
-		return $instances[$signature];
+		return self::$instances[$signature];
 	}
 
 	/**

--- a/libraries/joomla/error/profiler.php
+++ b/libraries/joomla/error/profiler.php
@@ -56,6 +56,12 @@ class JProfiler extends JObject
 	protected $_iswin = false;
 
 	/**
+	 * @var    array  JProfiler instances container.
+	 * @since  11.3
+	 */
+	protected static $instances = array();
+
+	/**
 	 * Constructor
 	 *
 	 * @param   string  $prefix  Prefix for mark messages
@@ -82,19 +88,12 @@ class JProfiler extends JObject
 	 */
 	public static function getInstance($prefix = '')
 	{
-		static $instances;
-
-		if (!isset($instances))
+		if (empty(self::$instances[$prefix]))
 		{
-			$instances = array();
+			self::$instances[$prefix] = new JProfiler($prefix);
 		}
 
-		if (empty($instances[$prefix]))
-		{
-			$instances[$prefix] = new JProfiler($prefix);
-		}
-
-		return $instances[$prefix];
+		return self::$instances[$prefix];
 	}
 
 	/**

--- a/libraries/joomla/html/editor.php
+++ b/libraries/joomla/html/editor.php
@@ -49,6 +49,12 @@ class JEditor extends JObservable
 	protected $author = null;
 
 	/**
+	 * @var    array  JEditor instances container.
+	 * @since  11.3
+	 */
+	protected static $instances = array();
+
+	/**
 	 * Constructor
 	 *
 	 * @param   string  $editor  The editor name
@@ -70,21 +76,14 @@ class JEditor extends JObservable
 	 */
 	public static function getInstance($editor = 'none')
 	{
-		static $instances;
-
-		if (!isset($instances))
-		{
-			$instances = array();
-		}
-
 		$signature = serialize($editor);
 
-		if (empty($instances[$signature]))
+		if (empty(self::$instances[$signature]))
 		{
-			$instances[$signature] = new JEditor($editor);
+			self::$instances[$signature] = new JEditor($editor);
 		}
 
-		return $instances[$signature];
+		return self::$instances[$signature];
 	}
 
 	/**

--- a/libraries/joomla/installer/installer.php
+++ b/libraries/joomla/installer/installer.php
@@ -105,6 +105,12 @@ class JInstaller extends JAdapter
 	protected $redirect_url = null;
 
 	/**
+	 * @var    JInstaller  JInstaller instance container.
+	 * @since  11.3
+	 */
+	protected static $instance;
+
+	/**
 	 * Constructor
 	 *
 	 * @since   11.1
@@ -124,9 +130,7 @@ class JInstaller extends JAdapter
 	 */
 	public static function getInstance()
 	{
-		static $instance;
-
-		if (!isset($instance))
+		if (!isset(self::$instance))
 		{
 			$instance = new JInstaller;
 		}

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -22,6 +22,12 @@ jimport('joomla.mail.helper');
 class JMail extends PHPMailer
 {
 	/**
+	 * @var    array  JMail instances container.
+	 * @since  11.3
+	 */
+	protected static $instances = array();
+
+	/**
 	 * Constructor
 	 */
 	public function __construct()
@@ -45,19 +51,12 @@ class JMail extends PHPMailer
 	 */
 	public static function getInstance($id = 'Joomla')
 	{
-		static $instances;
-
-		if (!isset($instances))
+		if (empty(self::$instances[$id]))
 		{
-			$instances = array();
+			self::$instances[$id] = new JMail;
 		}
 
-		if (empty($instances[$id]))
-		{
-			$instances[$id] = new JMail;
-		}
-
-		return $instances[$id];
+		return self::$instances[$id];
 	}
 
 	/**

--- a/libraries/joomla/registry/format.php
+++ b/libraries/joomla/registry/format.php
@@ -19,6 +19,12 @@ defined('JPATH_PLATFORM') or die();
 abstract class JRegistryFormat
 {
 	/**
+	 * @var    array  JRegistryFormat instances container.
+	 * @since  11.3
+	 */
+	protected static $instances = array();
+
+	/**
 	 * Returns a reference to a Format object, only creating it
 	 * if it doesn't already exist.
 	 *
@@ -31,18 +37,11 @@ abstract class JRegistryFormat
 	 */
 	public static function getInstance($type)
 	{
-		// Initialize static variable.
-		static $instances;
-		if (!isset($instances))
-		{
-			$instances = array();
-		}
-
 		// Sanitize format type.
 		$type = strtolower(preg_replace('/[^A-Z0-9_]/i', '', $type));
 
 		// Only instantiate the object if it doesn't already exist.
-		if (!isset($instances[$type]))
+		if (!isset(self::$instances[$type]))
 		{
 			// Only load the file the class does not exist.
 			$class = 'JRegistryFormat' . $type;
@@ -59,9 +58,9 @@ abstract class JRegistryFormat
 				}
 			}
 
-			$instances[$type] = new $class;
+			self::$instances[$type] = new $class;
 		}
-		return $instances[$type];
+		return self::$instances[$type];
 	}
 
 	/**

--- a/libraries/joomla/registry/registry.php
+++ b/libraries/joomla/registry/registry.php
@@ -30,6 +30,12 @@ class JRegistry
 	protected $data;
 
 	/**
+	 * @var    array  JRegistry instances container.
+	 * @since  11.3
+	 */
+	protected static $instances = array();
+
+	/**
 	 * Constructor
 	 *
 	 * @param   mixed  $data  The data to bind to the new JRegistry object.
@@ -194,19 +200,12 @@ class JRegistry
 	 */
 	public static function getInstance($id)
 	{
-		static $instances;
-
-		if (!isset($instances))
+		if (empty(self::$instances[$id]))
 		{
-			$instances = array();
+			self::$instances[$id] = new JRegistry;
 		}
 
-		if (empty($instances[$id]))
-		{
-			$instances[$id] = new JRegistry;
-		}
-
-		return $instances[$id];
+		return self::$instances[$id];
 	}
 
 	/**

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -79,6 +79,12 @@ class JSession extends JObject
 	protected $_force_ssl = false;
 
 	/**
+	 * @var    JSession  JSession instances container.
+	 * @since  11.3
+	 */
+	protected static $instance;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   string  $store    The type of storage for the session.
@@ -145,14 +151,12 @@ class JSession extends JObject
 	 */
 	public static function getInstance($handler, $options)
 	{
-		static $instance;
-
-		if (!is_object($instance))
+		if (!is_object(self::$instance))
 		{
-			$instance = new JSession($handler, $options);
+			self::$instance = new JSession($handler, $options);
 		}
 
-		return $instance;
+		return self::$instance;
 	}
 
 	/**

--- a/libraries/joomla/session/storage.php
+++ b/libraries/joomla/session/storage.php
@@ -20,6 +20,12 @@ defined('JPATH_PLATFORM') or die();
 abstract class JSessionStorage extends JObject
 {
 	/**
+	 * @var    array  JSessionStorage instances container.
+	 * @since  11.3
+	 */
+	protected static $instances = array();
+
+	/**
 	 * Constructor
 	 *
 	 * @param   array  $options  Optional parameters.
@@ -43,16 +49,9 @@ abstract class JSessionStorage extends JObject
 	 */
 	public static function getInstance($name = 'none', $options = array())
 	{
-		static $instances;
-
-		if (!isset($instances))
-		{
-			$instances = array();
-		}
-
 		$name = strtolower(JFilterInput::getInstance()->clean($name, 'word'));
 
-		if (empty($instances[$name]))
+		if (empty(self::$instances[$name]))
 		{
 			$class = 'JSessionStorage' . ucfirst($name);
 
@@ -71,10 +70,10 @@ abstract class JSessionStorage extends JObject
 				}
 			}
 
-			$instances[$name] = new $class($options);
+			self::$instances[$name] = new $class($options);
 		}
 
-		return $instances[$name];
+		return self::$instances[$name];
 	}
 
 	/**

--- a/libraries/joomla/updater/updater.php
+++ b/libraries/joomla/updater/updater.php
@@ -27,6 +27,12 @@ jimport('joomla.log.log');
 class JUpdater extends JAdapter
 {
 	/**
+	 * @var    JUpdater  JUpdater instance container.
+	 * @since  11.3
+	 */
+	protected static $instance;
+
+	/**
 	 * Constructor
 	 *
 	 * @since   11.1
@@ -47,13 +53,11 @@ class JUpdater extends JAdapter
 	 */
 	public static function &getInstance()
 	{
-		static $instance;
-
-		if (!isset($instance))
+		if (!isset(self::$instance))
 		{
-			$instance = new JUpdater;
+			self::$instance = new JUpdater;
 		}
-		return $instance;
+		return self::$instance;
 	}
 
 	/**

--- a/libraries/joomla/user/authentication.php
+++ b/libraries/joomla/user/authentication.php
@@ -86,6 +86,12 @@ class JAuthentication extends JObservable
 	const STATUS_UNKNOWN = 32;
 
 	/**
+	 * @var    JAuthentication  JAuthentication instances container.
+	 * @since  11.3
+	 */
+	protected static $instance;
+
+	/**
 	 * Constructor
 	 *
 	 * @since   11.1
@@ -110,19 +116,12 @@ class JAuthentication extends JObservable
 	 */
 	public static function getInstance()
 	{
-		static $instances;
-
-		if (!isset($instances))
+		if (empty(self::$instance))
 		{
-			$instances = array();
+			self::$instance = new JAuthentication;
 		}
 
-		if (empty($instances[0]))
-		{
-			$instances[0] = new JAuthentication;
-		}
-
-		return $instances[0];
+		return self::$instance;
 	}
 
 	/**

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -192,6 +192,12 @@ class JUser extends JObject
 	protected $_errorMsg = null;
 
 	/**
+	 * @var    array  JUser instances container.
+	 * @since  11.3
+	 */
+	protected static $instances = array();
+
+	/**
 	 * Constructor activating the default information of the language
 	 *
 	 * @param   integer  $identifier  The primary key of the user to load (optional).
@@ -230,13 +236,6 @@ class JUser extends JObject
 	 */
 	public static function getInstance($identifier = 0)
 	{
-		static $instances;
-
-		if (!isset($instances))
-		{
-			$instances = array();
-		}
-
 		// Find the user id
 		if (!is_numeric($identifier))
 		{
@@ -253,13 +252,13 @@ class JUser extends JObject
 			$id = $identifier;
 		}
 
-		if (empty($instances[$id]))
+		if (empty(self::$instances[$id]))
 		{
 			$user = new JUser($id);
-			$instances[$id] = $user;
+			self::$instances[$id] = $user;
 		}
 
-		return $instances[$id];
+		return self::$instances[$id];
 	}
 
 	/**


### PR DESCRIPTION
Changing all cases of static instance variables in functions to class static properties. This should cover all cases where a class stores itself in an $instance variable and makes all occurences identical. It only changed $instance(s) cases, some methods use different variables for different cases, which have not been touched and still need to be changed.
