### PR TITLE
Explicitly set useStorage param to 'true':'false' so that 'null' will no...

### DIFF
--- a/libraries/joomla/html/html/tabs.php
+++ b/libraries/joomla/html/html/tabs.php
@@ -85,7 +85,7 @@ abstract class JHtmlTabs
 			$opt['onActive'] = (isset($params['onActive'])) ? $params['onActive'] : null;
 			$opt['onBackground'] = (isset($params['onBackground'])) ? $params['onBackground'] : null;
 			$opt['display'] = (isset($params['startOffset'])) ? (int) $params['startOffset'] : null;
-			$opt['useStorage'] = (isset($params['useCookie']) && $params['useCookie']) ? 'true' : null;
+			$opt['useStorage'] = (isset($params['useCookie']) && $params['useCookie']) ? 'true' : 'false';
 			$opt['titleSelector'] = "'dt.tabs'";
 			$opt['descriptionSelector'] = "'dd.tabs'";
 


### PR DESCRIPTION
...t get defaulted to 'true' by the tabs.js. This should fix issue where setting useCookie=>'false' still resulted in tabs.js using the cookie storage.
