### PR TITLE
JPath::check() throws Error 20 when running in a chroot jail

### DIFF
--- a/libraries/joomla/filesystem/path.php
+++ b/libraries/joomla/filesystem/path.php
@@ -177,7 +177,7 @@ class JPath
 		}
 
 		$path = JPath::clean($path);
-		if (strpos($path, JPath::clean(JPATH_ROOT)) !== 0)
+		if (!empty(JPATH_ROOT) && strpos($path, JPath::clean(JPATH_ROOT)) !== 0)
 		{
 			// Don't translate
 			JError::raiseError(20, 'JPath::check Snooping out of bounds @ ' . $path);


### PR DESCRIPTION
When JPATH_ROOT is an empty string –i.e. we run inside a chroot jail– JPath::check() always raises error 20 (snooping out of bounds). By definition of the chroot jail, we can snoop out of bounds in this case. Therefore this check should always succeed. Ergo the proposed change.
