### PR TITLE
Add missing type hints to newer classes.

### DIFF
--- a/libraries/joomla/application/cli.php
+++ b/libraries/joomla/application/cli.php
@@ -297,7 +297,7 @@ class JCli
 	 *
 	 * @since   11.1
 	 */
-	public function triggerEvent($event, $args = null)
+	public function triggerEvent($event, array $args = null)
 	{
 		if ($this->dispatcher instanceof JDispatcher)
 		{

--- a/libraries/joomla/application/input.php
+++ b/libraries/joomla/application/input.php
@@ -64,7 +64,7 @@ class JInput
 	 *
 	 * @since   11.1
 	 */
-	public function __construct($source = null, $options = array())
+	public function __construct($source = null, array $options = array())
 	{
 		if (isset($options['filter']))
 		{
@@ -152,7 +152,7 @@ class JInput
 	 *
 	 * @since   11.1
 	 */
-	public function getArray($vars, $datasource = null)
+	public function getArray(array $vars, $datasource = null)
 	{
 		$results = array();
 

--- a/libraries/joomla/application/input/cli.php
+++ b/libraries/joomla/application/input/cli.php
@@ -45,7 +45,7 @@ class JInputCLI extends JInput
 	 *
 	 * @since   11.1
 	 */
-	public function __construct($source = null, $options = array ())
+	public function __construct(array $source = null, array $options = array())
 	{
 		if (isset($options['filter']))
 		{

--- a/libraries/joomla/application/input/cookie.php
+++ b/libraries/joomla/application/input/cookie.php
@@ -28,7 +28,7 @@ class JInputCookie extends JInput
 	 *
 	 * @since   11.1
 	 */
-	public function __construct($source = null, $options = array())
+	public function __construct(array $source = null, array $options = array())
 	{
 		if (isset($options['filter']))
 		{

--- a/libraries/joomla/application/input/files.php
+++ b/libraries/joomla/application/input/files.php
@@ -62,7 +62,7 @@ class JInputFiles extends JInput
 	 *
 	 * @since   11.1
 	 */
-	protected function decodeData($data)
+	protected function decodeData(array $data)
 	{
 		$result = array();
 

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -666,7 +666,7 @@ class JWeb
 	 *
 	 * @since   11.3
 	 */
-	public function triggerEvent($event, $args = null)
+	public function triggerEvent($event, array $args = null)
 	{
 		if ($this->dispatcher instanceof JDispatcher)
 		{

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -147,7 +147,7 @@ class JHttpTransportStream implements JHttpTransport
 	 * @since   11.3
 	 * @throws  UnexpectedValueException
 	 */
-	protected function getResponse($headers, $body)
+	protected function getResponse(array $headers, $body)
 	{
 		// Create the response object.
 		$return = new JHttpResponse;

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -228,7 +228,7 @@ class JImage
 	 * @throws  LogicException
 	 * @throws  RuntimeException
 	 */
-	public function filter($type, $options = array())
+	public function filter($type, array $options = array())
 	{
 		// Make sure the resource handle is valid.
 		if (!$this->isLoaded())
@@ -571,7 +571,7 @@ class JImage
 	 * @since   11.3
 	 * @throws  LogicException
 	 */
-	public function toFile($path, $type = IMAGETYPE_JPEG, $options = array())
+	public function toFile($path, $type = IMAGETYPE_JPEG, array $options = array())
 	{
 		// Make sure the resource handle is valid.
 		if (!$this->isLoaded())


### PR DESCRIPTION
Add missing type hints to newer classes.

Does it make sense to check older classes too or should I wait for 11.4 to be released?
