### PR TITLE
Fix an issue caused by pull request #554.

### DIFF
--- a/libraries/joomla/database/table.php
+++ b/libraries/joomla/database/table.php
@@ -57,7 +57,7 @@ abstract class JTable extends JObject
 	/**
 	 * The rules associated with this record.
 	 *
-	 * @var    JRules  A JRules object.
+	 * @var    JAccessRules  A JAccessRules object.
 	 * @since  11.1
 	 */
 	protected $_rules;
@@ -360,7 +360,7 @@ abstract class JTable extends JObject
 	/**
 	 * Method to set rules for the record.
 	 *
-	 * @param   mixed  $input  A JRules object, JSON string, or array.
+	 * @param   mixed  $input  A JAccessRules object, JSON string, or array.
 	 *
 	 * @return  void
 	 *
@@ -368,20 +368,20 @@ abstract class JTable extends JObject
 	 */
 	public function setRules($input)
 	{
-		if ($input instanceof JRules)
+		if ($input instanceof JAccessRules)
 		{
 			$this->_rules = $input;
 		}
 		else
 		{
-			$this->_rules = new JRules($input);
+			$this->_rules = new JAccessRules($input);
 		}
 	}
 
 	/**
 	 * Method to get the rules for the record.
 	 *
-	 * @return  JRules object
+	 * @return  JAccessRules object
 	 *
 	 * @since   11.1
 	 */
@@ -648,7 +648,7 @@ abstract class JTable extends JObject
 		$asset->name = $name;
 		$asset->title = $title;
 
-		if ($this->_rules instanceof JRules)
+		if ($this->_rules instanceof JAccessRules)
 		{
 			$asset->rules = (string) $this->_rules;
 		}

--- a/libraries/joomla/database/table/category.php
+++ b/libraries/joomla/database/table/category.php
@@ -182,7 +182,7 @@ class JTableCategory extends JTableNested
 		// Bind the rules.
 		if (isset($array['rules']) && is_array($array['rules']))
 		{
-			$rules = new JRules($array['rules']);
+			$rules = new JAccessRules($array['rules']);
 			$this->setRules($rules);
 		}
 

--- a/libraries/joomla/database/table/content.php
+++ b/libraries/joomla/database/table/content.php
@@ -151,7 +151,7 @@ class JTableContent extends JTable
 		// Bind the rules.
 		if (isset($array['rules']) && is_array($array['rules']))
 		{
-			$rules = new JRules($array['rules']);
+			$rules = new JAccessRules($array['rules']);
 			$this->setRules($rules);
 		}
 


### PR DESCRIPTION
We removed some jimports() without renaming the class so it can be picked up by the autoloader. 
