### PR TITLE
Allow application to set $options.

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -374,12 +374,13 @@ class JWeb
 			);
 		}
 
-		if (!isset($options['directory'])){
+		if (!isset($options['directory']))
+		{
 			if ($this->get('themes.base'))
 			{
 				$options['directory'] = $this->get('themes.base');
 			}
-			// Fall back to constants.
+			// Fall back to conventions.
 			else
 			{
 				$options['directory'] = (defined('JPATH_BASE') ? JPATH_BASE : dirname(__FILE__)) . '/themes';

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -360,21 +360,30 @@ class JWeb
 	 */
 	protected function render()
 	{
-		// Setup the document options.
-		$options = array(
-			'template' => $this->get('theme'),
-			'file' => 'index.php',
-			'params' => ''
-		);
-
-		if ($this->get('themes.base'))
+		if (isset($this->options))
 		{
-			$options['directory'] = $this->get('themes.base');
+			$options = $this->options;
 		}
-		// Fall back to constants.
 		else
 		{
-			$options['directory'] = (defined('JPATH_BASE') ? JPATH_BASE : dirname(__FILE__)) . '/themes';
+			// Setup the document options.
+			$options = array(
+				'template' => $this->get('theme'),
+				'file' => 'index.php',
+				'params' => ''
+			);
+		}
+
+		if (!isset($options['directory'])){
+			if ($this->get('themes.base'))
+			{
+				$options['directory'] = $this->get('themes.base');
+			}
+			// Fall back to constants.
+			else
+			{
+				$options['directory'] = (defined('JPATH_BASE') ? JPATH_BASE : dirname(__FILE__)) . '/themes';
+			}
 		}
 
 		// Parse the document.


### PR DESCRIPTION
Sometimes an application would like to use a different folder name for templates or a second template, but currently this is not always possible, at least not simply when using JWeb.  For example it is easy to create theme2 but to actually access it when it is in a folder that is not called themes is very complex. One way that should work is to be able to do something like this in the application:

```
    $this->options = array(
        'template' => $this->get('theme2'),
        'file' => 'index.php',
        'params' => '',
        'directory' => 'templates',
    );
```

However currently this will always be overwritten by the hard coded options in JWeb.  This pull request simply adds checks for existing options before JWeb sets them.
