### PR TITLE
Code style: Fix a superfluous tab character

### DIFF
--- a/libraries/joomla/application/component/helper.php
+++ b/libraries/joomla/application/component/helper.php
@@ -174,7 +174,7 @@ class JComponentHelper
 		{
 			// Get the task again, in case it has changed
 			$task = JRequest::getString('task');
-	
+
 			// Make the toolbar
 			include_once $path;
 		}


### PR DESCRIPTION
This will remove a tab character - not more not less...

This is the "1 error" that joomla-jenkins shows on all pull requests.
