### PR TITLE
Code style: Mark protected member vars as deprecated

### DIFF
--- a/libraries/import.php
+++ b/libraries/import.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * @package     Joomla.Platform
+ * @package    Joomla.Platform
  *
- * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE
+ * @copyright  Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 // Set the platform root path as a constant if necessary.

--- a/libraries/joomla/application/application.php
+++ b/libraries/joomla/application/application.php
@@ -33,6 +33,15 @@ class JApplication extends JObject
 	 * @var    integer
 	 * @since  11.1
 	 */
+	protected $clientId = null;
+
+	/**
+	 * The client identifier.
+	 *
+	 * @var    integer
+	 * @since  11.1
+	 * @deprecated use $clientId or declare as private
+	 */
 	protected $_clientId = null;
 
 	/**
@@ -41,6 +50,15 @@ class JApplication extends JObject
 	 * @var    array
 	 * @since  11.1
 	 */
+	protected $messageQueue = array();
+
+	/**
+	 * The application message queue.
+	 *
+	 * @var    array
+	 * @since  11.1
+	 * @deprecated use $messageQueue or declare as private
+	 */
 	protected $_messageQueue = array();
 
 	/**
@@ -48,6 +66,15 @@ class JApplication extends JObject
 	 *
 	 * @var    array
 	 * @since  11.1
+	 */
+	protected $name = null;
+
+	/**
+	 * The name of the application.
+	 *
+	 * @var    array
+	 * @since  11.1
+	 * @deprecated use $name or declare as private
 	 */
 	protected $_name = null;
 

--- a/libraries/joomla/application/categories.php
+++ b/libraries/joomla/application/categories.php
@@ -24,13 +24,22 @@ class JCategories
 	 * @var    array
 	 * @since  11.1
 	 */
-	static $instances = array();
+	public static $instances = array();
 
 	/**
 	 * Array of category nodes
 	 *
 	 * @var    mixed
 	 * @since  11.1
+	 */
+	protected $nodes;
+
+	/**
+	 * Array of category nodes
+	 *
+	 * @var    mixed
+	 * @since  11.1
+	 * @deprecated use $nodes or declare as private
 	 */
 	protected $_nodes;
 
@@ -40,6 +49,15 @@ class JCategories
 	 * @var    array
 	 * @since  11.1
 	 */
+	protected $checkedCategories;
+
+	/**
+	 * Array of checked categories -- used to save values when _nodes are null
+	 *
+	 * @var    array
+	 * @since  11.1
+	 * @deprecated use $checkedCategories or declare as private
+	 */
 	protected $_checkedCategories;
 
 	/**
@@ -47,6 +65,15 @@ class JCategories
 	 *
 	 * @var    string
 	 * @since  11.1
+	 */
+	protected $extension = null;
+
+	/**
+	 * Name of the extension the categories belong to
+	 *
+	 * @var    string
+	 * @since  11.1
+	 * @deprecated use $extension or declare as private
 	 */
 	protected $_extension = null;
 
@@ -56,6 +83,15 @@ class JCategories
 	 * @var    string
 	 * @since  11.1
 	 */
+	protected $table = null;
+
+	/**
+	 * Name of the linked content table to get category content count
+	 *
+	 * @var    string
+	 * @since  11.1
+	 * @deprecated use $table or declare as private
+	 */
 	protected $_table = null;
 
 	/**
@@ -63,6 +99,15 @@ class JCategories
 	 *
 	 * @var    string
 	 * @since  11.1
+	 */
+	protected $field = null;
+
+	/**
+	 * Name of the category field
+	 *
+	 * @var    string
+	 * @since  11.1
+	 * @deprecated use $field or declare as private
 	 */
 	protected $_field = null;
 
@@ -72,6 +117,15 @@ class JCategories
 	 * @var    string
 	 * @since  11.1
 	 */
+	protected $key = null;
+
+	/**
+	 * Name of the key field
+	 *
+	 * @var    string
+	 * @since  11.1
+	 * @deprecated use $key or declare as private
+	 */
 	protected $_key = null;
 
 	/**
@@ -80,6 +134,15 @@ class JCategories
 	 * @var    string
 	 * @since  11.1
 	 */
+	protected $statefield = null;
+
+	/**
+	 * Name of the items state field
+	 *
+	 * @var    string
+	 * @since  11.1
+	 * @deprecated use $statefield or declare as private
+	 */
 	protected $_statefield = null;
 
 	/**
@@ -87,6 +150,15 @@ class JCategories
 	 *
 	 * @var    array
 	 * @since  11.1
+	 */
+	protected $options = null;
+
+	/**
+	 * Array of options
+	 *
+	 * @var    array
+	 * @since  11.1
+	 * @deprecated use $options or declare as private
 	 */
 	protected $_options = null;
 
@@ -590,11 +662,27 @@ class JCategoryNode extends JObject
 	 * @var    object
 	 * @since  11.1
 	 */
+	protected $parent = null;
+
+	/**
+	 * Parent Category object
+	 *
+	 * @var    object
+	 * @since  11.1
+	 * @deprecated use $parent or declare as private
+	 */
 	protected $_parent = null;
 
 	/**
 	 * @var Array of Children
 	 * @since  11.1
+	 */
+	protected $children = array();
+
+	/**
+	 * @var Array of Children
+	 * @since  11.1
+	 * @deprecated use $children or declare as private
 	 */
 	protected $_children = array();
 
@@ -604,6 +692,15 @@ class JCategoryNode extends JObject
 	 * @var    array
 	 * @since  11.1
 	 */
+	protected $path = array();
+
+	/**
+	 * Path from root to this category
+	 *
+	 * @var    array
+	 * @since  11.1
+	 * @deprecated use $path or declare as private
+	 */
 	protected $_path = array();
 
 	/**
@@ -611,6 +708,15 @@ class JCategoryNode extends JObject
 	 *
 	 * @var    integer
 	 * @since  11.1
+	 */
+	protected $leftSibling = null;
+
+	/**
+	 * Category left of this one
+	 *
+	 * @var    integer
+	 * @since  11.1
+	 * @deprecated use $leftSibling or declare as private
 	 */
 	protected $_leftSibling = null;
 
@@ -620,6 +726,15 @@ class JCategoryNode extends JObject
 	 * @var
 	 * @since  11.1
 	 */
+	protected $rightSibling = null;
+
+	/**
+	 * Category right of this one
+	 *
+	 * @var
+	 * @since  11.1
+	 * @deprecated use $rightSibling or declare as private
+	 */
 	protected $_rightSibling = null;
 
 	/**
@@ -628,6 +743,15 @@ class JCategoryNode extends JObject
 	 * @var boolean
 	 * @since  11.1
 	 */
+	protected $allChildrenloaded = false;
+
+	/**
+	 * true if all children have been loaded
+	 *
+	 * @var boolean
+	 * @since  11.1
+	 * @deprecated use $allChildrenloaded or declare as private
+	 */
 	protected $_allChildrenloaded = false;
 
 	/**
@@ -635,6 +759,15 @@ class JCategoryNode extends JObject
 	 *
 	 * @var
 	 * @since  11.1
+	 */
+	protected $constructor = null;
+
+	/**
+	 * Constructor of this tree
+	 *
+	 * @var
+	 * @since  11.1
+	 * @deprecated use $constructor or declare as private
 	 */
 	protected $_constructor = null;
 

--- a/libraries/joomla/application/component/helper.php
+++ b/libraries/joomla/application/component/helper.php
@@ -24,6 +24,15 @@ class JComponentHelper
 	 * @var    array
 	 * @since  11.1
 	 */
+	protected static $components = array();
+
+	/**
+	 * The component list cache
+	 *
+	 * @var    array
+	 * @since  11.1
+	 * @deprecated use $components declare as private
+	 */
 	protected static $_components = array();
 
 	/**
@@ -38,11 +47,11 @@ class JComponentHelper
 	 */
 	public static function getComponent($option, $strict = false)
 	{
-		if (!isset(self::$_components[$option]))
+		if (!isset(self::$components[$option]))
 		{
 			if (self::_load($option))
 			{
-				$result = self::$_components[$option];
+				$result = self::$components[$option];
 			}
 			else
 			{
@@ -53,7 +62,7 @@ class JComponentHelper
 		}
 		else
 		{
-			$result = self::$_components[$option];
+			$result = self::$components[$option];
 		}
 
 		return $result;
@@ -224,9 +233,9 @@ class JComponentHelper
 
 		$cache = JFactory::getCache('_system', 'callback');
 
-		self::$_components[$option] = $cache->get(array($db, 'loadObject'), null, $option, false);
+		self::$components[$option] = $cache->get(array($db, 'loadObject'), null, $option, false);
 
-		if ($error = $db->getErrorMsg() || empty(self::$_components[$option]))
+		if ($error = $db->getErrorMsg() || empty(self::$components[$option]))
 		{
 			// Fatal error.
 			JError::raiseWarning(500, JText::sprintf('JLIB_APPLICATION_ERROR_COMPONENT_NOT_LOADING', $option, $error));
@@ -234,11 +243,11 @@ class JComponentHelper
 		}
 
 		// Convert the params to an object.
-		if (is_string(self::$_components[$option]->params))
+		if (is_string(self::$components[$option]->params))
 		{
 			$temp = new JRegistry;
-			$temp->loadString(self::$_components[$option]->params);
-			self::$_components[$option]->params = $temp;
+			$temp->loadString(self::$components[$option]->params);
+			self::$components[$option]->params = $temp;
 		}
 
 		return true;

--- a/libraries/joomla/application/component/model.php
+++ b/libraries/joomla/application/component/model.php
@@ -27,6 +27,15 @@ abstract class JModel extends JObject
 	 * @var    boolean
 	 * @since  11.1
 	 */
+	protected $stateSet = null;
+
+	/**
+	 * Indicates if the internal state has been set
+	 *
+	 * @var    boolean
+	 * @since  11.1
+	 * @deprecated use $stateSet declare as private
+	 */
 	protected $__state_set = null;
 
 	/**
@@ -34,6 +43,15 @@ abstract class JModel extends JObject
 	 *
 	 * @var    object
 	 * @since  11.1
+	 */
+	protected $db;
+
+	/**
+	 * Database Connector
+	 *
+	 * @var    object
+	 * @since  11.1
+	 * @deprecated use $db declare as private
 	 */
 	protected $_db;
 

--- a/libraries/joomla/application/component/modelform.php
+++ b/libraries/joomla/application/component/modelform.php
@@ -29,6 +29,15 @@ abstract class JModelForm extends JModel
 	 * @var    array
 	 * @since  11.1
 	 */
+	protected $forms = array();
+
+	/**
+	 * Array of form objects.
+	 *
+	 * @var    array
+	 * @since  11.1
+	 * @deprecated use $forms declare as private
+	 */
 	protected $_forms = array();
 
 	/**

--- a/libraries/joomla/application/component/modelitem.php
+++ b/libraries/joomla/application/component/modelitem.php
@@ -26,6 +26,14 @@ abstract class JModelItem extends JModel
 	 * @var    array
 	 * @since  11.1
 	 */
+	protected $item = null;
+
+	/**
+	 * An item.
+	 *
+	 * @var    array
+	 * @deprecated use $item declare as private
+	 */
 	protected $_item = null;
 
 	/**
@@ -33,6 +41,15 @@ abstract class JModelItem extends JModel
 	 *
 	 * @var    string
 	 * @since  11.1
+	 */
+	protected $context = 'group.type';
+
+	/**
+	 * Model context string.
+	 *
+	 * @var    string
+	 * @since  11.1
+	 * @deprecated use $context declare as private
 	 */
 	protected $_context = 'group.type';
 

--- a/libraries/joomla/application/component/view.php
+++ b/libraries/joomla/application/component/view.php
@@ -25,12 +25,28 @@ class JView extends JObject
 	 *
 	 * @var    array
 	 */
+	protected $name = null;
+
+	/**
+	 * The name of the view
+	 *
+	 * @var    array
+	 * @deprecated use $name declare as private
+	 */
 	protected $_name = null;
 
 	/**
 	 * Registered models
 	 *
 	 * @var    array
+	 */
+	protected $models = array();
+
+	/**
+	 * Registered models
+	 *
+	 * @var    array
+	 * @deprecated use $models declare as private
 	 */
 	protected $_models = array();
 
@@ -39,12 +55,28 @@ class JView extends JObject
 	 *
 	 * @var    string
 	 */
+	protected $basePath = null;
+
+	/**
+	 * The base path of the view
+	 *
+	 * @var    string
+	 * @deprecated use $basePath declare as private
+	 */
 	protected $_basePath = null;
 
 	/**
 	 * The default model
 	 *
 	 * @var	string
+	 */
+	protected $defaultModel = null;
+
+	/**
+	 * The default model
+	 *
+	 * @var	string
+	 * @deprecated use $defaultModel declare as private
 	 */
 	protected $_defaultModel = null;
 
@@ -53,12 +85,28 @@ class JView extends JObject
 	 *
 	 * @var    string
 	 */
+	protected $layout = 'default';
+
+	/**
+	 * Layout name
+	 *
+	 * @var    string
+	 * @deprecated use $layout declare as private
+	 */
 	protected $_layout = 'default';
 
 	/**
 	 * Layout extension
 	 *
 	 * @var    string
+	 */
+	protected $layoutExt = 'php';
+
+	/**
+	 * Layout extension
+	 *
+	 * @var    string
+	 * @deprecated use $layoutExt declare as private
 	 */
 	protected $_layoutExt = 'php';
 
@@ -67,12 +115,28 @@ class JView extends JObject
 	 *
 	 * @var    string
 	 */
+	protected $layoutTemplate = '_';
+
+	/**
+	 * Layout template
+	 *
+	 * @var    string
+	 * @deprecated use $layoutTemplate declare as private
+	 */
 	protected $_layoutTemplate = '_';
 
 	/**
 	 * The set of search directories for resources (templates)
 	 *
 	 * @var array
+	 */
+	protected $path = array('template' => array(), 'helper' => array());
+
+	/**
+	 * The set of search directories for resources (templates)
+	 *
+	 * @var array
+	 * @deprecated use $path declare as private
 	 */
 	protected $_path = array('template' => array(), 'helper' => array());
 
@@ -81,12 +145,28 @@ class JView extends JObject
 	 *
 	 * @var string
 	 */
+	protected $template = null;
+
+	/**
+	 * The name of the default template source file.
+	 *
+	 * @var string
+	 * @deprecated use $template declare as private
+	 */
 	protected $_template = null;
 
 	/**
 	 * The output of the template script.
 	 *
 	 * @var string
+	 */
+	protected $output = null;
+
+	/**
+	 * The output of the template script.
+	 *
+	 * @var string
+	 * @deprecated use $output declare as private
 	 */
 	protected $_output = null;
 
@@ -95,12 +175,28 @@ class JView extends JObject
 	 *
 	 * @var string
 	 */
+	protected $escape = 'htmlspecialchars';
+
+	/**
+	 * Callback for escaping.
+	 *
+	 * @var string
+	 * @deprecated use $escape declare as private
+	 */
 	protected $_escape = 'htmlspecialchars';
 
 	/**
 	 * Charset to use in escaping mechanisms; defaults to urf8 (UTF-8)
 	 *
 	 * @var string
+	 */
+	protected $charset = 'UTF-8';
+
+	/**
+	 * Charset to use in escaping mechanisms; defaults to urf8 (UTF-8)
+	 *
+	 * @var string
+	 * @deprecated use $charset declare as private
 	 */
 	protected $_charset = 'UTF-8';
 

--- a/libraries/joomla/application/helper.php
+++ b/libraries/joomla/application/helper.php
@@ -24,6 +24,15 @@ class JApplicationHelper
 	 * @var    array
 	 * @since  11.1
 	 */
+	protected static $clients = null;
+
+	/**
+	 * Client information array
+	 *
+	 * @var    array
+	 * @since  11.1
+	 * @deprecated use $clientsor declare as private
+	 */
 	protected static $_clients = null;
 
 	/**

--- a/libraries/joomla/application/menu.php
+++ b/libraries/joomla/application/menu.php
@@ -24,6 +24,15 @@ class JMenu extends JObject
 	 * @var    array
 	 * @since   11.1
 	 */
+	protected $items = array();
+
+	/**
+	 * Array to hold the menu items
+	 *
+	 * @var    array
+	 * @since   11.1
+	 * @deprecated use $items declare as private
+	 */
 	protected $_items = array();
 
 	/**
@@ -32,6 +41,15 @@ class JMenu extends JObject
 	 * @var    integer
 	 * @since   11.1
 	 */
+	protected $default = array();
+
+	/**
+	 * Identifier of the default menu item
+	 *
+	 * @var    integer
+	 * @since   11.1
+	 * @deprecated use $default declare as private
+	 */
 	protected $_default = array();
 
 	/**
@@ -39,6 +57,15 @@ class JMenu extends JObject
 	 *
 	 * @var    integer
 	 * @since  11.1
+	 */
+	protected $active = 0;
+
+	/**
+	 * Identifier of the active menu item
+	 *
+	 * @var    integer
+	 * @since  11.1
+	 * @deprecated use $active declare as private
 	 */
 	protected $_active = 0;
 

--- a/libraries/joomla/application/pathway.php
+++ b/libraries/joomla/application/pathway.php
@@ -24,11 +24,25 @@ class JPathway extends JObject
 	 * @var    array  Array to hold the pathway item objects
 	 * @since  11.1
 	 */
+	protected $pathway = null;
+
+	/**
+	 * @var    array  Array to hold the pathway item objects
+	 * @since  11.1
+	 * @deprecated use $pathway declare as private
+	 */
 	protected $_pathway = null;
 
 	/**
 	 * @var    integer  Integer number of items in the pathway
 	 * @since  11.1
+	 */
+	protected $count = 0;
+
+	/**
+	 * @var    integer  Integer number of items in the pathway
+	 * @since  11.1
+	 * @deprecated use $count declare as private
 	 */
 	protected $_count = 0;
 

--- a/libraries/joomla/application/router.php
+++ b/libraries/joomla/application/router.php
@@ -30,6 +30,15 @@ class JRouter extends JObject
 	 * @var    integer
 	 * @since  11.1
 	 */
+	protected $mode = null;
+
+	/**
+	 * The rewrite mode
+	 *
+	 * @var    integer
+	 * @since  11.1
+	 * @deprecated use $mode declare as private
+	 */
 	protected $_mode = null;
 
 	/**
@@ -38,6 +47,15 @@ class JRouter extends JObject
 	 * @var     array
 	 * @since   11.1
 	 */
+	protected $vars = array();
+
+	/**
+	 * An array of variables
+	 *
+	 * @var     array
+	 * @since   11.1
+	 * @deprecated use $vars declare as private
+	 */
 	protected $_vars = array();
 
 	/**
@@ -45,6 +63,18 @@ class JRouter extends JObject
 	 *
 	 * @var    array
 	 * @since  11.1
+	 */
+	protected $rules = array(
+		'build' => array(),
+		'parse' => array()
+	);
+
+	/**
+	 * An array of rules
+	 *
+	 * @var    array
+	 * @since  11.1
+	 * @deprecated use $rules declare as private
 	 */
 	protected $_rules = array(
 		'build' => array(),

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * @package     Joomla.Platform
+ * @package    Joomla.Platform
  *
- * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE
+ * @copyright  Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 defined('JPATH_PLATFORM') or die;
@@ -74,7 +74,7 @@ abstract class JLoader
 					// Register the class with the autoloader if not already registered or the force flag is set.
 					if (empty(self::$classes[$class]) || $force)
 					{
-						JLoader::register($class, $file->getPath().'/'.$fileName);
+						JLoader::register($class, $file->getPath() . '/' . $fileName);
 					}
 				}
 			}
@@ -100,8 +100,8 @@ abstract class JLoader
 	/**
 	 * Loads a class from specified directories.
 	 *
-	 * @param   string   $key   The class name to look for (dot notation).
-	 * @param   string   $base  Search this directory for the class.
+	 * @param   string  $key   The class name to look for (dot notation).
+	 * @param   string  $base  Search this directory for the class.
 	 *
 	 * @return  boolean  True on success.
 	 *
@@ -168,7 +168,7 @@ abstract class JLoader
 	/**
 	 * Load the file for a class.
 	 *
-	 * @param   string   $class  The class to be loaded.
+	 * @param   string  $class  The class to be loaded.
 	 *
 	 * @return  boolean  True on success
 	 *
@@ -241,7 +241,7 @@ abstract class JLoader
 	/**
 	 * Autoload a Joomla Platform class based on name.
 	 *
-	 * @param   string   $class  The class to be loaded.
+	 * @param   string  $class  The class to be loaded.
 	 *
 	 * @return  void
 	 *
@@ -253,7 +253,7 @@ abstract class JLoader
 		if ($class[0] == 'J')
 		{
 			// Split the class name (without the J) into parts separated by camelCase.
-			$parts = preg_split('/(?<=[a-z])(?=[A-Z])/x',substr($class, 1));
+			$parts = preg_split('/(?<=[a-z])(?=[A-Z])/x', substr($class, 1));
 
 			// If there is only one part we want to duplicate that part for generating the path.
 			$parts = (count($parts) === 1) ? array($parts[0], $parts[0]) : $parts;
@@ -290,7 +290,7 @@ function jexit($message = 0)
 /**
  * Intelligent file importer.
  *
- * @param   string   $path  A dot syntax path.
+ * @param   string  $path  A dot syntax path.
  *
  * @return  boolean  True on success.
  *

--- a/libraries/platform.php
+++ b/libraries/platform.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * @package     Joomla.Platform
+ * @package    Joomla.Platform
  *
- * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE
+ * @copyright  Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 defined('JPATH_PLATFORM') or die;


### PR DESCRIPTION
Mark protected member vars as deprecated if they are prefixed with an underscore. Add proper pendant.
Package: application

I used:
`@deprecated use $XXX or declare as private`
Not sure as of which version to deprecate - please advise.
It should also be verified if the var could be declared as private, including the underscore.

This will fix 45 code style warnings.
