### PR TITLE
Joomla CMS [#26893] add filterText method to JComponentHelper with new customList feature

### DIFF
--- a/libraries/joomla/application/component/helper.php
+++ b/libraries/joomla/application/component/helper.php
@@ -95,6 +95,132 @@ class JComponentHelper
 	}
 
 	/**
+	* Applies the global text filters to arbitrary text as per settings for current user group
+	* 
+	* @param	text The string to filter
+	* 
+	* @return	string The filtered string
+	* @since	11.3
+	*/
+	public static function filterText($text)
+	{
+		// Filter settings
+		$config		= self::getParams('com_config');
+		$user		= JFactory::getUser();
+		$userGroups	= JAccess::getGroupsByUser($user->get('id'));
+
+		$filters = $config->get('filters');
+
+		$blackListTags			= array();
+		$blackListAttributes	= array();
+
+		$whiteListTags			= array();
+		$whiteListAttributes	= array();
+
+		$noHtml		= false;
+		$whiteList	= false;
+		$blackList	= false;
+		$unfiltered	= false;
+
+		// Cycle through each of the user groups the user is in.
+		// Remember they are include in the Public group as well.
+		foreach ($userGroups as $groupId)
+		{
+			// May have added a group by not saved the filters.
+			if (!isset($filters->$groupId)) {
+				continue;
+			}
+
+			// Each group the user is in could have different filtering properties.
+			$filterData = $filters->$groupId;
+			$filterType	= strtoupper($filterData->filter_type);
+
+			if ($filterType == 'NH') {
+				// Maximum HTML filtering.
+				$noHtml = true;
+			}
+			elseif ($filterType == 'NONE') {
+				// No HTML filtering.
+				$unfiltered = true;
+			}
+			else {
+				// Black or white list.
+				// Preprocess the tags and attributes.
+				$tags			= explode(',', $filterData->filter_tags);
+				$attributes		= explode(',', $filterData->filter_attributes);
+				$tempTags		= array();
+				$tempAttributes	= array();
+
+				foreach ($tags as $tag)
+				{
+					$tag = trim($tag);
+
+					if ($tag) {
+						$tempTags[] = $tag;
+					}
+				}
+
+				foreach ($attributes as $attribute)
+				{
+					$attribute = trim($attribute);
+
+					if ($attribute) {
+						$tempAttributes[] = $attribute;
+					}
+				}
+
+				// Collect the black or white list tags and attributes.
+				// Each list is cummulative.
+				if ($filterType == 'BL') {
+					$blackList				= true;
+					$blackListTags			= array_merge($blackListTags, $tempTags);
+					$blackListAttributes	= array_merge($blackListAttributes, $tempAttributes);
+				}
+				elseif ($filterType == 'WL') {
+					$whiteList				= true;
+					$whiteListTags			= array_merge($whiteListTags, $tempTags);
+					$whiteListAttributes	= array_merge($whiteListAttributes, $tempAttributes);
+				}
+			}
+		}
+
+		// Remove duplicates before processing (because the black list uses both sets of arrays).
+		$blackListTags			= array_unique($blackListTags);
+		$blackListAttributes	= array_unique($blackListAttributes);
+		$whiteListTags			= array_unique($whiteListTags);
+		$whiteListAttributes	= array_unique($whiteListAttributes);
+
+		// Unfiltered assumes first priority.
+		if ($unfiltered) {
+			// Dont apply filtering.
+		}
+		else {
+			// Black lists take second precedence.
+			if ($blackList) {
+				// Remove the white-listed attributes from the black-list.
+				$filter = JFilterInput::getInstance(
+					array_diff($blackListTags, $whiteListTags), 			// blacklisted tags
+					array_diff($blackListAttributes, $whiteListAttributes), // blacklisted attributes
+					1,														// blacklist tags
+					1														// blacklist attributes
+				);
+			}
+			// White lists take third precedence.
+			elseif ($whiteList) {
+				$filter	= JFilterInput::getInstance($whiteListTags, $whiteListAttributes, 0, 0, 0);  // turn off xss auto clean
+			}
+			// No HTML takes last place.
+			else {
+				$filter = JFilterInput::getInstance();
+			}
+
+			$text = $filter->clean($text, 'html');
+		}
+
+		return $text;
+	}
+	
+	/**
 	 * Render the component.
 	 *
 	 * @param   string  $option  The component option.

--- a/libraries/joomla/application/component/helper.php
+++ b/libraries/joomla/application/component/helper.php
@@ -146,7 +146,7 @@ class JComponentHelper
 				// Maximum HTML filtering.
 				$noHtml = true;
 			}
-			else if ($filterType == 'NONE')
+			elseif ($filterType == 'NONE')
 			{
 				// No HTML filtering.
 				$unfiltered = true;
@@ -238,15 +238,14 @@ class JComponentHelper
 				}
 			}
 			// Black lists take second precedence.
-			else if ($blackList)
+			elseif ($blackList)
 			{
-				// Remove the white-listed attributes from the black-list.
-				$filter = JFilterInput::getInstance(
-					array_diff($blackListTags, $whiteListTags), 			// blacklisted tags
-					array_diff($blackListAttributes, $whiteListAttributes), // blacklisted attributes
-					1,														// blacklist tags
-					1														// blacklist attributes
-				);
+				// Remove the white-listed tags and attributes from the black-list.
+				$blackListTags			= array_diff($blackListTags, $whiteListTags);
+				$blackListAttributes	= array_diff($blackListAttributes, $whiteListAttributes);
+
+				$filter = JFilterInput::getInstance($blackListTags, $blackListAttributes, 1, 1);
+
 				// Remove white listed tags from filter's default blacklist
 				if ($whiteListTags)
 				{
@@ -259,7 +258,7 @@ class JComponentHelper
 				}
 			}
 			// White lists take third precedence.
-			else if ($whiteList)
+			elseif ($whiteList)
 			{
 				$filter	= JFilterInput::getInstance($whiteListTags, $whiteListAttributes, 0, 0, 0);  // turn off xss auto clean
 			}


### PR DESCRIPTION
See http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=26893 for description of problem having Text Filtering confined to Articles.

Incorporates feature requeste started here: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=26482

Logic for filtering is explained in the test instructions of #26893.  Custom black list allows SU to override the hard-corded default tagBlackList and attrBlackList of JFilterInput.
