### PR TITLE
Joomla CMS [#25431] JUserHelper::getProfile does not return a profile 

### DIFF
--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -215,7 +215,8 @@ abstract class JUserHelper
 	 */
 	function getProfile($userId = 0)
 	{
-		if ($userId == 0) {
+		if ($userId == 0)
+		{
 			$user	= JFactory::getUser();
 			$userId	= $user->id;
 		}
@@ -225,7 +226,7 @@ abstract class JUserHelper
 		JPluginHelper::importPlugin('user');
 
 		$data = new JObject;
-        $data->id = $userId;
+		$data->id = $userId;
 
 		// Trigger the data preparation event.
 		$dispatcher->trigger('onContentPrepareData', array('com_users.profile', &$data));

--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -215,24 +215,20 @@ abstract class JUserHelper
 	 */
 	function getProfile($userId = 0)
 	{
-		if ($userId == 0)
-		{
-			$user = JFactory::getUser();
-			$userId = $user->id;
-		}
-		else
-		{
-			$user = JFactory::getUser((int) $userId);
+		if ($userId == 0) {
+			$user	= JFactory::getUser();
+			$userId	= $user->id;
 		}
 
 		// Get the dispatcher and load the user's plugins.
-		$dispatcher = JDispatcher::getInstance();
+		$dispatcher	= JDispatcher::getInstance();
 		JPluginHelper::importPlugin('user');
 
 		$data = new JObject;
+        $data->id = $userId;
 
 		// Trigger the data preparation event.
-		$dispatcher->trigger('onPrepareUserProfileData', array($userId, &$data));
+		$dispatcher->trigger('onContentPrepareData', array('com_users.profile', &$data));
 
 		return $data;
 	}


### PR DESCRIPTION
Fixes #343

It now returns an array of the profile field data stored for a given user.

See also http://joomlacode.org/gf/project/joomla/tracker/%3Faction%3DTrackerItemEdit%26tracker_item_id%3D20025/?action=TrackerItemEdit&tracker_item_id=25431
