### PR TITLE
Add loadLanguage for JHtml

### DIFF
--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -933,4 +933,25 @@ abstract class JHtml
 
 		return JHtml::$includePaths;
 	}
+
+	/**
+	 * Loads the language file for a package
+	 *
+	 * @param   string  $package  The package name
+	 *
+	 * @return  void
+	 *
+	 * @since   11.4
+	 */
+	public static function loadLanguage($package)
+	{
+		// Load Library language
+		$lang = JFactory::getLanguage();
+
+		// Try the package's file in the current language (without allowing the loading of the file in the default language)
+		$lang->load($package, JPATH_PLATFORM . '/joomla/html', null, false, false)
+		// Fallback to the package's file in the default language
+		|| $lang->load($package, JPATH_PLATFORM . '/joomla/html', null, true);
+
+	}
 }

--- a/libraries/joomla/html/html/date.php
+++ b/libraries/joomla/html/html/date.php
@@ -32,6 +32,9 @@ abstract class JHtmlDate
 	 */
 	public static function relative($date, $unit = null, $time = null)
 	{
+		// Load the package language
+		JHtml::loadLanguage('jhtmldate');
+
 		if (is_null($time))
 		{
 			// Get now

--- a/tests/suite/joomla/html/html/JHtmlDateTest.php
+++ b/tests/suite/joomla/html/html/JHtmlDateTest.php
@@ -17,38 +17,6 @@ require_once JPATH_PLATFORM.'/joomla/html/html/date.php';
 class JHtmlDateTest extends JoomlaTestCase
 {
 	/**
-	 * Setup for testing.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.3
-	 */
-	public function setUp()
-	{
-		parent::setUp();
-
-		// We are only coupled to Document and Language in JFactory.
-		$this->saveFactoryState();
-
-		JFactory::$language = $this->getMockLanguage();
-	}
-
-	/**
-	 * Overrides the parent tearDown method.
-	 *
-	 * @return  void
-	 *
-	 * @see     PHPUnit_Framework_TestCase::tearDown()
-	 * @since   11.3
-	 */
-	protected function tearDown()
-	{
-		$this->restoreFactoryState();
-
-		parent::tearDown();
-	}
-
-	/**
 	 * @return	array
 	 *
 	 * @since   11.3
@@ -59,28 +27,28 @@ class JHtmlDateTest extends JoomlaTestCase
 			// Element order: result, date, unit, time
 			// result - 1 hour ago
 			array(
-				'JLIB_HTML_DATE_RELATIVE_HOURS',
+				'1 hour ago',
 				JFactory::getDate('2011-10-18 11:00:00'),
 				null,
 				JFactory::getDate('2011-10-18 12:00:00')
 			),
 			// result - 10 days ago
 			array(
-				'JLIB_HTML_DATE_RELATIVE_DAYS',
+				'10 days ago',
 				JFactory::getDate('2011-10-08 12:00:00'),
 				'day',
 				JFactory::getDate('2011-10-18 12:00:00')
 			),
 			// result - 3 weeks ago
 			array(
-				'JLIB_HTML_DATE_RELATIVE_WEEKS',
+				'3 weeks ago',
 				JFactory::getDate('2011-09-27 12:00:00'),
 				'week',
 				JFactory::getDate('2011-10-18 12:00:00')
 			),
 			// result - 10 minutes ago
 			array(
-				'JLIB_HTML_DATE_RELATIVE_MINUTES',
+				'10 minutes ago',
 				JFactory::getDate('2011-10-18 11:50:00'),
 				'minute',
 				JFactory::getDate('2011-10-18 12:00:00')


### PR DESCRIPTION
With the JHtmlDate addition, we added a language folder to the JHtml package, but currently have no real way to load in the language files.  I've added a loadLanguage method to JHtml to allow for this to happen.
