### PR TITLE
Code style: Fix FileCommentsSniff

### DIFF
--- a/build/phpcs/Joomla/Sniffs/Commenting/FileCommentSniff.php
+++ b/build/phpcs/Joomla/Sniffs/Commenting/FileCommentSniff.php
@@ -484,7 +484,7 @@ class Joomla_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sniff
             // Joomla change: allow for 2 space gap.
                 && $indentInfo['space'] !== ($longestTag + 2)
             ) {
-                $expected = (($longestTag - strlen($indentInfo['tag'])) + 1);
+                $expected = (($longestTag - strlen($indentInfo['tag'])) + 2);
                 $space    = ($indentInfo['space'] - strlen($indentInfo['tag']));
                 $error    = '@%s tag comment indented incorrectly; expected %s spaces but found %s';
                 $data     = array(


### PR DESCRIPTION
This sniff produces an erroneous message like:
`@foo tag comment indented incorrectly; expected 4 spaces but found 4'`

Last time this one appeared was in #603 as [commented](https://github.com/joomla/joomla-platform/pull/603#issuecomment-3033879) by Rouven.
