### PR TITLE
Add url filtering, improve url field, update  tests to reflect changes.

### DIFF
--- a/libraries/joomla/form/fields/url.php
+++ b/libraries/joomla/form/fields/url.php
@@ -22,7 +22,7 @@ JFormHelper::loadFieldClass('text');
  * @see         JFormRuleUrl for validation of full urls
  * @since       11.1
  */
-class JFormFieldUrl extends JFormField
+class JFormFieldUrl extends JFormFieldText
 {
 	/**
 	 * The form field type.
@@ -42,28 +42,10 @@ class JFormFieldUrl extends JFormField
 	* @return  string
 	*
 	* @see     JFormRuleUrl, JForm::Filter
-	* @since   11.4
+	* @since   11.1
 	*/
 	protected function getInput()
 	{
-		// Initialize some field attributes.
-		$accept		= $this->element['accept'] ? ' accept="' . (string) $this->element['accept'] . '"' : '';
-		$size		= $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
-		$class		= $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
-		$disabled	= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
-		$readonly	= ((string) $this->element['readonly'] == 'true') ? ' readonly="readonly"' : '';
-		$maxLength	= $this->element['maxlength'] ? ' maxlength="' . (int) $this->element['maxlength'] . '"' : '';
-		// Element to assume  of relative URLs without protocols are local. If not set or false, URLS
-		// without protocols are assumed to be external (with some exceptions based on string matching).
-		// Do not use if you intend to use the URL rule to validate.
-		$relative   = ((string) $this->element['relative'] == 'true') ? ' relative="relative"' : '';
-
-			// Initialize JavaScript field attributes.
-			$onchange	= $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
-
-			return '<input type="text" name="' . $this->name . '" id="' . $this->id . '"' .
-					' value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' .
-					$class . $size . $disabled . $relative . $readonly . $onchange . $maxLength . '/>';
-
+		protected $type = 'Url';
 	}
 }

--- a/libraries/joomla/form/fields/url.php
+++ b/libraries/joomla/form/fields/url.php
@@ -52,19 +52,18 @@ class JFormFieldUrl extends JFormField
 		$class		= $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
 		$disabled	= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
 		$readonly	= ((string) $this->element['readonly'] == 'true') ? ' readonly="readonly"' : '';
-		$maxLength	= $this->element['maxlength'] ? ' maxlength="' . (int) $this->element['maxlength'].'"' : '';
+		$maxLength	= $this->element['maxlength'] ? ' maxlength="' . (int) $this->element['maxlength'] . '"' : '';
 		// Element to assume  of relative URLs without protocols are local. If not set or false, URLS
 		// without protocols are assumed to be external (with some exceptions based on string matching).
 		// Do not use if you intend to use the URL rule to validate.
 		$relative   = ((string) $this->element['relative'] == 'true') ? ' relative="relative"' : '';
 
-
 			// Initialize JavaScript field attributes.
 			$onchange	= $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
 
-			return '<input type="text" name="'. $this->name . '" id="' . $this->id . '"' .
+			return '<input type="text" name="' . $this->name . '" id="' . $this->id . '"' .
 					' value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' .
 					$class . $size . $disabled . $relative . $readonly . $onchange . $maxLength . '/>';
 
-		}
+	}
 }

--- a/libraries/joomla/form/fields/url.php
+++ b/libraries/joomla/form/fields/url.php
@@ -31,21 +31,4 @@ class JFormFieldUrl extends JFormFieldText
 	 * @since  11.1
 	 */
 	protected $type = 'Url';
-
-	/**
-	* Method to get the field input markup.
-	* When used in conjunction with the url filter in JFormField, if the relative element is
-	* false the method assumes most URLS are external.
-	* When relative is true a URL that does not include a protocol is assumed to be local.
-	* This method does not validate a URL which should be done using JFormRuleUrl.
-	*
-	* @return  string
-	*
-	* @see     JFormRuleUrl, JForm::Filter
-	* @since   11.1
-	*/
-	protected function getInput()
-	{
-		protected $type = 'Url';
-	}
 }

--- a/libraries/joomla/form/fields/url.php
+++ b/libraries/joomla/form/fields/url.php
@@ -28,31 +28,31 @@ class JFormFieldUrl extends JFormField
 	 * The form field type.
 	 *
 	 * @var    string
-	 * @since  11.4
+	 * @since  11.1
 	 */
 	protected $type = 'Url';
 
 	/**
 	* Method to get the field input markup.
-	* When used in conjunction with the url filter in JFormField, ifthe relative element is
+	* When used in conjunction with the url filter in JFormField, if the relative element is
 	* false the method assumes most URLS are external.
-	* When relative is true a url that does not include a protocol is assumed to be local.
-	* This method does not validate a url which should be done using JFormRuleUrl.
+	* When relative is true a URL that does not include a protocol is assumed to be local.
+	* This method does not validate a URL which should be done using JFormRuleUrl.
 	*
 	* @return  string
 	*
 	* @see     JFormRuleUrl, JForm::Filter
-	* @since   11.1
+	* @since   11.4
 	*/
 	protected function getInput()
 	{
 		// Initialize some field attributes.
-		$accept		= $this->element['accept'] ? ' accept="'.(string) $this->element['accept'].'"' : '';
-		$size		= $this->element['size'] ? ' size="'.(int) $this->element['size'].'"' : '';
-		$class		= $this->element['class'] ? ' class="'.(string) $this->element['class'].'"' : '';
+		$accept		= $this->element['accept'] ? ' accept="' . (string) $this->element['accept'] . '"' : '';
+		$size		= $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
+		$class		= $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
 		$disabled	= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
 		$readonly	= ((string) $this->element['readonly'] == 'true') ? ' readonly="readonly"' : '';
-		$maxLength	= $this->element['maxlength'] ? ' maxlength="'.(int) $this->element['maxlength'].'"' : '';
+		$maxLength	= $this->element['maxlength'] ? ' maxlength="' . (int) $this->element['maxlength'].'"' : '';
 		// Element to assume  of relative URLs without protocols are local. If not set or false, URLS
 		// without protocols are assumed to be external (with some exceptions based on string matching).
 		// Do not use if you intend to use the URL rule to validate.
@@ -60,11 +60,11 @@ class JFormFieldUrl extends JFormField
 
 
 			// Initialize JavaScript field attributes.
-			$onchange	= $this->element['onchange'] ? ' onchange="'.(string) $this->element['onchange'].'"' : '';
+			$onchange	= $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
 
-			return '<input type="text" name="'.$this->name.'" id="'.$this->id.'"' .
-					' value="'.htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8').'"' .
-					$class.$size.$disabled.$relative.$readonly.$onchange.$maxLength.'/>';
+			return '<input type="text" name="'. $this->name . '" id="' . $this->id . '"' .
+					' value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' .
+					$class . $size . $disabled . $relative . $readonly . $onchange . $maxLength . '/>';
 
 		}
 }

--- a/libraries/joomla/form/fields/url.php
+++ b/libraries/joomla/form/fields/url.php
@@ -22,48 +22,49 @@ JFormHelper::loadFieldClass('text');
  * @see         JFormRuleUrl for validation of full urls
  * @since       11.1
  */
-class JFormFieldUrl extends JFormFieldText
+class JFormFieldUrl extends JFormField
 {
 	/**
 	 * The form field type.
 	 *
 	 * @var    string
-	 * @since  11.1
+	 * @since  11.4
 	 */
 	protected $type = 'Url';
-		/**
-		* Method to get the field input markup.
-		* When used in conjunction with the url filter in JFormField, ifthe relative element is
-		* false the method assumes most URLS are external.
-		* When relative is true a url that does not include a protocol is assumed to be local.
-		* This method does not validate a url which should be done using JFormRuleUrl.
-		*
-		* @return  string
-		*
-		* @see     JFormRuleUrl, JForm::Filter
-		* @since   11.1
-		*/
-		protected function getInput()
-		{
-			// Initialize some field attributes.
-			$accept		= $this->element['accept'] ? ' accept="'.(string) $this->element['accept'].'"' : '';
-			$size		= $this->element['size'] ? ' size="'.(int) $this->element['size'].'"' : '';
-			$class		= $this->element['class'] ? ' class="'.(string) $this->element['class'].'"' : '';
-			$disabled	= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
-			$readonly	= ((string) $this->element['readonly'] == 'true') ? ' readonly="readonly"' : '';
-			$maxLength	= $this->element['maxlength'] ? ' maxlength="'.(int) $this->element['maxlength'].'"' : '';
-			// Element to assume  of relative URLs without protocols are local. If not set or false, URLS
-			// without protocols are assumed to be external (with some exceptions based on string matching).
-			// Do not use if you intend to use the URL rule to validate.
-			$relative   = ((string) $this->element['relative'] == 'true') ? ' relative="relative"' : '';
+
+	/**
+	* Method to get the field input markup.
+	* When used in conjunction with the url filter in JFormField, ifthe relative element is
+	* false the method assumes most URLS are external.
+	* When relative is true a url that does not include a protocol is assumed to be local.
+	* This method does not validate a url which should be done using JFormRuleUrl.
+	*
+	* @return  string
+	*
+	* @see     JFormRuleUrl, JForm::Filter
+	* @since   11.1
+	*/
+	protected function getInput()
+	{
+		// Initialize some field attributes.
+		$accept		= $this->element['accept'] ? ' accept="'.(string) $this->element['accept'].'"' : '';
+		$size		= $this->element['size'] ? ' size="'.(int) $this->element['size'].'"' : '';
+		$class		= $this->element['class'] ? ' class="'.(string) $this->element['class'].'"' : '';
+		$disabled	= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
+		$readonly	= ((string) $this->element['readonly'] == 'true') ? ' readonly="readonly"' : '';
+		$maxLength	= $this->element['maxlength'] ? ' maxlength="'.(int) $this->element['maxlength'].'"' : '';
+		// Element to assume  of relative URLs without protocols are local. If not set or false, URLS
+		// without protocols are assumed to be external (with some exceptions based on string matching).
+		// Do not use if you intend to use the URL rule to validate.
+		$relative   = ((string) $this->element['relative'] == 'true') ? ' relative="relative"' : '';
 
 
-				// Initialize JavaScript field attributes.
-				$onchange	= $this->element['onchange'] ? ' onchange="'.(string) $this->element['onchange'].'"' : '';
+			// Initialize JavaScript field attributes.
+			$onchange	= $this->element['onchange'] ? ' onchange="'.(string) $this->element['onchange'].'"' : '';
 
-				return '<input type="text" name="'.$this->name.'" id="'.$this->id.'"' .
-						' value="'.htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8').'"' .
-						$class.$size.$disabled.$relative.$readonly.$onchange.$maxLength.'/>';
+			return '<input type="text" name="'.$this->name.'" id="'.$this->id.'"' .
+					' value="'.htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8').'"' .
+					$class.$size.$disabled.$relative.$readonly.$onchange.$maxLength.'/>';
 
-			}
+		}
 }

--- a/libraries/joomla/form/fields/url.php
+++ b/libraries/joomla/form/fields/url.php
@@ -31,4 +31,39 @@ class JFormFieldUrl extends JFormFieldText
 	 * @since  11.1
 	 */
 	protected $type = 'Url';
+		/**
+		* Method to get the field input markup.
+		* When used in conjunction with the url filter in JFormField, ifthe relative element is
+		* false the method assumes most URLS are external.
+		* When relative is true a url that does not include a protocol is assumed to be local.
+		* This method does not validate a url which should be done using JFormRuleUrl.
+		*
+		* @return  string
+		*
+		* @see     JFormRuleUrl, JForm::Filter
+		* @since   11.1
+		*/
+		protected function getInput()
+		{
+			// Initialize some field attributes.
+			$accept		= $this->element['accept'] ? ' accept="'.(string) $this->element['accept'].'"' : '';
+			$size		= $this->element['size'] ? ' size="'.(int) $this->element['size'].'"' : '';
+			$class		= $this->element['class'] ? ' class="'.(string) $this->element['class'].'"' : '';
+			$disabled	= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
+			$readonly	= ((string) $this->element['readonly'] == 'true') ? ' readonly="readonly"' : '';
+			$maxLength	= $this->element['maxlength'] ? ' maxlength="'.(int) $this->element['maxlength'].'"' : '';
+			// Element to assume  of relative URLs without protocols are local. If not set or false, URLS
+			// without protocols are assumed to be external (with some exceptions based on string matching).
+			// Do not use if you intend to use the URL rule to validate.
+			$relative   = ((string) $this->element['relative'] == 'true') ? ' relative="relative"' : '';
+
+
+				// Initialize JavaScript field attributes.
+				$onchange	= $this->element['onchange'] ? ' onchange="'.(string) $this->element['onchange'].'"' : '';
+
+				return '<input type="text" name="'.$this->name.'" id="'.$this->id.'"' .
+						' value="'.htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8').'"' .
+						$class.$size.$disabled.$relative.$readonly.$onchange.$maxLength.'/>';
+
+			}
 }

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1240,6 +1240,7 @@ class JForm
 
 			// Ensures a protocol is present in the saved field. Only use when
 			// the only permitted protocols requre '://'. See JFormRuleUrl for list of these.
+
 			case 'URL':
 				if (empty($value))
 				{
@@ -1247,8 +1248,10 @@ class JForm
 				}
 				$value = JFilterInput::getInstance()->clean($value, 'html');
 				$value = trim($value);
+
 				// Check for a protocol
 				$protocol = parse_url($value, PHP_URL_SCHEME);
+
 				// If there is no protocol and the relative option is not specified,
 				// we assume that it is an external URL and prepend http://.
 				if (($element['type'] == 'url' && !$protocol &&  !$element['relative'])
@@ -1260,14 +1263,17 @@ class JForm
 					{
 						$value = JURI::root() . $value;
 					}
+
 					// Otherwise we treat it is an external link.
 					// Put the url back together.
 					$value = $protocol . '://' . ltrim($value, $protocol);
 				}
+
 				// If relative URLS are allowed we assume that URLs without protocols are internal.
 				elseif (!$protocol && $element['relative'])
 				{
 					$host = JURI::getInstance('SERVER')->gethost();
+
 					// If it starts with the host string, just prepend the protocol.
 					if (substr($value, 0) == $host)
 					{

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1248,7 +1248,7 @@ class JForm
 				$value = JFilterInput::getInstance()->clean($value, 'html');
 				$value = trim($value);
 				// Check for a protocol
-				$protocol = parse_url($value,PHP_URL_SCHEME);
+				$protocol = parse_url($value, PHP_URL_SCHEME);
 				// If there is no protocol and the relative option is not specified,
 				// we assume that it is an external URL and prepend http://.
 				if (($element['type'] == 'url' && !$protocol &&  !$element['relative'])
@@ -1256,20 +1256,20 @@ class JForm
 				{
 					$protocol = 'http';
 					// If it looks like an internal link, then add the root.
-					if (substr($value,0) ==  'index.php')
+					if (substr($value, 0) ==  'index.php')
 					{
 						$value = JURI::root() . $value;
 					}
 					// Otherwise we treat it is an external link.
 					// Put the url back together.
-					$value = $protocol .'://'. ltrim($value,$protocol);
+					$value = $protocol . '://' . ltrim($value, $protocol);
 				}
 				// If relative URLS are allowed we assume that URLs without protocols are internal.
-				elseif (!$protocol && $element['relative'] )
+				elseif (!$protocol && $element['relative'])
 				{
 					$host = JURI::getInstance('SERVER')->gethost();
 					// If it starts with the host string, just prepend the protocol.
-					if (substr($value,0) == $host)
+					if (substr($value, 0) == $host)
 					{
 						$value = 'http://' . $value;
 					}

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1238,6 +1238,51 @@ class JForm
 				}
 				break;
 
+			// Ensures a protocol is present in the saved field. Only use when
+			// the only permitted protocols requre '://'. See JFormRuleUrl for list of these.
+			case 'URL':
+				if (empty($value))
+				{
+					return;
+				}
+				$value = JFilterInput::getInstance()->clean($value, 'html');
+				$value = trim($value);
+				// Check for a protocol
+				$protocol = parse_url($value,PHP_URL_SCHEME);
+				// If there is no protocol and the relative option is not specified,
+				// we assume that it is an external URL and prepend http://.
+				if (($element['type'] == 'url' && !$protocol &&  !$element['relative'])
+					|| (!$element['type'] == 'url' && !$protocol))
+				{
+					$protocol = 'http';
+					// If it looks like an internal link, then add the root.
+					if (substr($value,0) ==  'index.php')
+					{
+						$value = JURI::root() . $value;
+					}
+					// Otherwise we treat it is an external link.
+					// Put the url back together.
+					$value = $protocol .'://'. ltrim($value,$protocol);
+				}
+				// If relative URLS are allowed we assume that URLs without protocols are internal.
+				elseif (!$protocol && $element['relative'] )
+				{
+					$host = JURI::getInstance('SERVER')->gethost();
+					// If it starts with the host string, just prepend the protocol.
+					if (substr($value,0) == $host)
+					{
+						$value = 'http://' . $value;
+					}
+					// Otherwise prepend the root.
+					else
+					{
+						$value = JURI::root() . $value;
+					}
+				}
+
+				$return = $value;
+				break;
+
 			case 'TEL':
 				$value = trim($value);
 				// Does it match the NANP pattern?

--- a/tests/suite/joomla/form/JFormDataHelper.php
+++ b/tests/suite/joomla/form/JFormDataHelper.php
@@ -82,6 +82,9 @@ class JFormDataHelper
 		<field
 			name="tel" filter="tel" />
 
+		<field
+			name="url" filter="url" />
+
 		<fields
 			name="params"
 			description="Optional Settings">

--- a/tests/suite/joomla/form/JFormTest.php
+++ b/tests/suite/joomla/form/JFormTest.php
@@ -383,13 +383,13 @@ class JFormTest extends JoomlaTestCase
 
 		$this->assertThat(
 			$form->filterField($form->findField('url'), 'http://example.com'),
-		$this->equalTo('http://example.com'),
+			$this->equalTo('http://example.com'),
 			'Line:'.__LINE__.' A field with a valid protocol should return as is.'
 		);
 
 		$this->assertThat(
 			$form->filterField($form->findField('url'), 'http://<script>alert();</script> <p>Some text.</p>'),
-		$this->equalTo('http://alert(); Some text.'),
+			$this->equalTo('http://alert(); Some text.'),
 			'Line:'.__LINE__.' A "url" with scripts should be should be filtered.'
 		);
 

--- a/tests/suite/joomla/form/JFormTest.php
+++ b/tests/suite/joomla/form/JFormTest.php
@@ -382,6 +382,36 @@ class JFormTest extends JoomlaTestCase
 		);
 
 		$this->assertThat(
+			$form->filterField($form->findField('url'), 'http://example.com'),
+		$this->equalTo('http://example.com'),
+			'Line:'.__LINE__.' A field with a valid protocol should return as is.'
+		);
+
+		$this->assertThat(
+			$form->filterField($form->findField('url'), 'http://<script>alert();</script> <p>Some text.</p>'),
+		$this->equalTo('http://alert(); Some text.'),
+			'Line:'.__LINE__.' A "url" with scripts should be should be filtered.'
+		);
+
+		$this->assertThat(
+			$form->filterField($form->findField('url'), 'https://example.com'),
+			$this->equalTo('https://example.com'),
+			'Line:'.__LINE__.' A field with a valid protocol that is not http should return as is.'
+		);
+
+		$this->assertThat(
+			$form->filterField($form->findField('url'), 'example.com'),
+			$this->equalTo('http://example.com'),
+			'Line:'.__LINE__.' A field without a protocol should return with a http:// protocol.'
+		);
+
+		$this->assertThat(
+			$form->filterField($form->findField('url'), ''),
+			$this->equalTo(''),
+			'Line:'.__LINE__.' An empty "url" filter return nothing.'
+		);
+
+		$this->assertThat(
 			$form->filterField($form->findField('default'), $input),
 			$this->equalTo('alert(); Some text.'),
 			'Line:'.__LINE__.' The default strict filter should be correctly applied.'

--- a/tests/suite/joomla/form/example.xml
+++ b/tests/suite/joomla/form/example.xml
@@ -30,7 +30,6 @@
 			label="A URL"
 			filter="url" />
 
-
 		<!--
 		<field
 			name="f_usr_date"

--- a/tests/suite/joomla/form/example.xml
+++ b/tests/suite/joomla/form/example.xml
@@ -24,6 +24,13 @@
 			label="A Server Date"
 			filter="server_utc" />
 
+		<field
+			name="f_url"
+			type="text"
+			label="A URL"
+			filter="url" />
+
+
 		<!--
 		<field
 			name="f_usr_date"


### PR DESCRIPTION
This adds a url filter to the existing filters in Jform. The filter requires that a url have a protocol. If a protocol is not present it uses http://.  It also updates the tests to include tests of the url filtering option. This filter can optionally be used with the url field type or the url rule or both, but this is not required. 

As part of this change, the url field is built out and incorporates a new element, relative. By default (with the exception of some educated guessing based on the host and index.php) the url filter assumes that a url without a protocol is an external url that is only missing a protocol. If the relative element is used, the filter assumes that a url without a protocol is relative to the local root. 
