### PR TITLE
Make unit tests work with phpUnit 3.6.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
 	<filter>
 	  <whitelist addUncoveredFilesFromWhitelist="false">
 	    <directory suffix=".php">libraries/joomla</directory>
+	    <file>libraries/import.php</file>
 	    <file>libraries/loader.php</file>
 	    <file>libraries/platform.php</file>
 	  </whitelist>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -79,6 +79,3 @@ require_once JPATH_PLATFORM . '/import.php';
 // Include the base test cases.
 require_once JPATH_TESTS . '/includes/JoomlaTestCase.php';
 require_once JPATH_TESTS . '/includes/JoomlaDatabaseTestCase.php';
-
-// Exclude all of the tests and platform files from code coverage reports
-PHP_CodeCoverage_Filter::getInstance()->addDirectoryToBlacklist(JPATH_TESTS);


### PR DESCRIPTION
Add JImport to the whitelist.
