### PR TITLE
Add missing scope modifiers for functions.

### DIFF
--- a/libraries/joomla/application/application.php
+++ b/libraries/joomla/application/application.php
@@ -1173,7 +1173,7 @@ class JApplication extends JObject
 	 *
 	 * @since   11.1
 	 */
-	static function isWinOS()
+	public static function isWinOS()
 	{
 		return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
 	}

--- a/libraries/joomla/database/database.php
+++ b/libraries/joomla/database/database.php
@@ -28,7 +28,7 @@ interface JDatabaseInterface
 	 *
 	 * @since   11.2
 	 */
-	static function test();
+	public static function test();
 }
 
 /**

--- a/libraries/joomla/html/html/grid.php
+++ b/libraries/joomla/html/html/grid.php
@@ -30,7 +30,7 @@ abstract class JHtmlGrid
 	 *
 	 * @since    11.1
 	 */
-	static function boolean($i, $value, $taskOn = null, $taskOff = null)
+	public static function boolean($i, $value, $taskOn = null, $taskOff = null)
 	{
 		// Load the behavior.
 		self::behavior();
@@ -344,7 +344,7 @@ abstract class JHtmlGrid
 	 *
 	 * @since   11.1
 	 */
-	static function behavior()
+	public static function behavior()
 	{
 		static $loaded;
 

--- a/libraries/joomla/language/help.php
+++ b/libraries/joomla/language/help.php
@@ -30,7 +30,7 @@ class JHelp
 	 *
 	 * @since   11.1
 	 */
-	static function createURL($ref, $useComponent = false, $override = null, $component = null)
+	public static function createURL($ref, $useComponent = false, $override = null, $component = null)
 	{
 		$local = false;
 		$app = JFactory::getApplication();
@@ -155,7 +155,7 @@ class JHelp
 	 *
 	 * @since   11.1
 	 */
-	static function createSiteList($pathToXml, $selected = null)
+	public static function createSiteList($pathToXml, $selected = null)
 	{
 		$list = array();
 		$xml = false;

--- a/libraries/joomla/language/latin_transliterate.php
+++ b/libraries/joomla/language/latin_transliterate.php
@@ -35,7 +35,7 @@ class JLanguageTransliterate
 	 *
 	 * @since   11.1
 	 */
-	static function utf8_latin_to_ascii($string, $case = 0)
+	public static function utf8_latin_to_ascii($string, $case = 0)
 	{
 		static $UTF8_LOWER_ACCENTS = null;
 		static $UTF8_UPPER_ACCENTS = null;

--- a/libraries/joomla/session/storage/apc.php
+++ b/libraries/joomla/session/storage/apc.php
@@ -125,7 +125,7 @@ class JSessionStorageApc extends JSessionStorage
 	 *
 	 * @return boolean  True on success, false otherwise.
 	 */
-	static function test()
+	public static function test()
 	{
 		return extension_loaded('apc');
 	}


### PR DESCRIPTION
This should clean up a few (8) of the code style warnings.
