### PR TITLE
Joomla CMS [#25788] JFilterInput does not handle comment tags well.  

### DIFF
--- a/libraries/joomla/filter/filterinput.php
+++ b/libraries/joomla/filter/filterinput.php
@@ -334,6 +334,23 @@ class JFilterInput extends JObject
 			$postTag = substr($postTag, $tagOpen_start);
 			$fromTagOpen = substr($postTag, 1);
 			$tagOpen_end = strpos($fromTagOpen, '>');
+			
+			// Check for comment tag -- this will ignore all HTML within the comment tags
+			if (substr($fromTagOpen, 0, 1) == '!') 
+			{
+				// Find end of comment and skip all within it
+				$tagOpen_end = strpos($fromTagOpen, '-->');
+				if ($tagOpen_end) 
+				{
+					$tagOpen_end += 2;
+					$preTag .= '<' . substr($fromTagOpen, 0, $tagOpen_end);
+					$postTag = substr($postTag, $tagOpen_end + 1);
+				}
+				
+				// If comment tag is not closed, keep the opening tag and text but clean any tags within
+				$tagOpen_start	= strpos($fromTagOpen, '<') + 1;
+				continue;
+			}
 
 			// Check for mal-formed tag where we have a second '<' before the first '>'
 			$nextOpenTag = (strlen($postTag) > $tagOpen_start) ? strpos($postTag, '<', $tagOpen_start + 1) : false;


### PR DESCRIPTION
See http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=25788.  This adds a check for comment tags prior to the check for malformed tags.  If comment tag has proper open and close, any text or html within the tags is skipped over.  If the closing comment tag is missing, any contained html is cleaned and the opening tag is left in place to reduce user confusion (so they can see they had an opening tag but no closing tag).
