### PR TITLE
Make changes to JHtmlBehaviorTest setup because of failing tests.

### DIFF
--- a/tests/suite/joomla/html/html/JHtmlBehaviorTest.php
+++ b/tests/suite/joomla/html/html/JHtmlBehaviorTest.php
@@ -63,6 +63,7 @@ class JHtmlBehaviorTest extends JoomlaTestCase
 	protected function setUp()
 	{
 		$this->saveFactoryState();
+		$_SERVER['HTTP_HOST'] = 'example.com';
 	}
 
 	/**


### PR DESCRIPTION
24 tests in JHtmlBehavior were failing because of missing $_SERVER['HTTP_HOST'], probably this showed up for me because of the order in which the tests were run. 
