### PR TITLE
Added missing references =& instead of assignments = for array of module...

### DIFF
--- a/libraries/joomla/application/module/helper.php
+++ b/libraries/joomla/application/module/helper.php
@@ -33,7 +33,7 @@ abstract class JModuleHelper
 	public static function &getModule($name, $title = null)
 	{
 		$result = null;
-		$modules = JModuleHelper::_load();
+		$modules =& JModuleHelper::_load();
 		$total = count($modules);
 
 		for ($i = 0; $i < $total; $i++)
@@ -83,7 +83,7 @@ abstract class JModuleHelper
 		$position = strtolower($position);
 		$result = array();
 
-		$modules = JModuleHelper::_load();
+		$modules =& JModuleHelper::_load();
 
 		$total = count($modules);
 		for ($i = 0; $i < $total; $i++)


### PR DESCRIPTION
Proposing to add missing references =& instead of assignments = for array of module objects in the references chain. JModuleHelper::_load returns a reference, but it is used is by assignment, instead of by reference assignment.
