### PR TITLE
Revert #570

### DIFF
--- a/libraries/joomla/database/database/mysqli.php
+++ b/libraries/joomla/database/database/mysqli.php
@@ -185,7 +185,7 @@ class JDatabaseMySQLi extends JDatabaseMySQL
 	 */
 	public function connected()
 	{
-		if (is_resource($this->connection))
+		if (is_object($this->connection))
 		{
 			return mysqli_ping($this->connection);
 		}


### PR DESCRIPTION
Reverts #570 which causes a regression in the CMS (caused by the fact the mysqli object is not a resource).
