### PR TITLE
UT 1/10: Fixes and Unittests for JRegistry package

### DIFF
--- a/libraries/joomla/registry/format/php.php
+++ b/libraries/joomla/registry/format/php.php
@@ -39,9 +39,9 @@ class JRegistryFormatPHP extends JRegistryFormat
 			{
 				$vars .= "\tpublic $" . $k . " = '" . addcslashes($v, '\\\'') . "';\n";
 			}
-			elseif (is_array($v))
+			elseif (is_array($v) || is_object($v))
 			{
-				$vars .= "\tpublic $" . $k . " = " . $this->getArrayString($v) . ";\n";
+				$vars .= "\tpublic $" . $k . " = " . $this->getArrayString((array)$v) . ";\n";
 			}
 		}
 
@@ -90,9 +90,9 @@ class JRegistryFormatPHP extends JRegistryFormat
 		{
 			$s .= ($i) ? ', ' : '';
 			$s .= '"' . $k . '" => ';
-			if (is_array($v))
+			if (is_array($v) || is_object($v))
 			{
-				$s .= $this->getArrayString($v);
+				$s .= $this->getArrayString((array)$v);
 			}
 			else
 			{

--- a/libraries/joomla/registry/format/xml.php
+++ b/libraries/joomla/registry/format/xml.php
@@ -40,23 +40,7 @@ class JRegistryFormatXML extends JRegistryFormat
 		$root = simplexml_load_string('<' . $rootName . ' />');
 
 		// Iterate over the object members.
-		foreach ((array) $object as $k => $v)
-		{
-			if (is_scalar($v))
-			{
-				$n = $root->addChild($nodeName, $v);
-				$n->addAttribute('name', $k);
-				$n->addAttribute('type', gettype($v));
-			}
-			else
-			{
-				$n = $root->addChild($nodeName);
-				$n->addAttribute('name', $k);
-				$n->addAttribute('type', gettype($v));
-
-				$this->getXmlChildren($n, $v, $nodeName);
-			}
-		}
+		$this->getXmlChildren($root, $object, $nodeName);
 
 		return $root->asXML();
 	}

--- a/libraries/joomla/registry/registry.php
+++ b/libraries/joomla/registry/registry.php
@@ -470,10 +470,12 @@ class JRegistry
 	 */
 	public function loadXML($data, $namespace = null)
 	{
+		// @codeCoverageIgnoreStart
 		// Deprecation warning.
 		JLog::add('JRegistry::loadXML() is deprecated.', JLog::WARNING, 'deprecated');
 
 		return $this->loadString($data, 'XML');
+		// @codeCoverageIgnoreEnd
 	}
 
 	/**
@@ -491,10 +493,12 @@ class JRegistry
 	 */
 	public function loadINI($data, $namespace = null, $options = array())
 	{
+		// @codeCoverageIgnoreStart
 		// Deprecation warning.
 		JLog::add('JRegistry::loadINI() is deprecated.', JLog::WARNING, 'deprecated');
 
 		return $this->loadString($data, 'INI', $options);
+		// @codeCoverageIgnoreEnd
 	}
 
 	/**
@@ -510,10 +514,12 @@ class JRegistry
 	 */
 	public function loadJSON($data)
 	{
+		// @codeCoverageIgnoreStart
 		// Deprecation warning.
 		JLog::add('JRegistry::loadJSON() is deprecated.', JLog::WARNING, 'deprecated');
 
 		return $this->loadString($data, 'JSON');
+		// @codeCoverageIgnoreEnd
 	}
 
 	/**
@@ -529,11 +535,13 @@ class JRegistry
 	 */
 	public function makeNameSpace($namespace)
 	{
+		// @codeCoverageIgnoreStart
 		// Deprecation warning.
 		JLog::add('JRegistry::makeNameSpace() is deprecated.', JLog::WARNING, 'deprecated');
 
 		//$this->_registry[$namespace] = array('data' => new stdClass());
 		return true;
+		// @codeCoverageIgnoreEnd
 	}
 
 	/**
@@ -547,11 +555,13 @@ class JRegistry
 	 */
 	public function getNameSpaces()
 	{
+		// @codeCoverageIgnoreStart
 		// Deprecation warning.
 		JLog::add('JRegistry::getNameSpaces() is deprecated.', JLog::WARNING, 'deprecated');
 
 		//return array_keys($this->_registry);
 		return array();
+		// @codeCoverageIgnoreEnd
 	}
 
 	/**
@@ -568,6 +578,7 @@ class JRegistry
 	 */
 	public function getValue($path, $default = null)
 	{
+		// @codeCoverageIgnoreStart
 		// Deprecation warning.
 		JLog::add('JRegistry::getValue() is deprecated.', JLog::WARNING, 'deprecated');
 
@@ -578,6 +589,7 @@ class JRegistry
 			$path = implode('.', $parts);
 		}
 		return $this->get($path, $default);
+		// @codeCoverageIgnoreEnd
 	}
 
 	/**
@@ -594,6 +606,7 @@ class JRegistry
 	 */
 	public function setValue($path, $value)
 	{
+		// @codeCoverageIgnoreStart
 		// Deprecation warning.
 		JLog::add('JRegistry::setValue() is deprecated.', JLog::WARNING, 'deprecated');
 
@@ -604,6 +617,7 @@ class JRegistry
 			$path = implode('.', $parts);
 		}
 		return $this->set($path, $value);
+		// @codeCoverageIgnoreEnd
 	}
 
 	/**
@@ -619,9 +633,11 @@ class JRegistry
 	 */
 	public function loadSetupFile()
 	{
+		// @codeCoverageIgnoreStart
 		// Deprecation warning.
 		JLog::add('JRegistry::loadXML() is deprecated.', JLog::WARNING, 'deprecated');
 
 		return true;
+		// @codeCoverageIgnoreEnd
 	}
 }

--- a/tests/suite/joomla/registry/JRegistryFormatTest.php
+++ b/tests/suite/joomla/registry/JRegistryFormatTest.php
@@ -16,14 +16,9 @@ require_once JPATH_PLATFORM.'/joomla/registry/format.php';
 class JRegistryFormatTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var JRegistryFormat
-	 */
-	protected $object;
-
-	/**
 	 * Test the JRegistryFormat::getInstance method.
 	 */
-	public function testGetInstance01()
+	public function testGetInstance()
 	{
 		// Test INI format.
 		$object = JRegistryFormat::getInstance('INI');
@@ -52,24 +47,16 @@ class JRegistryFormatTest extends PHPUnit_Framework_TestCase
 			$object instanceof JRegistryFormatXml,
 			$this->isTrue()
 		);
-	}
-
-	/**
-	 * Failing test of the JRegistryFormat::getInstance method.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.3
-	 *
-	 * @expectedException  JException
-	 */
-	public function testGetInstance02()
-	{
-		// Test SQL format.
-		$object = JRegistryFormat::getInstance('SQL');
-		$this->assertThat(
-			$object instanceof JRegistryFormatSQL,
-			$this->isTrue()
-		);
+		
+		// Test non-existing format.
+		try
+		{
+			$object = JRegistryFormat::getInstance('SQL');	
+		}
+		catch(Exception $e)
+		{
+			return;
+		}
+		$this->fail('JRegistryFormat should throw an exception in case of non-existing formats');
 	}
 }

--- a/tests/suite/joomla/registry/JRegistryTest.php
+++ b/tests/suite/joomla/registry/JRegistryTest.php
@@ -340,16 +340,12 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the JRegistry::loadIni method.
+	 * Test the JRegistry::loadString() method.
 	 */
-	public function testLoadINI()
+	public function testLoadString()
 	{
-		//$string = "[section]\nfoo=\"testloadini\"";
-
 		$registry = new JRegistry;
-		$result = $registry->loadIni("foo=\"testloadini1\"");
-
-		// Result is always true, no error checking in method.
+		$result = $registry->loadString('foo="testloadini1"', 'INI');
 
 		// Test getting a known value.
 		$this->assertThat(
@@ -358,7 +354,7 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 			'Line: '.__LINE__.'.'
 		);
 
-		$result = $registry->loadIni("[section]\nfoo=\"testloadini2\"");
+		$result = $registry->loadString("[section]\nfoo=\"testloadini2\"", 'INI');
 		// Test getting a known value.
 		$this->assertThat(
 			$registry->get('foo'),
@@ -366,24 +362,18 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 			'Line: '.__LINE__.'.'
 		);
 
-		$result = $registry->loadIni("[section]\nfoo=\"testloadini3\"", null, true);
+		$result = $registry->loadString("[section]\nfoo=\"testloadini3\"", 'INI', true);
 		// Test getting a known value after processing sections.
 		$this->assertThat(
 			$registry->get('section.foo'),
 			$this->equalTo('testloadini3'),
 			'Line: '.__LINE__.'.'
 		);
-	}
-
-	/**
-	 * Test the JRegistry::loadJson method.
-	 */
-	public function testLoadJSON()
-	{
-		$string = '{"foo":"testloadjson"}';
+		
+				$string = '{"foo":"testloadjson"}';
 
 		$registry = new JRegistry;
-		$result = $registry->loadJson($string);
+		$result = $registry->loadString($string);
 
 		// Result is always true, no error checking in method.
 
@@ -393,6 +383,7 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 			$this->equalTo('testloadjson'),
 			'Line: '.__LINE__.'.'
 		);
+		
 	}
 
 	/**
@@ -422,45 +413,6 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 		$object2->set('test', 'testcase');
 		$object->set('test', $object2);
 		$this->assertTrue($registry->loadObject($object), 'Line: '.__LINE__.'. Should load object successfully');
-	}
-
-	/**
-	 * Test the JRegistry::loadXML method.
-	 */
-	public function testLoadXML()
-	{
-		// Cannot test since stringToObject is not implemented yet.
-	}
-
-	/**
-	 * Test the JRegistry::makeNamespace method.
-	 */
-	public function testMakeNameSpace()
-	{
-		$a = new JRegistry;
-		$a->makeNameSpace('foo');
-
-		$this->assertThat(
-			//in_array('foo', $a->getNameSpaces()),
-			//$this->isTrue()
-			$a->getNameSpaces(),
-			$this->equalTo(array()),
-			'Line: '.__LINE__.'.'
-		);
-	}
-
-	/**
-	 * Test the JRegistry::makeNamespace method.
-	 */
-	public function testLoadSetupFile()
-	{
-		$a = new JRegistry;
-
-		$this->assertThat(
-			$a->loadSetupFile(),
-			$this->equalTo(true),
-			'loadSetupFile does not exist or did not return true.'
-		);
 	}
 
 	/**

--- a/tests/suite/joomla/registry/format/JRegistryFormatJsonTest.php
+++ b/tests/suite/joomla/registry/format/JRegistryFormatJsonTest.php
@@ -8,7 +8,6 @@
  */
 
 require_once JPATH_PLATFORM.'/joomla/registry/format.php';
-require_once JPATH_PLATFORM.'/joomla/registry/format/json.php';
 
 /**
  * Test class for JRegistryFormatJSON.
@@ -17,25 +16,34 @@ require_once JPATH_PLATFORM.'/joomla/registry/format/json.php';
 class JRegistryFormatJSONTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var JRegistryFormatJSON
-	 */
-	protected $object;
-
-	/**
 	 * Test the JRegistryFormatJSON::objectToString method.
 	 */
 	public function testObjectToString()
 	{
-		$class = new JRegistryFormatJSON;
+		$class = JRegistryFormat::getInstance('JSON');
 		$options = null;
 		$object = new stdClass;
 		$object->foo = 'bar';
-
+		$object->quoted = '"stringwithquotes"';
+		$object->booleantrue = true;
+		$object->booleanfalse = false;
+		$object->numericint = 42;
+		$object->numericfloat = 3.1415;
+		$object->section = new stdClass(); //The PHP registry format does not support nested objects
+		$object->section->key = 'value';
+		$object->array = array('nestedarray' => array('test1' => 'value1'));
+		
+		$string = '{"foo":"bar","quoted":"\"stringwithquotes\"",'.
+				'"booleantrue":true,"booleanfalse":false,'.
+				'"numericint":42,"numericfloat":3.1415,'.
+				'"section":{"key":"value"},'.
+				'"array":{"nestedarray":{"test1":"value1"}}'.
+				'}';
+		
 		// Test basic object to string.
-		$string = $class->objectToString($object, $options);
 		$this->assertThat(
-			$string,
-			$this->equalTo('{"foo":"bar"}')
+			$class->objectToString($object, $options),
+			$this->equalTo($string)
 		);
 	}
 
@@ -88,9 +96,15 @@ class JRegistryFormatJSONTest extends PHPUnit_Framework_TestCase
 			$this->equalTo($object2),
 			'Line:'.__LINE__.' The INI string should covert into an object with sections.'
 		);
-
-		$this->markTestIncomplete(
-			'Need to test for bad input.'
+		
+		/**
+		 * Test for bad input
+		 * Everything that is not starting with { is handled by
+		 * JRegistryFormatIni, which we test seperately
+		 */ 
+		$this->assertThat(
+			$class->stringToObject('{key:\'value\''),
+			$this->equalTo(false)
 		);
 	}
 }

--- a/tests/suite/joomla/registry/format/JRegistryFormatPhpTest.php
+++ b/tests/suite/joomla/registry/format/JRegistryFormatPhpTest.php
@@ -8,7 +8,6 @@
  */
 
 require_once JPATH_PLATFORM.'/joomla/registry/format.php';
-require_once JPATH_PLATFORM.'/joomla/registry/format/php.php';
 
 /**
  * Test class for JRegistryFormatPHP.
@@ -17,63 +16,38 @@ require_once JPATH_PLATFORM.'/joomla/registry/format/php.php';
 class JRegistryFormatPHPTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * Sets up the fixture, for example, opens a network connection.
-	 * This method is called before a test is executed.
-	 */
-	function setUp()
-	{
-		$this->instance = new JRegistryFormatPHP;
-	}
-
-	/**
-	 * Convert an array into an object.
-	 *
-	 * @param   array
-	 * @return  object
-	 */
-	private static function _objectFactory($properties)
-	{
-		$obj = new stdClass();
-		foreach ($properties as $k => $v) {
-			$obj->{$k} = $v;
-		}
-		return $obj;
-	}
-
-	/**
-	 * Get the objects to run tests on.
-	 */
-	public function getObjects()
-	{
-		$tests = array(
-			'Regular Object' => array(
-				self::_objectFactory(array('test1' => 'value1', 'test2' => 'value2')),
-				array('class' => 'myClass'),
-				'<?php'."\n".'class myClass {'."\n\t".'public $test1 = \'value1\';'."\n\t".'public $test2 = \'value2\';'."\n}\n".'?>'
-			),
-			'Object with Double Quote' => array(
-				self::_objectFactory(array('test1' => 'value1"', 'test2' => 'value2')),
-				array('class' => 'myClass'),
-				'<?php'."\n".'class myClass {'."\n\t".'public $test1 = \'value1"\';'."\n\t".'public $test2 = \'value2\';'."\n}\n".'?>'
-			)
-
-		);
-
-		return $tests;
-	}
-
-	/**
 	 * Test the JRegistryFormatPHP::objectToString method.
-	 *
-	 * @dataProvider getObjects
-	 *
-	 * @param string The type of input
-	 * @param string The input
-	 * @param string The expected result for this test.
 	 */
-	function testObjectToString($object, $params, $expect)
+	function testObjectToString()
 	{
-		$this->assertEquals($expect, $this->instance->objectToString($object, $params));
+		$class = JRegistryFormat::getInstance('PHP');
+		$options = array('class' => 'myClass');
+		$object = new stdClass;
+		$object->foo = 'bar';
+		$object->quoted = '"stringwithquotes"';
+		$object->booleantrue = true;
+		$object->booleanfalse = false;
+		$object->numericint = 42;
+		$object->numericfloat = 3.1415;
+		$object->section = new stdClass(); //The PHP registry format does not support nested objects
+		$object->section->key = 'value';
+		$object->array = array('nestedarray' => array('test1' => 'value1'));
+		
+		$string = "<?php\n".
+			"class myClass {\n".
+			"\tpublic \$foo = 'bar';\n".
+			"\tpublic \$quoted = '\"stringwithquotes\"';\n".
+			"\tpublic \$booleantrue = '1';\n".
+			"\tpublic \$booleanfalse = '';\n".
+			"\tpublic \$numericint = '42';\n".
+			"\tpublic \$numericfloat = '3.1415';\n".
+			"\tpublic \$section = array(\"key\" => \"value\");\n".
+			"\tpublic \$array = array(\"nestedarray\" => array(\"test1\" => \"value1\"));\n".
+			"}\n?>"; 
+		$this->assertThat(
+			$class->objectToString($object, $options),
+			$this->equalTo($string)
+		);
 	}
 
 	/**
@@ -81,6 +55,8 @@ class JRegistryFormatPHPTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testStringToObject()
 	{
-		// This method is not implemented in the class.
+		$class = JRegistryFormat::getInstance('PHP');
+		// This method is not implemented in the class. The test is to achieve 100% code coverage
+		$this->assertTrue($class->stringToObject(''));
 	}
 }

--- a/tests/suite/joomla/registry/format/JRegistryFormatXmlTest.php
+++ b/tests/suite/joomla/registry/format/JRegistryFormatXmlTest.php
@@ -8,7 +8,6 @@
  */
 
 require_once JPATH_PLATFORM.'/joomla/registry/format.php';
-require_once JPATH_PLATFORM.'/joomla/registry/format/xml.php';
 
 /**
  * Test class for JRegistryFormatXML.
@@ -21,16 +20,40 @@ class JRegistryFormatXMLTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testObjectToString()
 	{
-		$class = new JRegistryFormatXML;
+		$class = JRegistryFormat::getInstance('XML');
 		$options = null;
 		$object = new stdClass;
 		$object->foo = 'bar';
+		$object->quoted = '"stringwithquotes"';
+		$object->booleantrue = true;
+		$object->booleanfalse = false;
+		$object->numericint = 42;
+		$object->numericfloat = 3.1415;
+		$object->section = new stdClass();
+		$object->section->key = 'value';
+		$object->array = array('nestedarray' => array('test1' => 'value1'));
 
+		$string = "<?xml version=\"1.0\"?>\n<registry>".
+			"<node name=\"foo\" type=\"string\">bar</node>".
+			"<node name=\"quoted\" type=\"string\">\"stringwithquotes\"</node>".
+			"<node name=\"booleantrue\" type=\"boolean\">1</node>".
+			"<node name=\"booleanfalse\" type=\"boolean\"></node>".
+			"<node name=\"numericint\" type=\"integer\">42</node>".
+			"<node name=\"numericfloat\" type=\"double\">3.1415</node>".
+			"<node name=\"section\" type=\"object\">".
+				"<node name=\"key\" type=\"string\">value</node>".
+			"</node>".
+			"<node name=\"array\" type=\"array\">".
+				"<node name=\"nestedarray\" type=\"array\">".
+					"<node name=\"test1\" type=\"string\">value1</node>".
+				"</node>".
+			"</node>".
+		"</registry>\n";
+		
 		// Test basic object to string.
-		$string = trim($class->objectToString($object, $options));
 		$this->assertThat(
-			$string,
-			$this->equalTo("<?xml version=\"1.0\"?>\n<registry><node name=\"foo\" type=\"string\">bar</node></registry>")
+			$class->objectToString($object, $options),
+			$this->equalTo($string)
 		);
 	}
 
@@ -39,7 +62,36 @@ class JRegistryFormatXMLTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testStringToObject()
 	{
-		// This method is not implemented in the class.
+		$class = JRegistryFormat::getInstance('XML');
+		$object = new stdClass;
+		$object->foo = 'bar';
+		$object->booleantrue = true;
+		$object->booleanfalse = false;
+		$object->numericint = 42;
+		$object->numericfloat = 3.1415;
+		$object->section = new stdClass();
+		$object->section->key = 'value';
+		$object->array = array('test1' => 'value1');
+
+		$string = "<?xml version=\"1.0\"?>\n<registry>".
+			"<node name=\"foo\" type=\"string\">bar</node>".
+			"<node name=\"booleantrue\" type=\"boolean\">1</node>".
+			"<node name=\"booleanfalse\" type=\"boolean\"></node>".
+			"<node name=\"numericint\" type=\"integer\">42</node>".
+			"<node name=\"numericfloat\" type=\"double\">3.1415</node>".
+			"<node name=\"section\" type=\"object\">".
+				"<node name=\"key\" type=\"string\">value</node>".
+			"</node>".
+			"<node name=\"array\" type=\"array\">".
+				"<node name=\"test1\" type=\"string\">value1</node>".
+			"</node>".
+		"</registry>\n";
+		
+		// Test basic object to string.
+		$this->assertThat(
+			$class->stringToObject($string),
+			$this->equalTo($object)
+		);
 	}
 
 }


### PR DESCRIPTION
This is the first of 10 pull requests that split up the commits from pull #466 into more or less digestable packages.

This request implements extended unittests for the registry package and fixes a few of the JRegistryFormat handlers.
The specific changes:
JRegistryFormatPHP: Up till now, nested objects were simply ignored, when converting an object to a string. This now converts objects to arrays and then tries to handle them as nested arrays. Otherwise data would be lost.

JRegistryFormatXML: The first iteration through the childs of the root node was a duplicate of the method that is later called for every childs child element. Simply less code.

JRegistry: Deprecated methods (that sometimes don't even work anymore) should not be covered by unittests and also should not need any code coverage checks. 

JRegistryFormatTest: The exception handling in the test was uncool in my book, since the function code did an assertion, but it didn't get that far and instead threw and exception. For a developer its not directly obvious that the exception handling is done through the doc-block and that an exception is expected here. 

JRegistryTest: loadINI & loadJSON are deprecated in favor of loadString() and thus loadString() should be tested, not the other two.

JRegistryFormatIniTest, JRegistryFormatPHPTest, JRegistryFormatXMLTest, JRegistryFormatJSONTest: The tests have been fleshed out a bit more to check for the majority of possible input. just checking for "foo=bar" is not much of a test.
