### PR TITLE
Allows JWeb to have a configurable themes path.

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -372,6 +372,7 @@ class JWeb
 			$options['directory'] = $this->get('themes.base');
 		}
 		// Fall back to constants.
+		else
 		{
 			$options['directory'] = (defined('JPATH_BASE') ? JPATH_BASE : dirname(__FILE__)) . '/themes';
 		}

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -368,7 +368,7 @@ class JWeb
 		);
 
 		// Handle the convention-based default case for themes path.
-		if (!define('JPATH_THEMES'))
+		if (!defined('JPATH_THEMES'))
 		{
 			if (defined('JPATH_BASE'))
 			{

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -368,15 +368,22 @@ class JWeb
 		);
 
 		// Handle the convention-based default case for themes path.
-		if (defined('JPATH_BASE'))
+		if (!define('JPATH_THEMES'))
 		{
-			$options['directory'] = JPATH_BASE . '/themes';
+			if (defined('JPATH_BASE'))
+			{
+				$options['directory'] = JPATH_BASE . '/themes';
+			}
+			else
+			{
+				$options['directory'] = dirname(__FILE__) . '/themes';
+			}
 		}
+		// Handle configured themes path
 		else
 		{
-			$options['directory'] = dirname(__FILE__) . '/themes';
+			$options['directory'] = JPATH_THEMES;
 		}
-
 		// Parse the document.
 		$this->document->parse($options);
 

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -367,23 +367,15 @@ class JWeb
 			'params' => ''
 		);
 
-		// Handle the convention-based default case for themes path.
-		if (!defined('JPATH_THEMES'))
+		if ($this->get('themes.base'))
 		{
-			if (defined('JPATH_BASE'))
-			{
-				$options['directory'] = JPATH_BASE . '/themes';
-			}
-			else
-			{
-				$options['directory'] = dirname(__FILE__) . '/themes';
-			}
+			$options['directory'] = $this->get('themes.base');
 		}
-		// Handle configured themes path
-		else
+		// Fall back to constants.
 		{
-			$options['directory'] = JPATH_THEMES;
+			$options['directory'] = (defined('JPATH_BASE') ? JPATH_BASE : dirname(__FILE__)) . '/themes';
 		}
+
 		// Parse the document.
 		$this->document->parse($options);
 


### PR DESCRIPTION
This adjusts JWeb::Render to use a configuration variable "themes.base" if it is available and then if not to use the convention based path. 
