### PR TITLE
- Added getLanguage method so language code can be retrieved.

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -1225,6 +1225,18 @@ class JLanguage extends JObject
 	}
 
 	/**
+	 * Get the language code of lanagugae instance
+	 *
+	 * @return  string  Previous value.
+	 *
+	 * @since   11.3
+	 */
+	public function getLanguage()
+	{
+		return $this->lang;
+	}
+
+	/**
 	 * Get the language locale based on current language.
 	 *
 	 * @return  array  The locale according to the language.


### PR DESCRIPTION
- in J1.5 we can do it by get('_lang') but till Platform 11.2 we cannot get it by get().
- So we need this function to retrieve language code of given language instance.
