### PR TITLE
Joomla CMS [#27246] JFormFieldTimezone default value not set

### DIFF
--- a/libraries/joomla/form/fields/timezone.php
+++ b/libraries/joomla/form/fields/timezone.php
@@ -55,7 +55,7 @@ class JFormFieldTimezone extends JFormFieldGroupedList
 		// If the timezone is not set use the server setting.
 		if (strlen($this->value) == 0)
 		{
-			$value = JFactory::getConfig()->get('offset');
+			$this->value = JFactory::getConfig()->get('offset');
 		}
 
 		// Get the list of time zones from the server.

--- a/libraries/joomla/form/fields/timezone.php
+++ b/libraries/joomla/form/fields/timezone.php
@@ -51,7 +51,7 @@ class JFormFieldTimezone extends JFormFieldGroupedList
 	{
 		// Initialize variables.
 		$groups = array();
-		
+
 		$keyField = $this->element['key_field'] ? (string) $this->element['key_field'] : 'id';
 		$keyValue = $this->form->getValue($keyField);
 

--- a/libraries/joomla/form/fields/timezone.php
+++ b/libraries/joomla/form/fields/timezone.php
@@ -51,9 +51,12 @@ class JFormFieldTimezone extends JFormFieldGroupedList
 	{
 		// Initialize variables.
 		$groups = array();
+		
+		$keyField = $this->element['key_field'] ? (string) $this->element['key_field'] : 'id';
+		$keyValue = $this->form->getValue($keyField);
 
 		// If the timezone is not set use the server setting.
-		if (strlen($this->value) == 0)
+		if (strlen($this->value) == 0 && empty($keyValue))
 		{
 			$this->value = JFactory::getConfig()->get('offset');
 		}


### PR DESCRIPTION
Server config value is set to wrong variable name.  See CMS Bug Tracker #27246.
