### PR TITLE
Add JOIN support to JDatabaseQuery UPDATE query

### DIFF
--- a/libraries/joomla/database/databasequery.php
+++ b/libraries/joomla/database/databasequery.php
@@ -349,6 +349,16 @@ abstract class JDatabaseQuery
 
 			case 'update':
 				$query .= (string) $this->update;
+
+				if ($this->join)
+				{
+					// special case for joins
+					foreach ($this->join as $join)
+					{
+						$query .= (string) $join;
+					}
+				}
+
 				$query .= (string) $this->set;
 
 				if ($this->where)

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -158,6 +158,34 @@ class JDatabaseQueryTest extends JoomlaTestCase
 	}
 
 	/**
+	 * Test for the JDatabaseQuery::__string method for a 'update' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function test__toStringUpdate()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
+
+		$q->update('#__foo AS a')
+			->join('INNER', 'b ON b.id = a.id')
+			->set('a.id = 2')
+			->where('b.id = 1');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(
+				"\nUPDATE #__foo AS a" .
+				"\nINNER JOIN b ON b.id = a.id" .
+				"\nSET a.id = 2" .
+				"\nWHERE b.id = 1"
+			),
+			'Tests for correct rendering.'
+		);
+	}
+
+	/**
 	 * Test for the castAsChar method.
 	 *
 	 * @return  void


### PR DESCRIPTION
JDatabaseQuery::__toString() currently does not handle JOIN statements in the UPDATE case.  This causes UPDATE queries that are joined to another table to fail due to the table not being joined.  Added support for this as well as a unit test testing the toString update case.
