### PR TITLE
Batch Processing work for CMS 2.5

### DIFF
--- a/libraries/joomla/application/component/controllerform.php
+++ b/libraries/joomla/application/component/controllerform.php
@@ -252,11 +252,28 @@ class JControllerForm extends JController
 	public function batch($model)
 	{
 		// Initialise variables.
-		$vars = JRequest::getVar('batch', array(), 'post', 'array');
-		$cid = JRequest::getVar('cid', array(), 'post', 'array');
+		$input	= JFactory::getApplication()->input;
+		$vars	= $input->post->get('batch', array(), 'array');
+		$cid	= $input->post->get('cid', array(), 'array');
+
+		// Build an array of item contexts to check
+		$contexts = array();
+		foreach ($cid as $id)
+		{
+			// If we're coming from com_categories, we need to use extension vs. option
+			if (isset($this->extension))
+			{
+				$option = $this->extension;
+			}
+			else
+			{
+				$option = $this->option;
+			}
+			$contexts[$id] = $option . '.' . $this->context . '.' . $id;
+		}
 
 		// Attempt to run the batch operation.
-		if ($model->batch($vars, $cid))
+		if ($model->batch($vars, $cid, $contexts))
 		{
 			$this->setMessage(JText::_('JLIB_APPLICATION_SUCCESS_BATCH'));
 

--- a/libraries/joomla/application/component/modeladmin.php
+++ b/libraries/joomla/application/component/modeladmin.php
@@ -225,9 +225,9 @@ abstract class JModelAdmin extends JModelForm
 	/**
 	 * Batch access level changes for a group of rows.
 	 *
-	 * @param   integer  $value      The new value matching an Asset Group ID.
-	 * @param   array    $pks        An array of row IDs.
-	 * @param   array    $contexts   An array of item contexts.
+	 * @param   integer  $value     The new value matching an Asset Group ID.
+	 * @param   array    $pks       An array of row IDs.
+	 * @param   array    $contexts  An array of item contexts.
 	 *
 	 * @return  boolean  True if successful, false otherwise and internal error is set.
 	 *
@@ -433,9 +433,9 @@ abstract class JModelAdmin extends JModelForm
 	/**
 	 * Batch move items to a new category
 	 *
-	 * @param   integer  $value      The new category ID.
-	 * @param   array    $pks        An array of row IDs.
-	 * @param   array    $contexts   An array of item contexts.
+	 * @param   integer  $value     The new category ID.
+	 * @param   array    $pks       An array of row IDs.
+	 * @param   array    $contexts  An array of item contexts.
 	 *
 	 * @return  boolean  True if successful, false otherwise and internal error is set.
 	 *

--- a/libraries/joomla/application/component/modeladmin.php
+++ b/libraries/joomla/application/component/modeladmin.php
@@ -141,12 +141,13 @@ abstract class JModelAdmin extends JModelForm
 	 *
 	 * @param   array  $commands  An array of commands to perform.
 	 * @param   array  $pks       An array of item ids.
+	 * @param   array  $contexts  An array of item contexts.
 	 *
-	 * @return	boolean	 Returns true on success, false on failure.
+	 * @return  boolean  Returns true on success, false on failure.
 	 *
-	 * @since	11.1
+	 * @since   11.1
 	 */
-	public function batch($commands, $pks)
+	public function batch($commands, $pks, $contexts)
 	{
 		// Sanitize user ids.
 		$pks = array_unique($pks);
@@ -172,7 +173,7 @@ abstract class JModelAdmin extends JModelForm
 
 			if ($cmd == 'c')
 			{
-				$result = $this->batchCopy($commands['category_id'], $pks);
+				$result = $this->batchCopy($commands['category_id'], $pks, $contexts);
 				if (is_array($result))
 				{
 					$pks = $result;
@@ -182,7 +183,7 @@ abstract class JModelAdmin extends JModelForm
 					return false;
 				}
 			}
-			elseif ($cmd == 'm' && !$this->batchMove($commands['category_id'], $pks))
+			elseif ($cmd == 'm' && !$this->batchMove($commands['category_id'], $pks, $contexts))
 			{
 				return false;
 			}
@@ -191,7 +192,7 @@ abstract class JModelAdmin extends JModelForm
 
 		if (!empty($commands['assetgroup_id']))
 		{
-			if (!$this->batchAccess($commands['assetgroup_id'], $pks))
+			if (!$this->batchAccess($commands['assetgroup_id'], $pks, $contexts))
 			{
 				return false;
 			}
@@ -201,7 +202,7 @@ abstract class JModelAdmin extends JModelForm
 
 		if (!empty($commands['language_id']))
 		{
-			if (!$this->batchLanguage($commands['language_id'], $pks))
+			if (!$this->batchLanguage($commands['language_id'], $pks, $contexts))
 			{
 				return false;
 			}
@@ -224,35 +225,37 @@ abstract class JModelAdmin extends JModelForm
 	/**
 	 * Batch access level changes for a group of rows.
 	 *
-	 * @param   integer  $value  The new value matching an Asset Group ID.
-	 * @param   array    $pks    An array of row IDs.
+	 * @param   integer  $value      The new value matching an Asset Group ID.
+	 * @param   array    $pks        An array of row IDs.
+	 * @param   array    $contexts   An array of item contexts.
 	 *
 	 * @return  boolean  True if successful, false otherwise and internal error is set.
 	 *
 	 * @since   11.1
 	 */
-	protected function batchAccess($value, $pks)
+	protected function batchAccess($value, $pks, $contexts)
 	{
-		// Check that user has edit permission for items
-		$extension = JRequest::getCmd('option');
+		// Set the variables
 		$user = JFactory::getUser();
-		if (!$user->authorise('core.edit', $extension))
-		{
-			$this->setError(JText::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
-			return false;
-		}
-
 		$table = $this->getTable();
 
 		foreach ($pks as $pk)
 		{
-			$table->reset();
-			$table->load($pk);
-			$table->access = (int) $value;
-
-			if (!$table->store())
+			if ($user->authorise('core.edit', $contexts[$pk]))
 			{
-				$this->setError($table->getError());
+				$table->reset();
+				$table->load($pk);
+				$table->access = (int) $value;
+
+				if (!$table->store())
+				{
+					$this->setError($table->getError());
+					return false;
+				}
+			}
+			else
+			{
+				$this->setError(JText::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
 				return false;
 			}
 		}
@@ -266,14 +269,15 @@ abstract class JModelAdmin extends JModelForm
 	/**
 	 * Batch copy items to a new category or current.
 	 *
-	 * @param   integer  $value  The new category.
-	 * @param   array    $pks    An array of row IDs.
+	 * @param   integer  $value     The new category.
+	 * @param   array    $pks       An array of row IDs.
+	 * @param   array    $contexts  An array of item contexts.
 	 *
 	 * @return  mixed  An array of new IDs on success, boolean false on failure.
 	 *
 	 * @since	11.1
 	 */
-	protected function batchCopy($value, $pks)
+	protected function batchCopy($value, $pks, $contexts)
 	{
 		$categoryId = (int) $value;
 
@@ -307,9 +311,9 @@ abstract class JModelAdmin extends JModelForm
 		}
 
 		// Check that the user has create permission for the component
-		$extension = JRequest::getCmd('option');
+		$extension = JFactory::getApplication()->input->get('option', '');
 		$user = JFactory::getUser();
-		if (!$user->authorise('core.create', $extension))
+		if (!$user->authorise('core.create', $extension . '.category.' . $categoryId))
 		{
 			$this->setError(JText::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_CREATE'));
 			return false;
@@ -385,35 +389,37 @@ abstract class JModelAdmin extends JModelForm
 	/**
 	 * Batch language changes for a group of rows.
 	 *
-	 * @param   string  $value  The new value matching a language.
-	 * @param   array   $pks    An array of row IDs.
+	 * @param   string  $value     The new value matching a language.
+	 * @param   array   $pks       An array of row IDs.
+	 * @param   array   $contexts  An array of item contexts.
 	 *
-	 * @return  booelan  True if successful, false otherwise and internal error is set.
+	 * @return  boolean  True if successful, false otherwise and internal error is set.
 	 *
 	 * @since   11.3
 	 */
-	protected function batchLanguage($value, $pks)
+	protected function batchLanguage($value, $pks, $contexts)
 	{
-		// Check that user has edit permission for items
-		$extension = JRequest::getCmd('option');
-		$user = JFactory::getUser();
-		if (!$user->authorise('core.edit', $extension))
-		{
-			$this->setError(JText::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
-			return false;
-		}
-
+		// Set the variables
+		$user	= JFactory::getUser();
 		$table = $this->getTable();
 
 		foreach ($pks as $pk)
 		{
-			$table->reset();
-			$table->load($pk);
-			$table->language = $value;
-
-			if (!$table->store())
+			if ($user->authorise('core.edit', $contexts[$pk]))
 			{
-				$this->setError($table->getError());
+				$table->reset();
+				$table->load($pk);
+				$table->language = $value;
+
+				if (!$table->store())
+				{
+					$this->setError($table->getError());
+					return false;
+				}
+			}
+			else
+			{
+				$this->setError(JText::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
 				return false;
 			}
 		}
@@ -425,16 +431,17 @@ abstract class JModelAdmin extends JModelForm
 	}
 
 	/**
-	 * Batch move articles to a new category
+	 * Batch move items to a new category
 	 *
-	 * @param   integer  $value  The new category ID.
-	 * @param   array    $pks    An array of row IDs.
+	 * @param   integer  $value      The new category ID.
+	 * @param   array    $pks        An array of row IDs.
+	 * @param   array    $contexts   An array of item contexts.
 	 *
 	 * @return  boolean  True if successful, false otherwise and internal error is set.
 	 *
 	 * @since	11.1
 	 */
-	protected function batchMove($value, $pks)
+	protected function batchMove($value, $pks, $contexts)
 	{
 		$categoryId = (int) $value;
 
@@ -467,23 +474,23 @@ abstract class JModelAdmin extends JModelForm
 		}
 
 		// Check that user has create and edit permission for the component
-		$extension = JRequest::getCmd('option');
+		$extension = JFactory::getApplication()->input->get('option', '');
 		$user = JFactory::getUser();
-		if (!$user->authorise('core.create', $extension))
+		if (!$user->authorise('core.create', $extension . '.category.' . $categoryId))
 		{
 			$this->setError(JText::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_CREATE'));
-			return false;
-		}
-
-		if (!$user->authorise('core.edit', $extension))
-		{
-			$this->setError(JText::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
 			return false;
 		}
 
 		// Parent exists so we let's proceed
 		foreach ($pks as $pk)
 		{
+			if (!$user->authorise('core.edit', $contexts[$pk]))
+			{
+				$this->setError(JText::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
+				return false;
+			}
+
 			// Check that the row actually exists
 			if (!$table->load($pk))
 			{

--- a/libraries/joomla/html/html/batch.php
+++ b/libraries/joomla/html/html/batch.php
@@ -78,15 +78,48 @@ abstract class JHtmlBatch
 	 */
 	public static function language()
 	{
-		// Create the batch selector to change an access level on a selection list.
+		// Create the batch selector to change the language on a selection list.
 		$lines = array(
 			'<label id="batch-language-lbl" for="batch-language" class="hasTip"'
-			. ' title="' . JText::_('JLIB_HTML_BATCH_LANGUAGE_LABEL') . '::' . JText::_('JLIB_HTML_BATCH_LANGUAGE_LABEL_DESC') . '">',
+			.' title="' . JText::_('JLIB_HTML_BATCH_LANGUAGE_LABEL') . '::' . JText::_('JLIB_HTML_BATCH_LANGUAGE_LABEL_DESC') . '">',
 			JText::_('JLIB_HTML_BATCH_LANGUAGE_LABEL'),
 			'</label>',
 			'<select name="batch[language_id]" class="inputbox" id="batch-language-id">',
 			'<option value="">' . JText::_('JLIB_HTML_BATCH_LANGUAGE_NOCHANGE') . '</option>',
 			JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text'),
+			'</select>'
+		);
+
+		return implode("\n", $lines);
+	}
+
+	/**
+	 * Display a batch widget for the user selector.
+	 *
+	 * @param   boolean  $noUser  Choose to display a "no user" option
+	 *
+	 * @return  string  The necessary HTML for the widget.
+	 *
+	 * @since   11.4
+	 */
+	public static function user($noUser = true)
+	{
+		$optionNo = '';
+		if ($noUser)
+		{
+			$optionNo = '<option value="0">' . JText::_('JLIB_HTML_BATCH_USER_NOUSER') . '</option>';
+		}
+
+		// Create the batch selector to select a user on a selection list.
+		$lines = array(
+			'<label id="batch-user-lbl" for="batch-user" class="hasTip"'
+			.' title="' . JText::_('JLIB_HTML_BATCH_USER_LABEL') . '::' . JText::_('JLIB_HTML_BATCH_USER_LABEL_DESC') . '">',
+			JText::_('JLIB_HTML_BATCH_USER_LABEL'),
+			'</label>',
+			'<select name="batch[user_id]" class="inputbox" id="batch-user-id">',
+			'<option value="">' . JText::_('JLIB_HTML_BATCH_USER_NOCHANGE') . '</option>',
+			$optionNo,
+			JHtml::_('select.options', JHtml::_('user.userlist'), 'value', 'text'),
 			'</select>'
 		);
 

--- a/libraries/joomla/html/html/batch.php
+++ b/libraries/joomla/html/html/batch.php
@@ -81,7 +81,7 @@ abstract class JHtmlBatch
 		// Create the batch selector to change the language on a selection list.
 		$lines = array(
 			'<label id="batch-language-lbl" for="batch-language" class="hasTip"'
-			.' title="' . JText::_('JLIB_HTML_BATCH_LANGUAGE_LABEL') . '::' . JText::_('JLIB_HTML_BATCH_LANGUAGE_LABEL_DESC') . '">',
+			. ' title="' . JText::_('JLIB_HTML_BATCH_LANGUAGE_LABEL') . '::' . JText::_('JLIB_HTML_BATCH_LANGUAGE_LABEL_DESC') . '">',
 			JText::_('JLIB_HTML_BATCH_LANGUAGE_LABEL'),
 			'</label>',
 			'<select name="batch[language_id]" class="inputbox" id="batch-language-id">',
@@ -113,7 +113,7 @@ abstract class JHtmlBatch
 		// Create the batch selector to select a user on a selection list.
 		$lines = array(
 			'<label id="batch-user-lbl" for="batch-user" class="hasTip"'
-			.' title="' . JText::_('JLIB_HTML_BATCH_USER_LABEL') . '::' . JText::_('JLIB_HTML_BATCH_USER_LABEL_DESC') . '">',
+			. ' title="' . JText::_('JLIB_HTML_BATCH_USER_LABEL') . '::' . JText::_('JLIB_HTML_BATCH_USER_LABEL_DESC') . '">',
 			JText::_('JLIB_HTML_BATCH_USER_LABEL'),
 			'</label>',
 			'<select name="batch[user_id]" class="inputbox" id="batch-user-id">',

--- a/libraries/joomla/html/html/user.php
+++ b/libraries/joomla/html/html/user.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  HTML
+ *
+ * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Utility class working with users
+ *
+ * @package     Joomla.Platform
+ * @subpackage  HTML
+ * @since       11.4
+ */
+abstract class JHtmlUser
+{
+	/**
+	 * Displays a list of user groups.
+	 *
+	 * @return  array  An array containing a list of user groups.
+	 *
+	 * @since   11.4
+	 */
+	public static function groups()
+	{
+		$db = JFactory::getDbo();
+		$query = $db->getQuery(true);
+		$query->select('a.id AS value, a.title AS text, COUNT(DISTINCT b.id) AS level');
+		$query->from($db->quoteName('#__usergroups').' AS a');
+		$query->join('LEFT', $db->quoteName('#__usergroups').' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
+		$query->group('a.id');
+		$query->order('a.lft ASC');
+		$db->setQuery($query);
+		$options = $db->loadObjectList();
+
+		// Check for a database error.
+		if ($db->getErrorNum())
+		{
+			JError::raiseNotice(500, $db->getErrorMsg());
+			return null;
+		}
+
+		for ($i = 0, $n = count($options); $i < $n; $i++)
+		{
+			$options[$i]->text = str_repeat('- ', $options[$i]->level).$options[$i]->text;
+			$groups[] = JHtml::_('select.option', $options[$i]->value, $options[$i]->text);
+		}
+
+		return $groups;
+	}
+
+	/**
+	 * Get a list of users.
+	 *
+	 * @return  string
+	 *
+	 * @since   11.4
+	 */
+	public static function userlist()
+	{
+		// Get the database object and a new query object.
+		$db		= JFactory::getDBO();
+		$query	= $db->getQuery(true);
+
+		// Build the query.
+		$query->select('a.id AS value, a.name AS text');
+		$query->from('#__users AS a');
+		$query->where('a.block = 0');
+		$query->order('a.name');
+
+		// Set the query and load the options.
+		$db->setQuery($query);
+		$items = $db->loadObjectList();
+
+		// Detect errors
+		if ($db->getErrorNum())
+		{
+			JError::raiseWarning(500, $db->getErrorMsg());
+		}
+
+		return $items;
+	}
+}

--- a/libraries/joomla/html/html/user.php
+++ b/libraries/joomla/html/html/user.php
@@ -30,8 +30,8 @@ abstract class JHtmlUser
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true);
 		$query->select('a.id AS value, a.title AS text, COUNT(DISTINCT b.id) AS level');
-		$query->from($db->quoteName('#__usergroups').' AS a');
-		$query->join('LEFT', $db->quoteName('#__usergroups').' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
+		$query->from($db->quoteName('#__usergroups') . ' AS a');
+		$query->join('LEFT', $db->quoteName('#__usergroups') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
 		$query->group('a.id');
 		$query->order('a.lft ASC');
 		$db->setQuery($query);
@@ -46,7 +46,7 @@ abstract class JHtmlUser
 
 		for ($i = 0, $n = count($options); $i < $n; $i++)
 		{
-			$options[$i]->text = str_repeat('- ', $options[$i]->level).$options[$i]->text;
+			$options[$i]->text = str_repeat('- ', $options[$i]->level) . $options[$i]->text;
 			$groups[] = JHtml::_('select.option', $options[$i]->value, $options[$i]->text);
 		}
 

--- a/tests/suite/joomla/html/html/JHtmlBatchTest.php
+++ b/tests/suite/joomla/html/html/JHtmlBatchTest.php
@@ -91,4 +91,19 @@ class JHtmlBatchTest extends JoomlaDatabaseTestCase
 			$this->StringContains('<option value="en-GB">English (UK)</option>')
 		);
 	}
+
+	/**
+	 * Tests the JHtmlBatch::user method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.4
+	 */
+	public function testUser()
+	{
+		$this->assertThat(
+			JHtmlBatch::user(true),
+			$this->StringContains('<option value="42">Super User</option>')
+		);
+	}
 }

--- a/tests/suite/joomla/html/html/JHtmlUserTest.php
+++ b/tests/suite/joomla/html/html/JHtmlUserTest.php
@@ -29,26 +29,34 @@ class JHtmlUserTest extends JoomlaDatabaseTestCase
 	}
 
     /**
-	 * @covers JHtmlUser::groups
-     * @todo Implement testGroups().
+	 * Tests the JHtmlUser::groups method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.4
      */
     public function testGroups()
     {
-        // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-          'This test has not been implemented yet.'
-        );
+		$this->assertThat(
+			JHtmlUser::groups(),
+			$this->arrayHasKey('3'),
+			'Line:'.__LINE__.' The groups method should an array with eight keys; key 3 is "- - - Super Users".'
+		);
     }
 
     /**
-	 * @covers JHtmlUser::userlist
-     * @todo Implement testUserlist().
+	 * Tests the JHtmlUser::userlist method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.4
      */
     public function testUserlist()
     {
-        // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-          'This test has not been implemented yet.'
-        );
+		$this->assertThat(
+			JHtmlUser::userlist(),
+			$this->arrayHasKey('2'),
+			'Line:'.__LINE__.' The userlist method should an array with four keys; key 2 is "Super User".'
+		);
     }
 }

--- a/tests/suite/joomla/html/html/JHtmlUserTest.php
+++ b/tests/suite/joomla/html/html/JHtmlUserTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  HTML
+ *
+ * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+require_once JPATH_PLATFORM.'/joomla/html/html/user.php';
+
+/**
+ * Test class for JHtmlUser.
+ *
+ * @since  11.4
+ */
+class JHtmlUserTest extends JoomlaDatabaseTestCase
+{
+	/**
+	 * Gets the data set to be loaded into the database during setup
+	 *
+	 * @return  xml dataset
+	 *
+	 * @since   11.4
+	 */
+	protected function getDataSet()
+	{
+		return $this->createXMLDataSet(__DIR__.'/testfiles/JHtmlTest.xml');
+	}
+
+    /**
+	 * @covers JHtmlUser::groups
+     * @todo Implement testGroups().
+     */
+    public function testGroups()
+    {
+        // Remove the following lines when you implement this test.
+        $this->markTestIncomplete(
+          'This test has not been implemented yet.'
+        );
+    }
+
+    /**
+	 * @covers JHtmlUser::userlist
+     * @todo Implement testUserlist().
+     */
+    public function testUserlist()
+    {
+        // Remove the following lines when you implement this test.
+        $this->markTestIncomplete(
+          'This test has not been implemented yet.'
+        );
+    }
+}


### PR DESCRIPTION
To coincide with joomla/joomla-cms#29, this pull request merges in all library work for this feature improvement.

Covered specifically in the libraries:

JControllerForm:
- batch() - Added logic to build an array of contexts to improve ACL permissions checks, converted JRequest calls to JInput

JModelAdmin:
- batch() - Handle receiving and forwarding contexts array to all batch functions
- batchAccess() - Rewritten to check edit permission on the item being edited (no ACL checks previously)
- batchCopy() - Converted JRequest to JInput, create permission check now looks at the category permissions where the item is being copied to
- batchLanguage() - Rewritten to check edit permission on the item being edited (no ACL checks previously)
- batchMove() - Converted JRequest to JInput, create permission check now looks at the category permissions where the item is being copied to, edit permission check uses contexts array to check item permissions

JHtmlBatch:
- user() - Added user widget to display a list of users

JHtmlUser:
- Added this class to display either a list of groups or users

Tests added for JHtmlBatch::user() and JHtmlUser methods.
