### PR TITLE
Some minor changes to improve exceptions and fix unit test issues with PHPUnit 3.6

### DIFF
--- a/libraries/joomla/application/cli.php
+++ b/libraries/joomla/application/cli.php
@@ -365,7 +365,7 @@ class JCli
 			}
 			else
 			{
-				throw new Exception('Configuration class does not exist.');
+				throw new RuntimeException('Configuration class does not exist.');
 			}
 		}
 

--- a/libraries/joomla/application/component/controller.php
+++ b/libraries/joomla/application/component/controller.php
@@ -287,7 +287,7 @@ class JController extends JObject
 			}
 			else
 			{
-				throw new Exception(JText::sprintf('JLIB_APPLICATION_ERROR_INVALID_CONTROLLER', $type, $format));
+				throw new InvalidArgumentException(JText::sprintf('JLIB_APPLICATION_ERROR_INVALID_CONTROLLER', $type, $format));
 			}
 		}
 
@@ -298,7 +298,7 @@ class JController extends JObject
 		}
 		else
 		{
-			throw new Exception(JText::sprintf('JLIB_APPLICATION_ERROR_INVALID_CONTROLLER_CLASS', $class));
+			throw new InvalidArgumentException(JText::sprintf('JLIB_APPLICATION_ERROR_INVALID_CONTROLLER_CLASS', $class));
 		}
 
 		return self::$instance;

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -1042,7 +1042,7 @@ class JWeb
 			}
 			else
 			{
-				throw new Exception('Configuration class does not exist.');
+				throw new RuntimeException('Configuration class does not exist.');
 			}
 		}
 

--- a/tests/suite/joomla/application/JCliTest.php
+++ b/tests/suite/joomla/application/JCliTest.php
@@ -246,7 +246,7 @@ class JCliTest extends JoomlaTestCase
 	{
 		if ($expectedException)
 		{
-			$this->setExpectedException('Exception');
+			$this->setExpectedException('RuntimeException');
 		}
 
 		if (is_null($file) && is_null($class))

--- a/tests/suite/joomla/application/JWebTest.php
+++ b/tests/suite/joomla/application/JWebTest.php
@@ -756,7 +756,7 @@ class JWebTest extends JoomlaTestCase
 	{
 		if ($expectedException)
 		{
-			$this->setExpectedException('Exception');
+			$this->setExpectedException('RuntimeException');
 		}
 
 		if (is_null($file) && is_null($class))

--- a/tests/suite/joomla/application/component/JControllerTest.php
+++ b/tests/suite/joomla/application/component/JControllerTest.php
@@ -203,7 +203,7 @@ class JControllerTest extends PHPUnit_Framework_TestCase
 	 *
 	 * @return  void
 	 *
-	 * @expectedException  Exception
+	 * @expectedException  InvalidArgumentException
 	 * @since   11.3
 	 */
 	public function testGetInstanceException()
@@ -240,9 +240,9 @@ class JControllerTest extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Test JController::getTask().
-	 * 
+	 *
 	 * @return  void
-	 * 
+	 *
 	 * @since   11.3
 	 */
 	public function testGetTask()

--- a/tests/suite/joomla/string/TestHelpers/JString-helper-dataset.php
+++ b/tests/suite/joomla/string/TestHelpers/JString-helper-dataset.php
@@ -104,7 +104,7 @@ class JStringTest_DataSet
 		array('Pig', 'cow', 'the pig jumped', false, 'the cow jumped'),
 		array('Pig', 'cow', 'the pig jumped', true, 'the cow jumped'),
 		array('Pig', 'cow', 'the pig jumped over the cow', true, 'the cow jumped over the cow'),
-		array(array('PIG', 'JUMPED'), array('cow', 'hopped'), true, 'the pig jumped over the pig', 'the cow hopped over the cow'),
+		array(array('PIG', 'JUMPED'), array('cow', 'hopped'), 'the pig jumped over the pig', true, 'the cow hopped over the cow'),
 		array('шил', 'биш', 'Би шил идэй чадна', true, 'Би биш идэй чадна'),
 		array('/', ':', '/test/slashes/', true, ':test:slashes:'),
 	);


### PR DESCRIPTION
1. PHPUnit 3.6 doesn't like you to expect generic exceptions.  This issue is addressed by using exceptions that are a bit more specific.
2. There is a JString unit test that somehow passes but is wrong.  This fails on PHPUnit 3.6 without the enclosed fix.  Very curious.
