### PR TITLE
Use less deprecated functions in the platform

### DIFF
--- a/libraries/joomla/application/application.php
+++ b/libraries/joomla/application/application.php
@@ -144,7 +144,7 @@ class JApplication extends JObject
 		// Create the session if a session name is passed.
 		if ($config['session'] !== false)
 		{
-			$this->_createSession(JUtility::getHash($config['session_name']));
+			$this->_createSession(self::getHash($config['session_name']));
 		}
 
 		$this->set('requestTime', gmdate('Y-m-d H:i'));
@@ -732,7 +732,7 @@ class JApplication extends JObject
 					jimport('joomla.utilities.utility');
 
 					// Create the encryption key, apply extra hardening using the user agent string.
-					$key = JUtility::getHash(@$_SERVER['HTTP_USER_AGENT']);
+					$key = self::getHash(@$_SERVER['HTTP_USER_AGENT']);
 
 					$crypt = new JSimpleCrypt($key);
 					$rcookie = $crypt->encrypt(serialize($credentials));
@@ -741,7 +741,7 @@ class JApplication extends JObject
 					// Use domain and path set in config for cookie if it exists.
 					$cookie_domain = $this->getCfg('cookie_domain', '');
 					$cookie_path = $this->getCfg('cookie_path', '/');
-					setcookie(JUtility::getHash('JLOGIN_REMEMBER'), $rcookie, $lifetime, $cookie_path, $cookie_domain);
+					setcookie(self::getHash('JLOGIN_REMEMBER'), $rcookie, $lifetime, $cookie_path, $cookie_domain);
 				}
 
 				return true;
@@ -811,7 +811,7 @@ class JApplication extends JObject
 			// Use domain and path set in config for cookie if it exists.
 			$cookie_domain = $this->getCfg('cookie_domain', '');
 			$cookie_path = $this->getCfg('cookie_path', '/');
-			setcookie(JUtility::getHash('JLOGIN_REMEMBER'), false, time() - 86400, $cookie_path, $cookie_domain);
+			setcookie(self::getHash('JLOGIN_REMEMBER'), false, time() - 86400, $cookie_path, $cookie_domain);
 
 			return true;
 		}
@@ -957,9 +957,7 @@ class JApplication extends JObject
 	 */
 	public static function getHash($seed)
 	{
-		$conf = JFactory::getConfig();
-
-		return md5($conf->get('secret') . $seed);
+		return md5(JFactory::getConfig()->get('secret') . $seed);
 	}
 
 	/**

--- a/libraries/joomla/application/application.php
+++ b/libraries/joomla/application/application.php
@@ -857,7 +857,7 @@ class JApplication extends JObject
 		jimport('joomla.application.router');
 		$router = JRouter::getInstance($name, $options);
 
-		if (JError::isError($router))
+		if ($router instanceof Exception)
 		{
 			return null;
 		}
@@ -910,7 +910,7 @@ class JApplication extends JObject
 		jimport('joomla.application.pathway');
 		$pathway = JPathway::getInstance($name, $options);
 
-		if (JError::isError($pathway))
+		if ($pathway instanceof Exception)
 		{
 			return null;
 		}
@@ -938,7 +938,7 @@ class JApplication extends JObject
 		jimport('joomla.application.menu');
 		$menu = JMenu::getInstance($name, $options);
 
-		if (JError::isError($menu))
+		if ($menu instanceof Exception)
 		{
 			return null;
 		}

--- a/libraries/joomla/application/component/controllerform.php
+++ b/libraries/joomla/application/component/controllerform.php
@@ -649,7 +649,7 @@ class JControllerForm extends JController
 			// Push up to three validation messages out to the user.
 			for ($i = 0, $n = count($errors); $i < $n && $i < 3; $i++)
 			{
-				if (JError::isError($errors[$i]))
+				if ($errors[$i] instanceof Exception)
 				{
 					$app->enqueueMessage($errors[$i]->getMessage(), 'warning');
 				}

--- a/libraries/joomla/application/component/modelform.php
+++ b/libraries/joomla/application/component/modelform.php
@@ -235,7 +235,7 @@ abstract class JModelForm extends JModel
 			// Get the last error.
 			$error = $dispatcher->getError();
 
-			if (!JError::isError($error))
+			if (!($error instanceof Exception))
 			{
 				throw new Exception($error);
 			}
@@ -262,7 +262,7 @@ abstract class JModelForm extends JModel
 		$return = $form->validate($data, $group);
 
 		// Check for an error.
-		if (JError::isError($return))
+		if ($return instanceof Exception)
 		{
 			$this->setError($return->getMessage());
 			return false;

--- a/libraries/joomla/application/component/view.php
+++ b/libraries/joomla/application/component/view.php
@@ -203,7 +203,7 @@ class JView extends JObject
 	public function display($tpl = null)
 	{
 		$result = $this->loadTemplate($tpl);
-		if (JError::isError($result))
+		if ($result instanceof Exception)
 		{
 			return $result;
 		}

--- a/libraries/joomla/base/object.php
+++ b/libraries/joomla/base/object.php
@@ -151,7 +151,7 @@ class JObject
 		}
 
 		// Check if only the string is requested
-		if (JError::isError($error) && $toString)
+		if ($error instanceof Exception && $toString)
 		{
 			return (string) $error;
 		}

--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -179,7 +179,7 @@ class JCache extends JObject
 
 		// Get the storage
 		$handler = $this->_getStorage();
-		if (!JError::isError($handler) && $this->_options['caching'])
+		if (!($handler instanceof Exception) && $this->_options['caching'])
 		{
 			return $handler->get($id, $group, $this->_options['checkTime']);
 		}
@@ -197,7 +197,7 @@ class JCache extends JObject
 	{
 		// Get the storage
 		$handler = $this->_getStorage();
-		if (!JError::isError($handler) && $this->_options['caching'])
+		if (!($handler instanceof Exception) && $this->_options['caching'])
 		{
 			return $handler->getAll();
 		}
@@ -222,7 +222,7 @@ class JCache extends JObject
 
 		// Get the storage and store the cached data
 		$handler = $this->_getStorage();
-		if (!JError::isError($handler) && $this->_options['caching'])
+		if (!($handler instanceof Exception) && $this->_options['caching'])
 		{
 			$handler->_lifetime = $this->_options['lifetime'];
 			return $handler->store($id, $group, $data);
@@ -247,7 +247,7 @@ class JCache extends JObject
 
 		// Get the storage
 		$handler = $this->_getStorage();
-		if (!JError::isError($handler))
+		if (!($handler instanceof Exception))
 		{
 			return $handler->remove($id, $group);
 		}
@@ -274,7 +274,7 @@ class JCache extends JObject
 
 		// Get the storage handler
 		$handler = $this->_getStorage();
-		if (!JError::isError($handler))
+		if (!($handler instanceof Exception))
 		{
 			return $handler->clean($group, $mode);
 		}
@@ -292,7 +292,7 @@ class JCache extends JObject
 	{
 		// Get the storage handler
 		$handler = $this->_getStorage();
-		if (!JError::isError($handler))
+		if (!($handler instanceof Exception))
 		{
 			return $handler->gc();
 		}
@@ -323,7 +323,7 @@ class JCache extends JObject
 		// Allow storage handlers to perform locking on their own
 		// NOTE drivers with lock need also unlock or unlocking will fail because of false $id
 		$handler = $this->_getStorage();
-		if (!JError::isError($handler) && $this->_options['locking'] == true && $this->_options['caching'] == true)
+		if (!($handler instanceof Exception) && $this->_options['locking'] == true && $this->_options['caching'] == true)
 		{
 			$locked = $handler->lock($id, $group, $locktime);
 			if ($locked !== false)
@@ -401,7 +401,7 @@ class JCache extends JObject
 
 		//allow handlers to perform unlocking on their own
 		$handler = $this->_getStorage();
-		if (!JError::isError($handler) && $this->_options['caching'])
+		if (!($handler instanceof Exception) && $this->_options['caching'])
 		{
 			$unlocked = $handler->unlock($id, $group);
 			if ($unlocked !== false)

--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -490,7 +490,7 @@ class JCache extends JObject
 		{
 			// The following code searches for a token in the cached page and replaces it with the
 			// proper token.
-			$token = JUtility::getToken();
+			$token = JSession::getFormToken();
 			$search = '#<input type="hidden" name="[0-9a-f]{32}" value="1" />#';
 			$replacement = '<input type="hidden" name="' . $token . '" value="1" />';
 			$data['body'] = preg_replace($search, $replacement, $data['body']);

--- a/libraries/joomla/document/error/error.php
+++ b/libraries/joomla/document/error/error.php
@@ -55,7 +55,7 @@ class JDocumentError extends JDocument
 	 */
 	public function setError($error)
 	{
-		if (JError::isError($error))
+		if ($error instanceof Exception)
 		{
 			$this->_error = & $error;
 			return true;

--- a/libraries/joomla/environment/request.php
+++ b/libraries/joomla/environment/request.php
@@ -509,7 +509,7 @@ class JRequest
 	 */
 	public static function checkToken($method = 'post')
 	{
-		$token = JUtility::getToken();
+		$token = JSession::getFormToken();
 		if (!self::getVar($token, '', $method, 'alnum'))
 		{
 			$session = JFactory::getSession();

--- a/libraries/joomla/error/exception.php
+++ b/libraries/joomla/error/exception.php
@@ -278,7 +278,7 @@ class JException extends Exception
 		}
 
 		// Check if only the string is requested
-		if (JError::isError($error) && $toString)
+		if ($error instanceof Exception && $toString)
 		{
 			return (string) $error;
 		}

--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -709,7 +709,7 @@ abstract class JFactory
 
 		$db = JDatabase::getInstance($options);
 
-		if (JError::isError($db))
+		if ($db instanceof Exception)
 		{
 			if (!headers_sent())
 			{

--- a/libraries/joomla/filesystem/archive.php
+++ b/libraries/joomla/filesystem/archive.php
@@ -78,7 +78,7 @@ class JArchive
 					$tmpfname = $config->get('tmp_path') . '/' . uniqid('gzip');
 					$gzresult = $adapter->extract($archivename, $tmpfname);
 
-					if (JError::isError($gzresult))
+					if ($gzresult instanceof Exception)
 					{
 						@unlink($tmpfname);
 
@@ -121,7 +121,7 @@ class JArchive
 					$tmpfname = $config->get('tmp_path') . '/' . uniqid('bzip2');
 					$bzresult = $adapter->extract($archivename, $tmpfname);
 
-					if (JError::isError($bzresult))
+					if ($bzresult instanceof Exception)
 					{
 						@unlink($tmpfname);
 						return false;
@@ -154,7 +154,7 @@ class JArchive
 				break;
 		}
 
-		if (!$result || JError::isError($result))
+		if (!$result || $result instanceof Exception)
 		{
 			return false;
 		}

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1116,7 +1116,7 @@ class JForm
 			$valid = $this->validateField($field, $group, $value, $input);
 
 			// Check for an error.
-			if (JError::isError($valid))
+			if ($valid instanceof Exception)
 			{
 				switch ($valid->get('level'))
 				{
@@ -1836,7 +1836,7 @@ class JForm
 			$valid = $rule->test($element, $value, $group, $input, $this);
 
 			// Check for an error in the validation test.
-			if (JError::isError($valid))
+			if ($valid instanceof Exception)
 			{
 				return $valid;
 			}

--- a/libraries/joomla/html/html/form.php
+++ b/libraries/joomla/html/html/form.php
@@ -30,6 +30,6 @@ abstract class JHtmlForm
 	 */
 	public static function token()
 	{
-		return '<input type="hidden" name="' . JUtility::getToken() . '" value="1" />';
+		return '<input type="hidden" name="' . JSession::getFormToken() . '" value="1" />';
 	}
 }

--- a/libraries/joomla/log/loggers/database.php
+++ b/libraries/joomla/log/loggers/database.php
@@ -151,7 +151,7 @@ class JLoggerDatabase extends JLogger
 		{
 			$db = JDatabase::getInstance($options);
 
-			if (JError::isError($db))
+			if ($db instanceof Exception)
 			{
 				throw new LogException('Database Error: ' . (string) $db);
 			}

--- a/libraries/joomla/utilities/utility.php
+++ b/libraries/joomla/utilities/utility.php
@@ -86,18 +86,16 @@ class JUtility
 	 *
 	 * @return  string
 	 *
-	 * @deprecated  12.1
-	 * @see     JApplication:getHash()
+	 * @deprecated  12.1 Use JApplication::getHash() instead.
+	 * @see     JApplication::getHash()
 	 * @since   11.1
 	 */
 	public static function getHash($seed)
 	{
 		// Deprecation warning.
-		JLog::add('JUtility::getHash() is deprecated.', JLog::WARNING, 'deprecated');
+		JLog::add('JUtility::getHash() is deprecated. Use JApplication::getHash() instead.', JLog::WARNING, 'deprecated');
 
-		$conf = JFactory::getConfig();
-
-		return md5($conf->get('secret') . $seed);
+		return JApplication::getHash($seed);
 	}
 
 	/**

--- a/libraries/joomla/utilities/utility.php
+++ b/libraries/joomla/utilities/utility.php
@@ -107,17 +107,16 @@ class JUtility
 	 *
 	 * @return  string   Hashed var name
 	 *
-	 * @deprecated  12.1
-	 * @see     JApplication:getHash()
+	 * @deprecated  12.1 Use JSession::getFormToken() instead
+	 * @see     JSession::getFormToken()
 	 * @since   11.1
 	 */
 	public static function getToken($forceNew = false)
 	{
 		// Deprecation warning.
-		JLog::add('JUtility::getToken() is deprecated.', JLog::WARNING, 'deprecated');
+		JLog::add('JUtility::getToken() is deprecated. Use JSession::getFormToken() instead.', JLog::WARNING, 'deprecated');
 
 		$session = JFactory::getSession();
-
 		return $session->getFormToken($forceNew);
 	}
 

--- a/tests/suite/joomla/html/html/JHtmlFormTest.php
+++ b/tests/suite/joomla/html/html/JHtmlFormTest.php
@@ -21,7 +21,7 @@ class JHtmlFormTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testToken()
 	{
-		$token = JUtility::getToken();
+		$token = JSession::getFormToken();
 
 		$this->assertThat(
 			JHtmlForm::token(),


### PR DESCRIPTION
This should make a start in getting rid off deprecated stuff. This handles the following three functions:
JError:isError()
JUtility::getHash()
JUtility::getToken()

The first one can be replaced with the instanceof operator, the other two just moved to a different class. 
