### PR TITLE
Update JHtmlForm::token() test

### DIFF
--- a/tests/suite/joomla/html/html/JHtmlFormTest.php
+++ b/tests/suite/joomla/html/html/JHtmlFormTest.php
@@ -14,8 +14,41 @@ require_once JPATH_PLATFORM.'/joomla/html/html/form.php';
  *
  * @since  11.1
  */
-class JHtmlFormTest extends PHPUnit_Framework_TestCase
+class JHtmlFormTest extends JoomlaTestCase
 {
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.4
+	 */
+	protected function setUp()
+	{
+		parent::setup();
+
+		$this->saveFactoryState();
+
+		JFactory::$session = $this->getMockSession();
+	}
+
+	/**
+	 * Tears down the fixture.
+	 *
+	 * This method is called after a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.4
+	 */
+	protected function tearDown()
+	{
+		$this->restoreFactoryState();
+
+		parent::tearDown();
+	}
+
 	/**
 	 * @todo Implement testToken().
 	 */


### PR DESCRIPTION
Update the test to mock the session due to a unit test failure locally, and use getFormToken in the test as well.
