### PR TITLE
Deprecation Work - Replace JException

### DIFF
--- a/libraries/joomla/database/table.php
+++ b/libraries/joomla/database/table.php
@@ -133,7 +133,7 @@ abstract class JTable extends JObject
 
 			if (empty($fields))
 			{
-				$e = new JException(JText::_('JLIB_DATABASE_ERROR_COLUMNS_NOT_FOUND'));
+				$e = new Exception(JText::_('JLIB_DATABASE_ERROR_COLUMNS_NOT_FOUND'));
 				$this->setError($e);
 				return false;
 			}
@@ -425,13 +425,14 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/bind
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function bind($src, $ignore = array())
 	{
 		// If the source value is not an array or object return false.
 		if (!is_object($src) && !is_array($src))
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_BIND_FAILED_INVALID_SOURCE_ARGUMENT', get_class($this)));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_BIND_FAILED_INVALID_SOURCE_ARGUMENT', get_class($this)));
 			$this->setError($e);
 			return false;
 		}
@@ -476,6 +477,7 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/load
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function load($keys = null, $reset = true)
 	{
@@ -515,7 +517,7 @@ abstract class JTable extends JObject
 			// Check that $field is in the table.
 			if (!in_array($field, $fields))
 			{
-				$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_CLASS_IS_MISSING_FIELD', get_class($this), $field));
+				$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_CLASS_IS_MISSING_FIELD', get_class($this), $field));
 				$this->setError($e);
 				return false;
 			}
@@ -529,7 +531,7 @@ abstract class JTable extends JObject
 		// Check for a database error.
 		if ($this->_db->getErrorNum())
 		{
-			$e = new JException($this->_db->getErrorMsg());
+			$e = new Exception($this->_db->getErrorMsg());
 			$this->setError($e);
 			return false;
 		}
@@ -537,7 +539,7 @@ abstract class JTable extends JObject
 		// Check that we have a result.
 		if (empty($row))
 		{
-			$e = new JException(JText::_('JLIB_DATABASE_ERROR_EMPTY_ROW_RETURNED'));
+			$e = new Exception(JText::_('JLIB_DATABASE_ERROR_EMPTY_ROW_RETURNED'));
 			$this->setError($e);
 			return false;
 		}
@@ -575,6 +577,7 @@ abstract class JTable extends JObject
 	 *
 	 * @link	http://docs.joomla.org/JTable/store
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function store($updateNulls = false)
 	{
@@ -600,7 +603,7 @@ abstract class JTable extends JObject
 		// If the store failed return false.
 		if (!$stored)
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_STORE_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_STORE_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			return false;
 		}
@@ -672,7 +675,7 @@ abstract class JTable extends JObject
 
 			if (!$this->_db->query())
 			{
-				$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_STORE_FAILED_UPDATE_ASSET_ID', $this->_db->getErrorMsg()));
+				$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_STORE_FAILED_UPDATE_ASSET_ID', $this->_db->getErrorMsg()));
 				$this->setError($e);
 				return false;
 			}
@@ -747,6 +750,7 @@ abstract class JTable extends JObject
 	 *
 	 * @link	http://docs.joomla.org/JTable/delete
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function delete($pk = null)
 	{
@@ -757,7 +761,7 @@ abstract class JTable extends JObject
 		// If no primary key is given, return false.
 		if ($pk === null)
 		{
-			$e = new JException(JText::_('JLIB_DATABASE_ERROR_NULL_PRIMARY_KEY'));
+			$e = new Exception(JText::_('JLIB_DATABASE_ERROR_NULL_PRIMARY_KEY'));
 			$this->setError($e);
 			return false;
 		}
@@ -795,7 +799,7 @@ abstract class JTable extends JObject
 		// Check for a database error.
 		if (!$this->_db->query())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_DELETE_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_DELETE_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			return false;
 		}
@@ -819,6 +823,7 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/checkOut
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function checkOut($userId, $pk = null)
 	{
@@ -835,7 +840,7 @@ abstract class JTable extends JObject
 		// If no primary key is given, return false.
 		if ($pk === null)
 		{
-			$e = new JException(JText::_('JLIB_DATABASE_ERROR_NULL_PRIMARY_KEY'));
+			$e = new Exception(JText::_('JLIB_DATABASE_ERROR_NULL_PRIMARY_KEY'));
 			$this->setError($e);
 			return false;
 		}
@@ -853,7 +858,7 @@ abstract class JTable extends JObject
 
 		if (!$this->_db->query())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_CHECKOUT_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_CHECKOUT_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			return false;
 		}
@@ -875,6 +880,7 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/checkIn
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function checkIn($pk = null)
 	{
@@ -891,7 +897,7 @@ abstract class JTable extends JObject
 		// If no primary key is given, return false.
 		if ($pk === null)
 		{
-			$e = new JException(JText::_('JLIB_DATABASE_ERROR_NULL_PRIMARY_KEY'));
+			$e = new Exception(JText::_('JLIB_DATABASE_ERROR_NULL_PRIMARY_KEY'));
 			$this->setError($e);
 			return false;
 		}
@@ -907,7 +913,7 @@ abstract class JTable extends JObject
 		// Check for a database error.
 		if (!$this->_db->query())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_CHECKIN_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_CHECKIN_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			return false;
 		}
@@ -928,6 +934,7 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/hit
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function hit($pk = null)
 	{
@@ -957,7 +964,7 @@ abstract class JTable extends JObject
 		// Check for a database error.
 		if (!$this->_db->query())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_HIT_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_HIT_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			return false;
 		}
@@ -1016,13 +1023,14 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/getNextOrder
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function getNextOrder($where = '')
 	{
 		// If there is no ordering field set an error and return false.
 		if (!property_exists($this, 'ordering'))
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_CLASS_DOES_NOT_SUPPORT_ORDERING', get_class($this)));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_CLASS_DOES_NOT_SUPPORT_ORDERING', get_class($this)));
 			$this->setError($e);
 			return false;
 		}
@@ -1043,7 +1051,7 @@ abstract class JTable extends JObject
 		// Check for a database error.
 		if ($this->_db->getErrorNum())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_GET_NEXT_ORDER_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_GET_NEXT_ORDER_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 
 			return false;
@@ -1063,13 +1071,14 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/reorder
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function reorder($where = '')
 	{
 		// If there is no ordering field set an error and return false.
 		if (!property_exists($this, 'ordering'))
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_CLASS_DOES_NOT_SUPPORT_ORDERING', get_class($this)));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_CLASS_DOES_NOT_SUPPORT_ORDERING', get_class($this)));
 			$this->setError($e);
 			return false;
 		}
@@ -1096,7 +1105,7 @@ abstract class JTable extends JObject
 		// Check for a database error.
 		if ($this->_db->getErrorNum())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_REORDER_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_REORDER_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 
 			return false;
@@ -1121,7 +1130,7 @@ abstract class JTable extends JObject
 					// Check for a database error.
 					if (!$this->_db->query())
 					{
-						$e = new JException(
+						$e = new Exception(
 							JText::sprintf('JLIB_DATABASE_ERROR_REORDER_UPDATE_ROW_FAILED', get_class($this), $i, $this->_db->getErrorMsg())
 						);
 						$this->setError($e);
@@ -1147,13 +1156,14 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/move
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function move($delta, $where = '')
 	{
 		// If there is no ordering field set an error and return false.
 		if (!property_exists($this, 'ordering'))
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_CLASS_DOES_NOT_SUPPORT_ORDERING', get_class($this)));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_CLASS_DOES_NOT_SUPPORT_ORDERING', get_class($this)));
 			$this->setError($e);
 			return false;
 		}
@@ -1209,7 +1219,7 @@ abstract class JTable extends JObject
 			// Check for a database error.
 			if (!$this->_db->query())
 			{
-				$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_MOVE_FAILED', get_class($this), $this->_db->getErrorMsg()));
+				$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_MOVE_FAILED', get_class($this), $this->_db->getErrorMsg()));
 				$this->setError($e);
 
 				return false;
@@ -1225,7 +1235,7 @@ abstract class JTable extends JObject
 			// Check for a database error.
 			if (!$this->_db->query())
 			{
-				$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_MOVE_FAILED', get_class($this), $this->_db->getErrorMsg()));
+				$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_MOVE_FAILED', get_class($this), $this->_db->getErrorMsg()));
 				$this->setError($e);
 
 				return false;
@@ -1246,7 +1256,7 @@ abstract class JTable extends JObject
 			// Check for a database error.
 			if (!$this->_db->query())
 			{
-				$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_MOVE_FAILED', get_class($this), $this->_db->getErrorMsg()));
+				$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_MOVE_FAILED', get_class($this), $this->_db->getErrorMsg()));
 				$this->setError($e);
 
 				return false;
@@ -1269,6 +1279,7 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/publish
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function publish($pks = null, $state = 1, $userId = 0)
 	{
@@ -1290,7 +1301,7 @@ abstract class JTable extends JObject
 			// Nothing to set publishing state on, return false.
 			else
 			{
-				$e = new JException(JText::_('JLIB_DATABASE_ERROR_NO_ROWS_SELECTED'));
+				$e = new Exception(JText::_('JLIB_DATABASE_ERROR_NO_ROWS_SELECTED'));
 				$this->setError($e);
 
 				return false;
@@ -1321,7 +1332,7 @@ abstract class JTable extends JObject
 		// Check for a database error.
 		if (!$this->_db->query())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_PUBLISH_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_PUBLISH_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 
 			return false;

--- a/libraries/joomla/database/table.php
+++ b/libraries/joomla/database/table.php
@@ -425,7 +425,6 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/bind
 	 * @since   11.1
-	 * @throws  Exception
 	 */
 	public function bind($src, $ignore = array())
 	{
@@ -477,7 +476,6 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/load
 	 * @since   11.1
-	 * @throws  Exception
 	 */
 	public function load($keys = null, $reset = true)
 	{
@@ -577,7 +575,6 @@ abstract class JTable extends JObject
 	 *
 	 * @link	http://docs.joomla.org/JTable/store
 	 * @since   11.1
-	 * @throws  Exception
 	 */
 	public function store($updateNulls = false)
 	{
@@ -750,7 +747,6 @@ abstract class JTable extends JObject
 	 *
 	 * @link	http://docs.joomla.org/JTable/delete
 	 * @since   11.1
-	 * @throws  Exception
 	 */
 	public function delete($pk = null)
 	{
@@ -823,7 +819,6 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/checkOut
 	 * @since   11.1
-	 * @throws  Exception
 	 */
 	public function checkOut($userId, $pk = null)
 	{
@@ -880,7 +875,6 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/checkIn
 	 * @since   11.1
-	 * @throws  Exception
 	 */
 	public function checkIn($pk = null)
 	{
@@ -934,7 +928,6 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/hit
 	 * @since   11.1
-	 * @throws  Exception
 	 */
 	public function hit($pk = null)
 	{
@@ -1023,7 +1016,6 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/getNextOrder
 	 * @since   11.1
-	 * @throws  Exception
 	 */
 	public function getNextOrder($where = '')
 	{
@@ -1071,7 +1063,6 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/reorder
 	 * @since   11.1
-	 * @throws  Exception
 	 */
 	public function reorder($where = '')
 	{
@@ -1152,11 +1143,10 @@ abstract class JTable extends JObject
 	 * @param   string   $where  WHERE clause to use for limiting the selection of rows to compact the
 	 * ordering values.
 	 *
-	 * @return  mixed    Boolean true on success.
+	 * @return  mixed  Boolean true on success.
 	 *
 	 * @link    http://docs.joomla.org/JTable/move
 	 * @since   11.1
-	 * @throws  Exception
 	 */
 	public function move($delta, $where = '')
 	{
@@ -1279,7 +1269,6 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/publish
 	 * @since   11.1
-	 * @throws  Exception
 	 */
 	public function publish($pks = null, $state = 1, $userId = 0)
 	{

--- a/libraries/joomla/database/table/usergroup.php
+++ b/libraries/joomla/database/table/usergroup.php
@@ -144,7 +144,6 @@ class JTableUsergroup extends JTable
 	 * @return  mixed  True on success, Exception on failure.
 	 *
 	 * @since   11.1
-	 * @throws  Exception
 	 */
 	public function delete($oid = null)
 	{

--- a/libraries/joomla/database/table/usergroup.php
+++ b/libraries/joomla/database/table/usergroup.php
@@ -141,9 +141,10 @@ class JTableUsergroup extends JTable
 	 *
 	 * @param   integer  $oid  The primary key of the user group to delete.
 	 *
-	 * @return  mixed  Boolean or Exception.
+	 * @return  mixed  True on success, Exception on failure.
 	 *
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function delete($oid = null)
 	{
@@ -153,15 +154,15 @@ class JTableUsergroup extends JTable
 		}
 		if ($this->id == 0)
 		{
-			return new JException(JText::_('JGLOBAL_CATEGORY_NOT_FOUND'));
+			return new Exception(JText::_('JGLOBAL_CATEGORY_NOT_FOUND'));
 		}
 		if ($this->parent_id == 0)
 		{
-			return new JException(JText::_('JLIB_DATABASE_ERROR_DELETE_ROOT_CATEGORIES'));
+			return new Exception(JText::_('JLIB_DATABASE_ERROR_DELETE_ROOT_CATEGORIES'));
 		}
 		if ($this->lft == 0 or $this->rgt == 0)
 		{
-			return new JException(JText::_('JLIB_DATABASE_ERROR_DELETE_CATEGORY'));
+			return new Exception(JText::_('JLIB_DATABASE_ERROR_DELETE_CATEGORY'));
 		}
 
 		$db = $this->_db;
@@ -176,7 +177,7 @@ class JTableUsergroup extends JTable
 		$ids = $db->loadColumn();
 		if (empty($ids))
 		{
-			return new JException(JText::_('JLIB_DATABASE_ERROR_DELETE_CATEGORY'));
+			return new Exception(JText::_('JLIB_DATABASE_ERROR_DELETE_CATEGORY'));
 		}
 
 		// Delete the category dependencies

--- a/libraries/joomla/database/tablenested.php
+++ b/libraries/joomla/database/tablenested.php
@@ -124,6 +124,7 @@ class JTableNested extends JTable
 	 *
 	 * @link    http://docs.joomla.org/JTableNested/getPath
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function getPath($pk = null, $diagnostic = false)
 	{
@@ -146,7 +147,7 @@ class JTableNested extends JTable
 		// Check for a database error.
 		if ($this->_db->getErrorNum())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_GET_PATH_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_GET_PATH_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			return false;
 		}
@@ -164,6 +165,7 @@ class JTableNested extends JTable
 	 *
 	 * @link    http://docs.joomla.org/JTableNested/getTree
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function getTree($pk = null, $diagnostic = false)
 	{
@@ -185,7 +187,7 @@ class JTableNested extends JTable
 		// Check for a database error.
 		if ($this->_db->getErrorNum())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_GET_TREE_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_GET_TREE_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			return false;
 		}
@@ -232,13 +234,14 @@ class JTableNested extends JTable
 	 *
 	 * @link    http://docs.joomla.org/JTableNested/setLocation
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function setLocation($referenceId, $position = 'after')
 	{
 		// Make sure the location is valid.
 		if (($position != 'before') && ($position != 'after') && ($position != 'first-child') && ($position != 'last-child'))
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_INVALID_LOCATION', get_class($this)));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_INVALID_LOCATION', get_class($this)));
 			$this->setError($e);
 			return false;
 		}
@@ -315,8 +318,8 @@ class JTableNested extends JTable
 	 *
 	 * @link    http://docs.joomla.org/JTableNested/moveByReference
 	 * @since   11.1
+	 * @throws  Exception
 	 */
-
 	public function moveByReference($referenceId, $position = 'after', $pk = null)
 	{
 		if ($this->_debug)
@@ -346,7 +349,7 @@ class JTableNested extends JTable
 		// Check for a database error.
 		if ($this->_db->getErrorNum())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_MOVE_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_MOVE_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			return false;
 		}
@@ -358,7 +361,7 @@ class JTableNested extends JTable
 		// Cannot move the node to be a child of itself.
 		if (in_array($referenceId, $children))
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_INVALID_NODE_RECURSION', get_class($this)));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_INVALID_NODE_RECURSION', get_class($this)));
 			$this->setError($e);
 			return false;
 		}
@@ -435,7 +438,7 @@ class JTableNested extends JTable
 			// Check for a database error.
 			if ($this->_db->getErrorNum())
 			{
-				$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_MOVE_FAILED', get_class($this), $this->_db->getErrorMsg()));
+				$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_MOVE_FAILED', get_class($this), $this->_db->getErrorMsg()));
 				$this->setError($e);
 				$this->_unlock();
 				return false;
@@ -670,6 +673,7 @@ class JTableNested extends JTable
 	 *
 	 * @link    http://docs.joomla.org/JTable/check
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function check()
 	{
@@ -690,19 +694,19 @@ class JTableNested extends JTable
 			{
 				if ($this->_db->getErrorNum())
 				{
-					$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_CHECK_FAILED', get_class($this), $this->_db->getErrorMsg()));
+					$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_CHECK_FAILED', get_class($this), $this->_db->getErrorMsg()));
 					$this->setError($e);
 				}
 				else
 				{
-					$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_INVALID_PARENT_ID', get_class($this)));
+					$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_INVALID_PARENT_ID', get_class($this)));
 					$this->setError($e);
 				}
 			}
 		}
 		else
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_INVALID_PARENT_ID', get_class($this)));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_INVALID_PARENT_ID', get_class($this)));
 			$this->setError($e);
 		}
 
@@ -718,6 +722,7 @@ class JTableNested extends JTable
 	 *
 	 * @link    http://docs.joomla.org/JTableNested/store
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function store($updateNulls = false)
 	{
@@ -764,7 +769,7 @@ class JTableNested extends JTable
 					// Check for a database error.
 					if ($this->_db->getErrorNum())
 					{
-						$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_STORE_FAILED', get_class($this), $this->_db->getErrorMsg()));
+						$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_STORE_FAILED', get_class($this), $this->_db->getErrorMsg()));
 						$this->setError($e);
 						$this->_unlock();
 						return false;
@@ -817,7 +822,7 @@ class JTableNested extends JTable
 			else
 			{
 				// Negative parent ids are invalid
-				$e = new JException(JText::_('JLIB_DATABASE_ERROR_INVALID_PARENT_ID'));
+				$e = new Exception(JText::_('JLIB_DATABASE_ERROR_INVALID_PARENT_ID'));
 				$this->setError($e);
 				return false;
 			}
@@ -880,6 +885,7 @@ class JTableNested extends JTable
 	 *
 	 * @link    http://docs.joomla.org/JTableNested/publish
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function publish($pks = null, $state = 1, $userId = 0)
 	{
@@ -904,7 +910,7 @@ class JTableNested extends JTable
 			// Nothing to set publishing state on, return false.
 			else
 			{
-				$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_NO_ROWS_SELECTED', get_class($this)));
+				$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_NO_ROWS_SELECTED', get_class($this)));
 				$this->setError($e);
 				return false;
 			}
@@ -937,7 +943,7 @@ class JTableNested extends JTable
 				// Check for checked out children.
 				if ($this->_db->loadResult())
 				{
-					$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_CHILD_ROWS_CHECKED_OUT', get_class($this)));
+					$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_CHILD_ROWS_CHECKED_OUT', get_class($this)));
 					$this->setError($e);
 					return false;
 				}
@@ -959,14 +965,14 @@ class JTableNested extends JTable
 				// Check for a database error.
 				if ($this->_db->getErrorNum())
 				{
-					$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_PUBLISH_FAILED', get_class($this), $this->_db->getErrorMsg()));
+					$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_PUBLISH_FAILED', get_class($this), $this->_db->getErrorMsg()));
 					$this->setError($e);
 					return false;
 				}
 
 				if (!empty($rows))
 				{
-					$e = new JException(JText::_('JLIB_DATABASE_ERROR_ANCESTOR_NODES_LOWER_STATE'));
+					$e = new Exception(JText::_('JLIB_DATABASE_ERROR_ANCESTOR_NODES_LOWER_STATE'));
 					$this->setError($e);
 					return false;
 				}
@@ -980,7 +986,7 @@ class JTableNested extends JTable
 			// Check for a database error.
 			if (!$this->_db->query())
 			{
-				$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_PUBLISH_FAILED', get_class($this), $this->_db->getErrorMsg()));
+				$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_PUBLISH_FAILED', get_class($this), $this->_db->getErrorMsg()));
 				$this->setError($e);
 				return false;
 			}
@@ -1011,6 +1017,7 @@ class JTableNested extends JTable
 	 *
 	 * @link    http://docs.joomla.org/JTableNested/orderUp
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function orderUp($pk)
 	{
@@ -1052,7 +1059,7 @@ class JTableNested extends JTable
 		// Check for a database error.
 		if ($this->_db->getErrorNum())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_ORDERUP_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_ORDERUP_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			$this->_unlock();
 			return false;
@@ -1069,7 +1076,7 @@ class JTableNested extends JTable
 		// Check for a database error.
 		if (!$this->_db->query())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_ORDERUP_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_ORDERUP_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			$this->_unlock();
 			return false;
@@ -1087,7 +1094,7 @@ class JTableNested extends JTable
 		// Check for a database error.
 		if (!$this->_db->query())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_ORDERUP_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_ORDERUP_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			$this->_unlock();
 			return false;
@@ -1108,6 +1115,7 @@ class JTableNested extends JTable
 	 *
 	 * @link    http://docs.joomla.org/JTableNested/orderDown
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function orderDown($pk)
 	{
@@ -1150,7 +1158,7 @@ class JTableNested extends JTable
 		// Check for a database error.
 		if ($this->_db->getErrorNum())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_ORDERDOWN_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_ORDERDOWN_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			$this->_unlock();
 			return false;
@@ -1167,7 +1175,7 @@ class JTableNested extends JTable
 		// Check for a database error.
 		if (!$this->_db->query())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_ORDERDOWN_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_ORDERDOWN_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			$this->_unlock();
 			return false;
@@ -1185,7 +1193,7 @@ class JTableNested extends JTable
 		// Check for a database error.
 		if (!$this->_db->query())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_ORDERDOWN_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_ORDERDOWN_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			$this->_unlock();
 			return false;
@@ -1203,6 +1211,7 @@ class JTableNested extends JTable
 	 * @return  mixed  The ID of the root row, or false and the internal error is set.
 	 *
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function getRootId()
 	{
@@ -1220,7 +1229,7 @@ class JTableNested extends JTable
 
 		if ($this->_db->getErrorNum())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_GETROOTID_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_GETROOTID_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			return false;
 		}
@@ -1241,7 +1250,7 @@ class JTableNested extends JTable
 			$result = $this->_db->loadColumn();
 			if ($this->_db->getErrorNum())
 			{
-				$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_GETROOTID_FAILED', get_class($this), $this->_db->getErrorMsg()));
+				$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_GETROOTID_FAILED', get_class($this), $this->_db->getErrorMsg()));
 				$this->setError($e);
 				return false;
 			}
@@ -1262,7 +1271,7 @@ class JTableNested extends JTable
 				$result = $this->_db->loadColumn();
 				if ($this->_db->getErrorNum())
 				{
-					$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_GETROOTID_FAILED', get_class($this), $this->_db->getErrorMsg()));
+					$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_GETROOTID_FAILED', get_class($this), $this->_db->getErrorMsg()));
 					$this->setError($e);
 					return false;
 				}
@@ -1273,14 +1282,14 @@ class JTableNested extends JTable
 				}
 				else
 				{
-					$e = new JException(JText::_('JLIB_DATABASE_ERROR_ROOT_NODE_NOT_FOUND'));
+					$e = new Exception(JText::_('JLIB_DATABASE_ERROR_ROOT_NODE_NOT_FOUND'));
 					$this->setError($e);
 					return false;
 				}
 			}
 			else
 			{
-				$e = new JException(JText::_('JLIB_DATABASE_ERROR_ROOT_NODE_NOT_FOUND'));
+				$e = new Exception(JText::_('JLIB_DATABASE_ERROR_ROOT_NODE_NOT_FOUND'));
 				$this->setError($e);
 				return false;
 			}
@@ -1301,6 +1310,7 @@ class JTableNested extends JTable
 	 *
 	 * @link    http://docs.joomla.org/JTableNested/rebuild
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function rebuild($parentId = null, $leftId = 0, $level = 0, $path = '')
 	{
@@ -1374,7 +1384,7 @@ class JTableNested extends JTable
 		// If there is an update failure, return false to break out of the recursion.
 		if (!$this->_db->query())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_REBUILD_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_REBUILD_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			return false;
 		}
@@ -1393,6 +1403,7 @@ class JTableNested extends JTable
 	 *
 	 * @link    http://docs.joomla.org/JTableNested/rebuildPath
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function rebuildPath($pk = null)
 	{
@@ -1436,7 +1447,7 @@ class JTableNested extends JTable
 		// Check for a database error.
 		if (!$this->_db->query())
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_REBUILDPATH_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_REBUILDPATH_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			return false;
 		}
@@ -1456,6 +1467,7 @@ class JTableNested extends JTable
 	 * @return  integer  1 + value of root rgt on success, false on failure.
 	 *
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	public function saveorder($idArray = null, $lft_array = null)
 	{
@@ -1474,7 +1486,7 @@ class JTableNested extends JTable
 				// Check for a database error.
 				if (!$this->_db->query())
 				{
-					$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_REORDER_FAILED', get_class($this), $this->_db->getErrorMsg()));
+					$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_REORDER_FAILED', get_class($this), $this->_db->getErrorMsg()));
 					$this->setError($e);
 					$this->_unlock();
 					return false;
@@ -1504,6 +1516,7 @@ class JTableNested extends JTable
 	 * @return  mixed    Boolean false on failure or node object on success.
 	 *
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	protected function _getNode($id, $key = null)
 	{
@@ -1536,7 +1549,7 @@ class JTableNested extends JTable
 		// Check for a database error or no $row returned
 		if ((!$row) || ($this->_db->getErrorNum()))
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_GETNODE_FAILED', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('JLIB_DATABASE_ERROR_GETNODE_FAILED', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			return false;
 		}
@@ -1686,6 +1699,7 @@ class JTableNested extends JTable
 	 * @return  boolean  False on exception
 	 *
 	 * @since   11.1
+	 * @throws  Exception
 	 */
 	protected function _runQuery($query, $errorMessage)
 	{
@@ -1694,7 +1708,7 @@ class JTableNested extends JTable
 		// Check for a database error.
 		if (!$this->_db->query())
 		{
-			$e = new JException(JText::sprintf('$errorMessage', get_class($this), $this->_db->getErrorMsg()));
+			$e = new Exception(JText::sprintf('$errorMessage', get_class($this), $this->_db->getErrorMsg()));
 			$this->setError($e);
 			$this->_unlock();
 			return false;

--- a/libraries/joomla/database/tablenested.php
+++ b/libraries/joomla/database/tablenested.php
@@ -120,11 +120,10 @@ class JTableNested extends JTable
 	 * @param   integer  $pk          Primary key of the node for which to get the path.
 	 * @param   boolean  $diagnostic  Only select diagnostic data for the nested sets.
 	 *
-	 * @return  mixed    Boolean false on failure or array of node objects on success.
+	 * @return  mixed  Boolean false on failure or array of node objects on success.
 	 *
 	 * @link    http://docs.joomla.org/JTableNested/getPath
 	 * @since   11.1
-	 * @throws  Exception
 	 */
 	public function getPath($pk = null, $diagnostic = false)
 	{
@@ -161,11 +160,10 @@ class JTableNested extends JTable
 	 * @param   integer  $pk          Primary key of the node for which to get the tree.
 	 * @param   boolean  $diagnostic  Only select diagnostic data for the nested sets.
 	 *
-	 * @return  mixed    Boolean false on failure or array of node objects on success.
+	 * @return  mixed  Boolean false on failure or array of node objects on success.
 	 *
 	 * @link    http://docs.joomla.org/JTableNested/getTree
 	 * @since   11.1
-	 * @throws  Exception
 	 */
 	public function getTree($pk = null, $diagnostic = false)
 	{
@@ -234,7 +232,6 @@ class JTableNested extends JTable
 	 *
 	 * @link    http://docs.joomla.org/JTableNested/setLocation
 	 * @since   11.1
-	 * @throws  Exception
 	 */
 	public function setLocation($referenceId, $position = 'after')
 	{
@@ -318,7 +315,6 @@ class JTableNested extends JTable
 	 *
 	 * @link    http://docs.joomla.org/JTableNested/moveByReference
 	 * @since   11.1
-	 * @throws  Exception
 	 */
 	public function moveByReference($referenceId, $position = 'after', $pk = null)
 	{
@@ -673,7 +669,6 @@ class JTableNested extends JTable
 	 *
 	 * @link    http://docs.joomla.org/JTable/check
 	 * @since   11.1
-	 * @throws  Exception
 	 */
 	public function check()
 	{

--- a/libraries/joomla/html/html/select.php
+++ b/libraries/joomla/html/html/select.php
@@ -153,7 +153,7 @@ abstract class JHtmlSelect
 	 *
 	 * @since   11.1
 	 *
-	 * @throws  JException If a group has unprocessable contents.
+	 * @throws  Exception If a group has unprocessable contents.
 	 */
 	public static function groupedlist($data, $name, $options = array())
 	{
@@ -241,7 +241,7 @@ abstract class JHtmlSelect
 			}
 			else
 			{
-				throw new JException('Invalid group contents.', 1, E_WARNING);
+				throw new Exception('Invalid group contents.', 1);
 			}
 
 			if ($noGroup)

--- a/libraries/joomla/installer/adapters/component.php
+++ b/libraries/joomla/installer/adapters/component.php
@@ -1726,7 +1726,7 @@ class JInstallerComponent extends JAdapterInstance
 		{
 			$this->parent->extension->store();
 		}
-		catch (JException $e)
+		catch (Exception $e)
 		{
 			JError::raiseWarning(101, JText::_('JLIB_INSTALLER_ERROR_COMP_DISCOVER_STORE_DETAILS'));
 			return false;
@@ -2001,7 +2001,7 @@ class JInstallerComponent extends JAdapterInstance
 		{
 			return $this->parent->extension->store();
 		}
-		catch (JException $e)
+		catch (Exception $e)
 		{
 			JError::raiseWarning(101, JText::_('JLIB_INSTALLER_ERROR_COMP_REFRESH_MANIFEST_CACHE'));
 			return false;

--- a/libraries/joomla/installer/adapters/file.php
+++ b/libraries/joomla/installer/adapters/file.php
@@ -203,7 +203,7 @@ class JInstallerFile extends JAdapterInstance
 		{
 			$db->Query();
 		}
-		catch (JException $e)
+		catch (Exception $e)
 		{
 			// Install failed, roll back changes
 			$this->parent->abort(
@@ -590,7 +590,7 @@ class JInstallerFile extends JAdapterInstance
 		{
 			$db->Query();
 		}
-		catch (JException $e)
+		catch (Exception $e)
 		{
 			// Install failed, roll back changes
 			$this->parent->abort(JText::sprintf('JLIB_INSTALLER_ABORT_FILE_ROLLBACK', $db->stderr(true)));
@@ -724,7 +724,7 @@ class JInstallerFile extends JAdapterInstance
 		{
 			return $this->parent->extension->store();
 		}
-		catch (JException $e)
+		catch (Exception $e)
 		{
 			JError::raiseWarning(101, JText::_('JLIB_INSTALLER_ERROR_PACK_REFRESH_MANIFEST_CACHE'));
 			return false;

--- a/libraries/joomla/installer/adapters/language.php
+++ b/libraries/joomla/installer/adapters/language.php
@@ -630,7 +630,7 @@ class JInstallerLanguage extends JAdapterInstance
 		{
 			$this->parent->extension->store();
 		}
-		catch (JException $e)
+		catch (Exception $e)
 		{
 			JError::raiseWarning(101, JText::_('JLIB_INSTALLER_ERROR_LANG_DISCOVER_STORE_DETAILS'));
 			return false;

--- a/libraries/joomla/installer/adapters/library.php
+++ b/libraries/joomla/installer/adapters/library.php
@@ -399,7 +399,7 @@ class JInstallerLibrary extends JAdapterInstance
 		{
 			return $this->parent->extension->store();
 		}
-		catch (JException $e)
+		catch (Exception $e)
 		{
 			JError::raiseWarning(101, JText::_('JLIB_INSTALLER_ERROR_LIB_REFRESH_MANIFEST_CACHE'));
 			return false;

--- a/libraries/joomla/installer/adapters/module.php
+++ b/libraries/joomla/installer/adapters/module.php
@@ -218,7 +218,7 @@ class JInstallerModule extends JAdapterInstance
 		{
 			$db->Query();
 		}
-		catch (JException $e)
+		catch (Exception $e)
 		{
 			// Install failed, roll back changes
 			$this->parent
@@ -819,7 +819,7 @@ class JInstallerModule extends JAdapterInstance
 		{
 			$modules = $db->loadColumn();
 		}
-		catch (JException $e)
+		catch (Exception $e)
 		{
 			$modules = array();
 		}
@@ -838,7 +838,7 @@ class JInstallerModule extends JAdapterInstance
 			{
 				$db->query();
 			}
-			catch (JException $e)
+			catch (Exception $e)
 			{
 				JError::raiseWarning(100, JText::sprintf('JLIB_INSTALLER_ERROR_MOD_UNINSTALL_EXCEPTION', $db->stderr(true)));
 				$retval = false;
@@ -852,7 +852,7 @@ class JInstallerModule extends JAdapterInstance
 			{
 				$db->query();
 			}
-			catch (JException $e)
+			catch (Exception $e)
 			{
 				JError::raiseWarning(100, JText::sprintf('JLIB_INSTALLER_ERROR_MOD_UNINSTALL_EXCEPTION', $db->stderr(true)));
 				$retval = false;
@@ -869,7 +869,7 @@ class JInstallerModule extends JAdapterInstance
 			// Clean up any other ones that might exist as well
 			$db->Query();
 		}
-		catch (JException $e)
+		catch (Exception $e)
 		{
 			// Ignore the error...
 		}
@@ -909,7 +909,7 @@ class JInstallerModule extends JAdapterInstance
 		{
 			return $db->query();
 		}
-		catch (JException $e)
+		catch (Exception $e)
 		{
 			return false;
 		}
@@ -937,7 +937,7 @@ class JInstallerModule extends JAdapterInstance
 		{
 			return $db->query();
 		}
-		catch (JException $e)
+		catch (Exception $e)
 		{
 			return false;
 		}

--- a/libraries/joomla/installer/adapters/package.php
+++ b/libraries/joomla/installer/adapters/package.php
@@ -390,7 +390,7 @@ class JInstallerPackage extends JAdapterInstance
 		{
 			return $this->parent->extension->store();
 		}
-		catch (JException $e)
+		catch (Exception $e)
 		{
 			JError::raiseWarning(101, JText::_('JLIB_INSTALLER_ERROR_PACK_REFRESH_MANIFEST_CACHE'));
 			return false;

--- a/libraries/joomla/installer/adapters/plugin.php
+++ b/libraries/joomla/installer/adapters/plugin.php
@@ -193,7 +193,7 @@ class JInstallerPlugin extends JAdapterInstance
 		{
 			$db->Query();
 		}
-		catch (JException $e)
+		catch (Exception $e)
 		{
 			// Install failed, roll back changes
 			$this->parent

--- a/libraries/joomla/installer/adapters/template.php
+++ b/libraries/joomla/installer/adapters/template.php
@@ -546,7 +546,7 @@ class JInstallerTemplate extends JAdapterInstance
 		{
 			return $this->parent->extension->store();
 		}
-		catch (JException $e)
+		catch (Exception $e)
 		{
 			JError::raiseWarning(101, JText::_('JLIB_INSTALLER_ERROR_TPL_REFRESH_MANIFEST_CACHE'));
 			return false;

--- a/libraries/joomla/registry/format.php
+++ b/libraries/joomla/registry/format.php
@@ -33,7 +33,7 @@ abstract class JRegistryFormat
 	 * @return  JRegistryFormat  Registry format handler
 	 *
 	 * @since   11.1
-	 * @throws  JException
+	 * @throws  Exception
 	 */
 	public static function getInstance($type)
 	{
@@ -54,7 +54,7 @@ abstract class JRegistryFormat
 				}
 				else
 				{
-					throw new JException(JText::_('JLIB_REGISTRY_EXCEPTION_LOAD_FORMAT_CLASS'), 500, E_ERROR);
+					throw new Exception(JText::_('JLIB_REGISTRY_EXCEPTION_LOAD_FORMAT_CLASS'), 500);
 				}
 			}
 

--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -89,7 +89,7 @@ abstract class JUserHelper
 	 *
 	 * @param   integer  $userId  The id of the user.
 	 *
-	 * @return  mixed  Array on success, JException on error.
+	 * @return  mixed  Array on success, Exception on error.
 	 *
 	 * @since   11.1
 	 */
@@ -107,7 +107,7 @@ abstract class JUserHelper
 	 * @param   integer  $userId   The id of the user.
 	 * @param   integer  $groupId  The id of the group.
 	 *
-	 * @return  mixed  Boolean true on success, JException on error.
+	 * @return  mixed  Boolean true on success, Exception on error.
 	 *
 	 * @since   11.1
 	 */
@@ -126,7 +126,7 @@ abstract class JUserHelper
 			// Store the user object.
 			if (!$user->save())
 			{
-				return new JException($user->getError());
+				return new Exception($user->getError());
 			}
 		}
 

--- a/libraries/joomla/utilities/date.php
+++ b/libraries/joomla/utilities/date.php
@@ -84,7 +84,7 @@ class JDate extends DateTime
 	 *
 	 * @since   11.1
 	 *
-	 * @throws  JException
+	 * @throws  Exception
 	 */
 	public function __construct($date = 'now', $tz = null)
 	{
@@ -223,7 +223,7 @@ class JDate extends DateTime
 	 * @return  JDate
 	 *
 	 * @since   11.3
-	 * @throws  JException
+	 * @throws  Exception
 	 */
 	public static function getInstance($date = 'now', $tz = null)
 	{

--- a/tests/includes/JoomlaDatabaseTestCase.php
+++ b/tests/includes/JoomlaDatabaseTestCase.php
@@ -290,7 +290,7 @@ abstract class JoomlaDatabaseTestCase extends PHPUnit_Extensions_Database_TestCa
 	/**
 	 * Receives the callback from JError and logs the required error information for the test.
 	 *
-	 * @param	JException	The JException object from JError
+	 * @param	Exception	The Exception object from JError
 	 *
 	 * @return	bool	To not continue with JError processing
 	 *
@@ -510,7 +510,7 @@ abstract class JoomlaDatabaseTestCase extends PHPUnit_Extensions_Database_TestCa
 
 		return JSessionGlobalMock::create($this, $options);
 	}
-	
+
 	/**
 	 * Gets a mock web object.
 	 *
@@ -522,10 +522,10 @@ abstract class JoomlaDatabaseTestCase extends PHPUnit_Extensions_Database_TestCa
 	{
 		// Load the real class first otherwise the mock will be used if jimport is called again.
 		require_once JPATH_PLATFORM . '/joomla/application/web.php';
-	
+
 		// Load the mock class builder.
 		require_once JPATH_TESTS . '/includes/mocks/JWebMock.php';
-	
+
 		return JWebGlobalMock::create($this);
 	}
 }

--- a/tests/includes/JoomlaTestCase.php
+++ b/tests/includes/JoomlaTestCase.php
@@ -200,7 +200,7 @@ abstract class JoomlaTestCase extends PHPUnit_Framework_TestCase
 	/**
 	 * Receives the callback from JError and logs the required error information for the test.
 	 *
-	 * @param   JException	$error  The JException object from JError
+	 * @param   Exception	$error  The Exception object from JError
 	 *
 	 * @return  boolean  To not continue with JError processing
 	 *
@@ -451,7 +451,7 @@ abstract class JoomlaTestCase extends PHPUnit_Framework_TestCase
 
 		return JSessionGlobalMock::create($this, $options);
 	}
-	
+
 	/**
 	 * Gets a mock web object.
 	 *
@@ -463,10 +463,10 @@ abstract class JoomlaTestCase extends PHPUnit_Framework_TestCase
 	{
 		// Load the real class first otherwise the mock will be used if jimport is called again.
 		require_once JPATH_PLATFORM . '/joomla/application/web.php';
-	
+
 		// Load the mock class builder.
 		require_once JPATH_TESTS . '/includes/mocks/JWebMock.php';
-	
+
 		return JWebGlobalMock::create($this);
 	}
 }

--- a/tests/suite/joomla/cache/JCacheStorageTest.php
+++ b/tests/suite/joomla/cache/JCacheStorageTest.php
@@ -57,7 +57,7 @@ class JCacheStorageTest extends JoomlaTestCase
 	/**
 	 * Receives the callback from JError and logs the required error information for the test.
 	 *
-	 * @param	JException	The JException object from JError
+	 * @param	Exception	The Exception object from JError
 	 *
 	 * @return	bool	To not continue with JError processing
 	 */
@@ -79,10 +79,10 @@ class JCacheStorageTest extends JoomlaTestCase
 		JCacheStorageTest::$actualError = array();
 
 		$this->object = new JCacheStorage;
-		
+
 		$this->checkStores();
 	}
-	
+
 	protected function checkStores()
 	{
 		$this->apcAvailable = extension_loaded('apc');

--- a/tests/suite/joomla/event/JDispatcherTest.php
+++ b/tests/suite/joomla/event/JDispatcherTest.php
@@ -54,14 +54,14 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
 	public function testGetInstance()
 	{
 		$mock = JDispatcher::getInstance();
-		
+
 		$this->assertInstanceOf(
 			'JDispatcherInspector',
 			$mock
 		);
-		
+
 		$this->object->setInstance(null);
-		
+
 		$instance = JDispatcher::getInstance();
 
 		$this->assertInstanceOf(
@@ -78,15 +78,15 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
 			$this->equalTo('foo'),
 			'Tests that a subsequent call to JDispatcher::getInstance returns the cached singleton.'
 		);
-		
+
 		JDispatcherInspector::setInstance($mock);
 	}
 
     /**
      * Test JDispatcher::getState().
-     * 
+     *
      * @return void
-     * 
+     *
      * @since 11.3
      */
     public function testGetState()
@@ -95,9 +95,9 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
     		$this->object->getState(),
     		$this->equalTo(null)
     	);
-    	
+
     	$this->object->_state = 'test';
-    	
+
     	$this->assertThat(
     		$this->object->getState(),
     		$this->equalTo('test')
@@ -106,7 +106,7 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
 
     /**
      * Test JDispatcher::register().
-     * 
+     *
      * @since 11.3
      */
     public function testRegister()
@@ -116,15 +116,15 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
     		$this->object->_observers,
     		$this->equalTo(array())
     	);
-    	
+
     	$this->assertThat(
     		$this->object->_methods,
     		$this->equalTo(array())
     	);
-    	
+
     	//We register a function on the event 'onTestEvent'
     	$this->object->register('onTestEvent', 'JEventMockFunction');
-    	
+
     	$this->assertThat(
     		$this->object->_observers,
     		$this->equalTo(
@@ -133,17 +133,17 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
     			)
     		)
     	);
-    	
+
     	$this->assertThat(
     		$this->object->_methods,
     		$this->equalTo(
     			array('ontestevent' => array(0))
     		)
     	);
-    	
+
     	//We register the same function on a different event 'onTestOtherEvent'
     	$this->object->register('onTestOtherEvent', 'JEventMockFunction');
-    	
+
     	$this->assertThat(
     		$this->object->_observers,
     		$this->equalTo(
@@ -153,7 +153,7 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
     			)
     		)
     	);
-    	
+
     	$this->assertThat(
     		$this->object->_methods,
     		$this->equalTo(
@@ -163,10 +163,10 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
     			)
     		)
     	);
-    	
+
     	//Now we attach a class to the dispatcher
     	$this->object->register('', 'JEventInspector');
-    	
+
     	$object = $this->object->_observers[2];
 
     	$this->assertThat(
@@ -179,7 +179,7 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
     			)
     		)
     	);
-    	
+
     	$this->assertThat(
     		$this->object->_methods,
     		$this->equalTo(
@@ -190,30 +190,30 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
     			)
     		)
     	);
-    	
+
     	//Now we trigger an error with an invalid handler
    		$error = $this->object->register('fakeevent', 'nonExistingClass');
     	$this->assertTrue(
-    		is_a($error, 'JException')
+    		is_a($error, 'Exception')
     	);
     }
 
     /**
      * Test JDispatcher::trigger().
-     * 
+     *
      * @since 11.3
      */
     public function testTrigger()
     {
     	$this->object->register('onTestEvent', 'JEventMockFunction');
     	$this->object->register('', 'JEventInspector');
-    	
+
     	//We check a non-existing event
     	$this->assertThat(
     		$this->object->trigger('onFakeEvent'),
     		$this->equalTo(array())
     	);
-    	
+
     	//Lets check the existing event "onTestEvent" without parameters
     	$this->assertThat(
     		$this->object->trigger('onTestEvent'),
@@ -224,7 +224,7 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
     			)
     		)
     	);
-    	
+
     	//Lets check the existing event "onTestEvent" with parameters
     	$this->assertThat(
     		$this->object->trigger('onTestEvent', array('one', 'two')),
@@ -235,10 +235,10 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
     			)
     		)
     	);
-    	
+
     	//We check a situation where the observer is broken. Joomla should handle this gracefully
     	$this->object->_observers = array();
-    	
+
     	$this->assertThat(
     		$this->object->trigger('onTestEvent'),
     		$this->equalTo(array())
@@ -247,47 +247,47 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
 
     /**
      * Test JDispatcher::attach().
-     * 
+     *
      * @since 11.3
      */
     public function testAttach()
     {
     	//Lets test an invalid observer
     	$observer = array();
-    	
+
     	$this->object->attach($observer);
-    	
+
     	$this->assertThat(
     		$this->object->_methods,
     		$this->equalTo(array())
     	);
-    	
+
     	$this->assertThat(
     		$this->object->_observers,
     		$this->equalTo(array())
     	);
-    	
+
     	//Lets test an uncallable observer
     	$observer = array('handler' => 'fakefunction', 'event' => 'onTestEvent');
-    	
+
     	$this->object->attach($observer);
-    	
+
     	$this->assertThat(
     		$this->object->_methods,
     		$this->equalTo(array())
     	);
-    	
+
     	$this->assertThat(
     		$this->object->_observers,
     		$this->equalTo(array())
     	);
-    	
+
     	//Lets test a callable function observer
     	$observer = array('handler' => 'JEventMockFunction', 'event' => 'onTestEvent');
     	$observers = array($observer);
-    	
+
     	$this->object->attach($observer);
-    	
+
     	$this->assertThat(
     		$this->object->_methods,
     		$this->equalTo(
@@ -296,7 +296,7 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
     			)
     		)
     	);
-    	
+
     	$this->assertThat(
     		$this->object->_observers,
     		$this->equalTo($observers)
@@ -305,9 +305,9 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
     	//Lets test that an observer is not attached twice
     	$observer = array('handler' => 'JEventMockFunction', 'event' => 'onTestEvent');
     	$observers = array($observer);
-    	
+
     	$this->object->attach($observer);
-    	
+
     	$this->assertThat(
     		$this->object->_methods,
     		$this->equalTo(
@@ -316,7 +316,7 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
     			)
     		)
     	);
-    	
+
     	$this->assertThat(
     		$this->object->_observers,
     		$this->equalTo($observers)
@@ -324,9 +324,9 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
 
     	//Lets test an invalid object
     	$observer = new stdClass();
-    	
+
     	$this->object->attach($observer);
-    	
+
     	$this->assertThat(
     		$this->object->_methods,
     		$this->equalTo(
@@ -335,18 +335,18 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
     			)
     		)
     	);
-    	
+
     	$this->assertThat(
     		$this->object->_observers,
     		$this->equalTo($observers)
     	);
-    	
+
     	//Lets test a valid event object
     	$observer = new JEventInspector($this->object);
     	$observers[] = $observer;
-    	
+
     	$this->object->attach($observer);
-    	
+
     	$this->assertThat(
     		$this->object->_methods,
     		$this->equalTo(
@@ -356,7 +356,7 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
     			)
     		)
     	);
-    	
+
     	$this->assertThat(
     		$this->object->_observers,
     		$this->equalTo($observers)
@@ -364,9 +364,9 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
 
     	//Lets test that an object observer is not attached twice
     	$observer = new JEventInspector($this->object);
-    	
+
     	$this->object->attach($observer);
-    	
+
     	$this->assertThat(
     		$this->object->_methods,
     		$this->equalTo(
@@ -376,7 +376,7 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
     			)
     		)
     	);
-    	
+
     	$this->assertThat(
     		$this->object->_observers,
     		$this->equalTo($observers)
@@ -385,7 +385,7 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
 
     /**
      * Test JDispatcher::detach().
-     * 
+     *
      * @since 11.3
      */
     public function testDetach()
@@ -396,7 +396,7 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
     	$this->object->attach($observer2);
     	$observer3 = new JEventInspector($this->object);
     	$this->object->attach($observer3);
-    	
+
     	//Test removing a non-existing observer
     	$this->assertThat(
     		$this->object->_methods,
@@ -417,11 +417,11 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
 				)
 			)
 		);
-		
+
 		$return = $this->object->detach($observer1);
 
 		$this->assertFalse($return);
-		
+
 		$this->assertThat(
     		$this->object->_methods,
     		$this->equalTo(
@@ -441,12 +441,12 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
 				)
 			)
 		);
-		
+
     	//Test removing a functional observer
     	$return = $this->object->detach($observer2);
-    	
+
     	$this->assertTrue($return);
-    	
+
     	$this->assertThat(
     		$this->object->_methods,
     		$this->equalTo(
@@ -465,12 +465,12 @@ class JDispatcherTest extends PHPUnit_Framework_TestCase
 				)
 			)
 		);
-		
+
     	//Test removing an object observer with more than one event
         $return = $this->object->detach($observer3);
-    	
+
     	$this->assertTrue($return);
-    	
+
     	$this->assertThat(
     		$this->object->_methods,
     		$this->equalTo(

--- a/tests/suite/joomla/utilities/JSimpleXMLTest.php
+++ b/tests/suite/joomla/utilities/JSimpleXMLTest.php
@@ -25,7 +25,7 @@ class JSimpleXMLTest extends JoomlaTestCase
 	/**
 	 * Receives the callback from JError and logs the required error information for the test.
 	 *
-	 * @param   JException	The JException object from JError
+	 * @param   Exception	The Exception object from JError
 	 *
 	 * @return  bool	To not continue with JError processing
 	 */


### PR DESCRIPTION
This pull request removes most instances of JException in favor of Exception.  All but the Form package are handled because I couldn't sort out where the unit test suite was failing with this change in that package.
