### PR TITLE
Fix a problem with the close method in the MySQLi driver.

### DIFF
--- a/libraries/joomla/database/database/mysqli.php
+++ b/libraries/joomla/database/database/mysqli.php
@@ -155,7 +155,7 @@ class JDatabaseMySQLi extends JDatabase
 	 */
 	public function __destruct()
 	{
-		if ($this->get('connection') != null && is_object($this->connection))
+		if (is_resource($this->connection))
 		{
 			mysqli_close($this->connection);
 		}

--- a/libraries/joomla/database/database/mysqli.php
+++ b/libraries/joomla/database/database/mysqli.php
@@ -155,7 +155,7 @@ class JDatabaseMySQLi extends JDatabase
 	 */
 	public function __destruct()
 	{
-		if (is_object($this->connection))
+		if ($this->get('connection') != null && is_object($this->connection))
 		{
 			mysqli_close($this->connection);
 		}


### PR DESCRIPTION
If no actual connection exists (even though the object exists) and you try to close the connection you get a warning. This adds a check to see if the connection is null before trying to close. 
