### PR TITLE
UT 2/10: Using realpath() in JLoaderTest to remove platform issues

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,19 +28,19 @@ ini_set('display_errors', 1);
  */
 if (!defined('JPATH_TESTS'))
 {
-	define('JPATH_TESTS', realpath(__DIR__));
+	define('JPATH_TESTS', str_replace(DIRECTORY_SEPARATOR, '/', realpath(__DIR__)));
 }
 if (!defined('JPATH_PLATFORM'))
 {
-	define('JPATH_PLATFORM', realpath(dirname(JPATH_TESTS) . '/libraries'));
+	define('JPATH_PLATFORM', str_replace(DIRECTORY_SEPARATOR, '/', realpath(dirname(JPATH_TESTS) . '/libraries')));
 }
 if (!defined('JPATH_BASE'))
 {
-	define('JPATH_BASE', realpath(JPATH_TESTS . '/tmp'));
+	define('JPATH_BASE', str_replace(DIRECTORY_SEPARATOR, '/', realpath(JPATH_TESTS . '/tmp')));
 }
 if (!defined('JPATH_ROOT'))
 {
-	define('JPATH_ROOT', realpath(JPATH_BASE));
+	define('JPATH_ROOT', str_replace(DIRECTORY_SEPARATOR, '/', realpath(JPATH_BASE)));
 }
 if (!defined('JPATH_CACHE'))
 {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,19 +28,19 @@ ini_set('display_errors', 1);
  */
 if (!defined('JPATH_TESTS'))
 {
-	define('JPATH_TESTS', str_replace(DIRECTORY_SEPARATOR, '/', realpath(__DIR__)));
+	define('JPATH_TESTS', realpath(__DIR__));
 }
 if (!defined('JPATH_PLATFORM'))
 {
-	define('JPATH_PLATFORM', str_replace(DIRECTORY_SEPARATOR, '/', realpath(dirname(JPATH_TESTS) . '/libraries')));
+	define('JPATH_PLATFORM', realpath(dirname(JPATH_TESTS) . '/libraries'));
 }
 if (!defined('JPATH_BASE'))
 {
-	define('JPATH_BASE', str_replace(DIRECTORY_SEPARATOR, '/', realpath(JPATH_TESTS . '/tmp')));
+	define('JPATH_BASE', realpath(JPATH_TESTS . '/tmp'));
 }
 if (!defined('JPATH_ROOT'))
 {
-	define('JPATH_ROOT', str_replace(DIRECTORY_SEPARATOR, '/', realpath(JPATH_BASE)));
+	define('JPATH_ROOT', realpath(JPATH_BASE));
 }
 if (!defined('JPATH_CACHE'))
 {

--- a/tests/suite/JLoaderTest.php
+++ b/tests/suite/JLoaderTest.php
@@ -213,9 +213,10 @@ class JLoaderTest extends PHPUnit_Framework_TestCase
 			'Checks that force overrides existing classes.'
 		);
 
+		$d = DIRECTORY_SEPARATOR;
 		$this->assertThat(
 			$classes['shuttleatlantis'],
-			$this->equalTo(JPATH_TESTS.'/suite/stubs/discover2/discover3/atlantis.php'),
+			$this->equalTo(JPATH_TESTS.'/suite/stubs/discover2'.$d.'discover3/atlantis.php'),
 			'Checks that recurse works.'
 		);
 	}

--- a/tests/suite/JLoaderTest.php
+++ b/tests/suite/JLoaderTest.php
@@ -213,10 +213,9 @@ class JLoaderTest extends PHPUnit_Framework_TestCase
 			'Checks that force overrides existing classes.'
 		);
 
-		$d = DIRECTORY_SEPARATOR;
 		$this->assertThat(
-			$classes['shuttleatlantis'],
-			$this->equalTo(JPATH_TESTS.'/suite/stubs/discover2'.$d.'discover3/atlantis.php'),
+			str_replace(DIRECTORY_SEPARATOR, '/', $classes['shuttleatlantis']),
+			$this->equalTo(JPATH_TESTS.'/suite/stubs/discover2/discover3/atlantis.php'),
 			'Checks that recurse works.'
 		);
 	}

--- a/tests/suite/JLoaderTest.php
+++ b/tests/suite/JLoaderTest.php
@@ -157,14 +157,14 @@ class JLoaderTest extends PHPUnit_Framework_TestCase
 		$classes = JLoader::getClassList();
 
 		$this->assertThat(
-			$classes['challenger'],
-			$this->equalTo(JPATH_TESTS.'/suite/stubs/discover1/challenger.php'),
+			realpath($classes['challenger']),
+			$this->equalTo(realpath(JPATH_TESTS.'/suite/stubs/discover1/challenger.php')),
 			'Checks that the class path is correct (1).'
 		);
 
 		$this->assertThat(
-			$classes['columbia'],
-			$this->equalTo(JPATH_TESTS.'/suite/stubs/discover1/columbia.php'),
+			realpath($classes['columbia']),
+			$this->equalTo(realpath(JPATH_TESTS.'/suite/stubs/discover1/columbia.php')),
 			'Checks that the class path is correct (2).'
 		);
 
@@ -178,14 +178,14 @@ class JLoaderTest extends PHPUnit_Framework_TestCase
 		$classes = JLoader::getClassList();
 
 		$this->assertThat(
-			$classes['shuttlechallenger'],
-			$this->equalTo(JPATH_TESTS.'/suite/stubs/discover1/challenger.php'),
+			realpath($classes['shuttlechallenger']),
+			$this->equalTo(realpath(JPATH_TESTS.'/suite/stubs/discover1/challenger.php')),
 			'Checks that the class path with prefix is correct (1).'
 		);
 
 		$this->assertThat(
-			$classes['shuttlecolumbia'],
-			$this->equalTo(JPATH_TESTS.'/suite/stubs/discover1/columbia.php'),
+			realpath($classes['shuttlecolumbia']),
+			$this->equalTo(realpath(JPATH_TESTS.'/suite/stubs/discover1/columbia.php')),
 			'Checks that the class path with prefix is correct (2).'
 		);
 
@@ -193,8 +193,8 @@ class JLoaderTest extends PHPUnit_Framework_TestCase
 		$classes = JLoader::getClassList();
 
 		$this->assertThat(
-			$classes['shuttlechallenger'],
-			$this->equalTo(JPATH_TESTS.'/suite/stubs/discover1/challenger.php'),
+			realpath($classes['shuttlechallenger']),
+			$this->equalTo(realpath(JPATH_TESTS.'/suite/stubs/discover1/challenger.php')),
 			'Checks that the original class paths are maintained when not forced.'
 		);
 
@@ -208,14 +208,14 @@ class JLoaderTest extends PHPUnit_Framework_TestCase
 		$classes = JLoader::getClassList();
 
 		$this->assertThat(
-			$classes['shuttlechallenger'],
-			$this->equalTo(JPATH_TESTS.'/suite/stubs/discover2/challenger.php'),
+			realpath($classes['shuttlechallenger']),
+			$this->equalTo(realpath(JPATH_TESTS.'/suite/stubs/discover2/challenger.php')),
 			'Checks that force overrides existing classes.'
 		);
 
 		$this->assertThat(
-			str_replace(DIRECTORY_SEPARATOR, '/', $classes['shuttleatlantis']),
-			$this->equalTo(JPATH_TESTS.'/suite/stubs/discover2/discover3/atlantis.php'),
+			realpath($classes['shuttleatlantis']),
+			$this->equalTo(realpath(JPATH_TESTS.'/suite/stubs/discover2/discover3/atlantis.php')),
 			'Checks that recurse works.'
 		);
 	}

--- a/tests/suite/joomla/access/JAccessTest.php
+++ b/tests/suite/joomla/access/JAccessTest.php
@@ -394,6 +394,13 @@ class JAccessTest extends JoomlaDatabaseTestCase
 			$array2,
 			$this->equalTo($access->getGroupsByUser(42, False))
 		);
+		
+		jimport('joomla.application.component.helper');
+		
+		$this->assertThat(
+			$access->getGroupsByUser(null),
+			$this->equalTo(array(1))
+		);
 	}
 
 	/**


### PR DESCRIPTION
Adding unittest to JAccessTest to achieve more code coverage
