### PR TITLE
Change the way core.js is loaded.

### DIFF
--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -543,6 +543,7 @@ abstract class JHtml
 		// Function stylesheet($filename, $path = 'media/system/css/', $attribs = array())
 		if (is_string($attribs))
 		{
+			JLog::add('The used parameter set in JHtml::stylesheet() is deprecated.', JLog::WARNING, 'deprecated');
 			// Assume this was the old $path variable.
 			$file = $attribs . $file;
 		}
@@ -606,6 +607,7 @@ abstract class JHtml
 		// function script($filename, $path = 'media/system/js/', $mootools = true)
 		if (is_string($framework))
 		{
+			JLog::add('The used parameter set in JHtml::script() is deprecated.', JLog::WARNING, 'deprecated');
 			// Assume this was the old $path variable.
 			$file = $framework . $file;
 			$framework = $relative;
@@ -654,19 +656,12 @@ abstract class JHtml
 	 * @return  void
 	 *
 	 * @since   11.1
+	 * @deprecated  12.1  Use JHtml::_('behavior.framework'); instead.
 	 */
 	public static function core($debug = null)
 	{
-		// If no debugging value is set, use the configuration setting
-		if ($debug === null)
-		{
-			$debug = JFactory::getConfig()->get('debug');
-		}
-
-		$uncompressed = $debug ? '-uncompressed' : '';
-
-		$document = JFactory::getDocument();
-		$document->addScript(JURI::root(true) . '/media/system/js/core' . $uncompressed . '.js');
+		JLog::add('JHtml::core() is deprecated. Use JHtml::_(\'behavior.framework\');.', JLog::WARNING, 'deprecated');
+		JHtml::_('behavior.framework', false, $debug);
 	}
 
 	/**

--- a/libraries/joomla/html/html/behavior.php
+++ b/libraries/joomla/html/html/behavior.php
@@ -45,8 +45,6 @@ abstract class JHtmlBehavior
 			return;
 		}
 
-		JHtml::core($debug);
-
 		// If no debugging value is set, use the configuration setting
 		if ($debug === null)
 		{
@@ -60,6 +58,7 @@ abstract class JHtmlBehavior
 		}
 
 		JHtml::_('script', 'system/mootools-' . $type . '.js', false, true, false, false, $debug);
+		JHtml::_('script', 'system/core.js', false, true);
 		self::$loaded[__METHOD__][$type] = true;
 
 		return;


### PR DESCRIPTION
Since core.js requires MooTools anyways we don't need to be able to load it without MooTools.
