### PR TITLE
Add ability for JDatabase::quoteName to auto split and quote dotted strings

### DIFF
--- a/libraries/joomla/database/database.php
+++ b/libraries/joomla/database/database.php
@@ -519,7 +519,7 @@ abstract class JDatabase implements JDatabaseInterface
 	 */
 	abstract public function escape($text, $extra = false);
 
-	/**q
+	/**
 	 * Method to fetch a row from the result set cursor as an array.
 	 *
 	 * @param   mixed  $cursor  The optional result set cursor from which to fetch the row.

--- a/libraries/joomla/database/database.php
+++ b/libraries/joomla/database/database.php
@@ -519,7 +519,7 @@ abstract class JDatabase implements JDatabaseInterface
 	 */
 	abstract public function escape($text, $extra = false);
 
-	/**
+	/**q
 	 * Method to fetch a row from the result set cursor as an array.
 	 *
 	 * @param   mixed  $cursor  The optional result set cursor from which to fetch the row.
@@ -1225,7 +1225,7 @@ abstract class JDatabase implements JDatabaseInterface
 	 * Method to quote and optionally escape a string to database requirements for insertion into the database.
 	 *
 	 * @param   string   $text    The string to quote.
-	 * @param   boolean  $escape  True to escape the string, false to leave it unchanged.
+	 * @param   boolean  $escape  True (default) to escape the string, false to leave it unchanged.
 	 *
 	 * @return  string  The quoted input string.
 	 *
@@ -1240,7 +1240,7 @@ abstract class JDatabase implements JDatabaseInterface
 	 * Wrap an SQL statement identifier name such as column, table or database names in quotes to prevent injection
 	 * risks and reserved word conflicts.
 	 *
-	 * @param   string  $name  The identifier name to wrap in quotes.
+	 * @param   mixed  $name  The identifier name to wrap in quotes, or an array of parts to quote with dot-notation.
 	 *
 	 * @return  string  The quote wrapped name.
 	 *
@@ -1248,24 +1248,31 @@ abstract class JDatabase implements JDatabaseInterface
 	 */
 	public function quoteName($name)
 	{
-		// Don't quote names with dot-notation.
-		if (strpos($name, '.') !== false)
+		if (is_string($name))
 		{
-			return $name;
+			$name = explode('.', $name);
 		}
-		else
+		elseif (!is_array($name))
 		{
-			$q = $this->nameQuote;
+			settype($name, 'array');
+		}
 
+		$parts = array();
+		$q = $this->nameQuote;
+
+		foreach ($name as $part)
+		{
 			if (strlen($q) == 1)
 			{
-				return $q . $name . $q;
+				$parts[] = $q . $part . $q;
 			}
 			else
 			{
-				return $q{0} . $name . $q{1};
+				$parts[] = $q{0} . $part . $q{1};
 			}
 		}
+
+		return implode('.', $parts);
 	}
 
 	/**

--- a/libraries/joomla/database/databasequery.php
+++ b/libraries/joomla/database/databasequery.php
@@ -136,7 +136,7 @@ class JDatabaseQueryElement
 abstract class JDatabaseQuery
 {
 	/**
-	 * @var    resource  The database connection resource.
+	 * @var    JDatabase  The database connection resource.
 	 * @since  11.1
 	 */
 	protected $db = null;

--- a/tests/suite/joomla/database/JDatabaseTest.php
+++ b/tests/suite/joomla/database/JDatabaseTest.php
@@ -16,7 +16,7 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 {
 	/**
 	 * @var	   JDatabase
-	 * @since  11.3
+	 * @since  11.4
 	 */
 	protected $db;
 
@@ -66,7 +66,7 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	public function testGetConnection()
 	{
@@ -92,7 +92,7 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	public function testGetCount()
 	{
@@ -109,7 +109,7 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	public function testGetDatabase()
 	{
@@ -124,7 +124,7 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	public function testGetDateFormat()
 	{
@@ -202,7 +202,7 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	public function testGetLog()
 	{
@@ -237,7 +237,7 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	public function testGetPrefix()
 	{
@@ -252,7 +252,7 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	public function testGetNullDate()
 	{
@@ -312,7 +312,7 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	public function testQuote()
 	{
@@ -334,7 +334,7 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	public function testQuoteName()
 	{

--- a/tests/suite/joomla/database/JDatabaseTest.php
+++ b/tests/suite/joomla/database/JDatabaseTest.php
@@ -5,7 +5,8 @@
  * @license		GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-require_once JPATH_PLATFORM.'/joomla/database/database.php';
+require_once JPATH_PLATFORM . '/joomla/database/database.php';
+require_once __DIR__ . '/stubs/nosqldriver.php';
 
 /**
  * Test class for JDatabase.
@@ -14,9 +15,10 @@ require_once JPATH_PLATFORM.'/joomla/database/database.php';
 class JDatabaseTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var	JDatabase
+	 * @var	   JDatabase
+	 * @since  11.3
 	 */
-	protected $object;
+	protected $db;
 
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
@@ -24,10 +26,13 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 	 */
 	protected function setUp()
 	{
-		/**
-		 * JDatabase is an abstract class
-		 * $this->object = new JDatabase;
-		 */
+		$this->db = JDatabase::getInstance(
+			array(
+				'driver' => 'nosql',
+				'database' => 'europa',
+				'prefix' => '&',
+			)
+		);
 	}
 
 	/**
@@ -57,11 +62,76 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Tests the JDatabase::getConnection method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testGetConnection()
+	{
+		ReflectionHelper::setValue($this->db, 'connection', 'foo');
+
+		$this->assertThat(
+			$this->db->getConnection(),
+			$this->equalTo('foo')
+		);
+	}
+
+	/**
 	 * @todo Implement testGetConnectors().
 	 */
-	public function testGetConnectors() {
+	public function testGetConnectors()
+	{
 		// Remove the following lines when you implement this test.
 		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	/**
+	 * Tests the JDatabase::getCount method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testGetCount()
+	{
+		ReflectionHelper::setValue($this->db, 'count', 42);
+
+		$this->assertThat(
+			$this->db->getCount(),
+			$this->equalTo(42)
+		);
+	}
+
+	/**
+	 * Tests the JDatabase::getDatabase method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testGetDatabase()
+	{
+		$this->assertThat(
+			ReflectionHelper::invoke($this->db, 'getDatabase'),
+			$this->equalTo('europa')
+		);
+	}
+
+	/**
+	 * Tests the JDatabase::getDateFormat method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testGetDateFormat()
+	{
+		$this->assertThat(
+			$this->db->getDateFormat(),
+			$this->equalTo('Y-m-d H:i:s')
+		);
 	}
 
 	/**
@@ -70,7 +140,7 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 	public function testAddQuoted()
 	{
 		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestSkipped('Deprecated method');
 	}
 
 	/**
@@ -88,7 +158,7 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 	public function testIsQuoted()
 	{
 		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestSkipped('Deprecated method');
 	}
 
 	/**
@@ -128,12 +198,20 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @todo Implement testGetLog().
+	 * Tests the JDatabase::getLog method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
 	 */
 	public function testGetLog()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		ReflectionHelper::setValue($this->db, 'log', 'foo');
+
+		$this->assertThat(
+			$this->db->getLog(),
+			$this->equalTo('foo')
+		);
 	}
 
 	/**
@@ -155,21 +233,33 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @todo Implement testGetPrefix().
+	 * Tests the JDatabase::getDateFormat method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
 	 */
 	public function testGetPrefix()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->assertThat(
+			$this->db->getPrefix(),
+			$this->equalTo('&')
+		);
 	}
 
 	/**
-	 * @todo Implement testGetNullDate().
+	 * Tests the JDatabase::getDateFormat method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
 	 */
 	public function testGetNullDate()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->assertThat(
+			$this->db->getNullDate(),
+			$this->equalTo('1BC')
+		);
 	}
 
 	/**
@@ -205,7 +295,7 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 	public function testStderr()
 	{
 		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->markTestSkipped('Deprecated method');
 	}
 
 	/**
@@ -218,12 +308,67 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @todo Implement testQuote().
+	 * Tests the JDatabase::quote method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
 	 */
 	public function testQuote()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete('This test has not been implemented yet.');
+		$this->assertThat(
+			$this->db->quote('test', false),
+			$this->equalTo("'test'"),
+			'Tests the without escaping.'
+		);
+
+		$this->assertThat(
+			$this->db->quote('test'),
+			$this->equalTo("'-test-'"),
+			'Tests the with escaping (default).'
+		);
+	}
+
+	/**
+	 * Tests the JDatabase::quoteName method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testQuoteName()
+	{
+		$this->assertThat(
+			$this->db->quoteName('test'),
+			$this->equalTo('[test]'),
+			'Tests the left-right quotes on a string.'
+		);
+
+		$this->assertThat(
+			$this->db->quoteName('a.test'),
+			$this->equalTo('[a].[test]'),
+			'Tests the left-right quotes on a dotted string.'
+		);
+
+		$this->assertThat(
+			$this->db->quoteName(array('a', 'test')),
+			$this->equalTo('[a].[test]'),
+			'Tests the left-right quotes on an array.'
+		);
+
+		$this->assertThat(
+			$this->db->quoteName((object) array('a', 'test')),
+			$this->equalTo('[a].[test]'),
+			'Tests the left-right quotes on an object.'
+		);
+
+		ReflectionHelper::setValue($this->db, 'nameQuote', '/');
+
+		$this->assertThat(
+			$this->db->quoteName('test'),
+			$this->equalTo('/test/'),
+			'Tests the uni-quotes on a string.'
+		);
 	}
 
 	/**

--- a/tests/suite/joomla/database/stubs/nosqldriver.php
+++ b/tests/suite/joomla/database/stubs/nosqldriver.php
@@ -12,7 +12,7 @@
  *
  * @package     Joomla.UnitTest
  * @subpackage  Database
- * @since       11.3
+ * @since       11.4
  */
 class JDatabaseNosql extends JDatabase
 {
@@ -20,7 +20,7 @@ class JDatabaseNosql extends JDatabase
 	 * The name of the database driver.
 	 *
 	 * @var    string
-	 * @since  11.3
+	 * @since  11.4
 	 */
 	public $name = 'nosql';
 
@@ -31,7 +31,7 @@ class JDatabaseNosql extends JDatabase
 	 * used for the opening quote and the second for the closing quote.
 	 *
 	 * @var    string
-	 * @since  11.3
+	 * @since  11.4
 	 */
 	protected $nameQuote = '[]';
 
@@ -40,7 +40,7 @@ class JDatabaseNosql extends JDatabase
 	 * defined in child classes to hold the appropriate value for the engine.
 	 *
 	 * @var    string
-	 * @since  11.3
+	 * @since  11.4
 	 */
 	protected $nullDate = '1BC';
 
@@ -49,7 +49,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  boolean  True if connected to the database engine.
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	public function connected()
 	{
@@ -80,7 +80,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  string   The escaped string.
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	public function escape($text, $extra = false)
 	{
@@ -93,7 +93,7 @@ class JDatabaseNosql extends JDatabase
 	 * @return  string  The explain output.
 	 *
 	 * @deprecated  12.1
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	public function explain()
 	{
@@ -107,7 +107,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  mixed  Either the next row from the result set or false if there are no more rows.
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	protected function fetchArray($cursor = null)
 	{
@@ -121,7 +121,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  mixed  Either the next row from the result set or false if there are no more rows.
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	protected function fetchAssoc($cursor = null)
 	{
@@ -136,7 +136,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  mixed   Either the next row from the result set or false if there are no more rows.
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	protected function fetchObject($cursor = null, $class = 'stdClass')
 	{
@@ -150,7 +150,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  void
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	protected function freeResult($cursor = null)
 	{
@@ -162,7 +162,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  integer  The number of affected rows.
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	public function getAffectedRows()
 	{
@@ -174,7 +174,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  mixed  The collation in use by the database or boolean false if not supported.
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	public function getCollation()
 	{
@@ -188,7 +188,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  integer   The number of returned rows.
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	public function getNumRows($cursor = null)
 	{
@@ -202,7 +202,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  JDatabaseQuery  The current query object or a new object extending the JDatabaseQuery class.
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 * @throws  JDatabaseException
 	 */
 	public function getQuery($new = false)
@@ -218,7 +218,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  array  An array of fields by table.
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 * @throws  JDatabaseException
 	 */
 	public function getTableColumns($table, $typeOnly = true)
@@ -233,7 +233,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  array  A list of the create SQL for the tables.
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 * @throws  JDatabaseException
 	 */
 	public function getTableCreate($tables)
@@ -248,7 +248,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  array  An array of keys for the table(s).
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 * @throws  JDatabaseException
 	 */
 	public function getTableKeys($tables)
@@ -261,7 +261,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  array  An array of all the tables in the database.
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 * @throws  JDatabaseException
 	 */
 	public function getTableList()
@@ -274,7 +274,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  string  The database connector version.
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	public function getVersion()
 	{
@@ -286,7 +286,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  boolean  True if supported.
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 *
 	 * @deprecated  12.1
 	 */
@@ -300,7 +300,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  integer  The value of the auto-increment field from the last inserted row.
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	public function insertid()
 	{
@@ -327,7 +327,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  mixed  A database cursor resource on success, boolean false on failure.
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 * @throws  JDatabaseException
 	 */
 	public function query()
@@ -344,7 +344,7 @@ class JDatabaseNosql extends JDatabase
 	 * @return  mixed  A database resource if successful, false if not.
 	 *
 	 * @deprecated  12.1
-	 * @since   11.3
+	 * @since   11.4
 	 */
 	public function queryBatch($abortOnError = true, $transactionSafe = false)
 	{
@@ -376,7 +376,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  boolean  True if the database was successfully selected.
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 * @throws  JDatabaseException
 	 */
 	public function select($database)
@@ -389,7 +389,7 @@ class JDatabaseNosql extends JDatabase
 	*
 	* @return  boolean  True on success.
 	*
-	* @since   11.3
+	* @since   11.4
 	*/
 	public function setUTF()
 	{
@@ -413,7 +413,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  void
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 * @throws  JDatabaseException
 	 */
 	public function transactionCommit()
@@ -425,7 +425,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  void
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 * @throws  JDatabaseException
 	 */
 	public function transactionRollback()
@@ -437,7 +437,7 @@ class JDatabaseNosql extends JDatabase
 	 *
 	 * @return  void
 	 *
-	 * @since   11.3
+	 * @since   11.4
 	 * @throws  JDatabaseException
 	 */
 	public function transactionStart()

--- a/tests/suite/joomla/database/stubs/nosqldriver.php
+++ b/tests/suite/joomla/database/stubs/nosqldriver.php
@@ -1,0 +1,459 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Database
+ *
+ * @copyright	Copyright (C) 2005 - 2011 Open Source Matters. All rights reserved.
+ * @license		GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+/**
+ * Test class JDatabase.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Database
+ * @since       11.3
+ */
+class JDatabaseNosql extends JDatabase
+{
+	/**
+	 * The name of the database driver.
+	 *
+	 * @var    string
+	 * @since  11.3
+	 */
+	public $name = 'nosql';
+
+	/**
+	 * The character(s) used to quote SQL statement names such as table names or field names,
+	 * etc. The child classes should define this as necessary.  If a single character string the
+	 * same character is used for both sides of the quoted name, else the first character will be
+	 * used for the opening quote and the second for the closing quote.
+	 *
+	 * @var    string
+	 * @since  11.3
+	 */
+	protected $nameQuote = '[]';
+
+	/**
+	 * The null or zero representation of a timestamp for the database driver.  This should be
+	 * defined in child classes to hold the appropriate value for the engine.
+	 *
+	 * @var    string
+	 * @since  11.3
+	 */
+	protected $nullDate = '1BC';
+
+	/**
+	 * Determines if the connection to the server is active.
+	 *
+	 * @return  boolean  True if connected to the database engine.
+	 *
+	 * @since   11.3
+	 */
+	public function connected()
+	{
+		return true;
+	}
+
+	/**
+	 * Drops a table from the database.
+	 *
+	 * @param   string   $table     The name of the database table to drop.
+	 * @param   boolean  $ifExists  Optionally specify that the table must exist before it is dropped.
+	 *
+	 * @return  JDatabase  Returns this object to support chaining.
+	 *
+	 * @since   11.4
+	 * @throws  JDatabaseException
+	 */
+	public function dropTable($table, $ifExists = true)
+	{
+		return $this;
+	}
+
+	/**
+	 * Method to escape a string for usage in an SQL statement.
+	 *
+	 * @param   string   $text   The string to be escaped.
+	 * @param   boolean  $extra  Optional parameter to provide extra escaping.
+	 *
+	 * @return  string   The escaped string.
+	 *
+	 * @since   11.3
+	 */
+	public function escape($text, $extra = false)
+	{
+		return $extra ? "/$text//" : "-$text-";
+	}
+
+	/**
+	 * Diagnostic method to return explain information for a query.
+	 *
+	 * @return  string  The explain output.
+	 *
+	 * @deprecated  12.1
+	 * @since   11.3
+	 */
+	public function explain()
+	{
+		return 'Not possible.';
+	}
+
+	/**
+	 * Method to fetch a row from the result set cursor as an array.
+	 *
+	 * @param   mixed  $cursor  The optional result set cursor from which to fetch the row.
+	 *
+	 * @return  mixed  Either the next row from the result set or false if there are no more rows.
+	 *
+	 * @since   11.3
+	 */
+	protected function fetchArray($cursor = null)
+	{
+		return array();
+	}
+
+	/**
+	 * Method to fetch a row from the result set cursor as an associative array.
+	 *
+	 * @param   mixed  $cursor  The optional result set cursor from which to fetch the row.
+	 *
+	 * @return  mixed  Either the next row from the result set or false if there are no more rows.
+	 *
+	 * @since   11.3
+	 */
+	protected function fetchAssoc($cursor = null)
+	{
+		return array();
+	}
+
+	/**
+	 * Method to fetch a row from the result set cursor as an object.
+	 *
+	 * @param   mixed   $cursor  The optional result set cursor from which to fetch the row.
+	 * @param   string  $class   The class name to use for the returned row object.
+	 *
+	 * @return  mixed   Either the next row from the result set or false if there are no more rows.
+	 *
+	 * @since   11.3
+	 */
+	protected function fetchObject($cursor = null, $class = 'stdClass')
+	{
+		return new $class;
+	}
+
+	/**
+	 * Method to free up the memory used for the result set.
+	 *
+	 * @param   mixed  $cursor  The optional result set cursor from which to fetch the row.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	protected function freeResult($cursor = null)
+	{
+		return null;
+	}
+
+	/**
+	 * Get the number of affected rows for the previous executed SQL statement.
+	 *
+	 * @return  integer  The number of affected rows.
+	 *
+	 * @since   11.3
+	 */
+	public function getAffectedRows()
+	{
+		return 0;
+	}
+
+	/**
+	 * Method to get the database collation in use by sampling a text field of a table in the database.
+	 *
+	 * @return  mixed  The collation in use by the database or boolean false if not supported.
+	 *
+	 * @since   11.3
+	 */
+	public function getCollation()
+	{
+		return false;
+	}
+
+	/**
+	 * Get the number of returned rows for the previous executed SQL statement.
+	 *
+	 * @param   resource  $cursor  An optional database cursor resource to extract the row count from.
+	 *
+	 * @return  integer   The number of returned rows.
+	 *
+	 * @since   11.3
+	 */
+	public function getNumRows($cursor = null)
+	{
+		return 0;
+	}
+
+	/**
+	 * Get the current query object or a new JDatabaseQuery object.
+	 *
+	 * @param   boolean  $new  False to return the current query object, True to return a new JDatabaseQuery object.
+	 *
+	 * @return  JDatabaseQuery  The current query object or a new object extending the JDatabaseQuery class.
+	 *
+	 * @since   11.3
+	 * @throws  JDatabaseException
+	 */
+	public function getQuery($new = false)
+	{
+		return null;
+	}
+
+	/**
+	 * Retrieves field information about the given tables.
+	 *
+	 * @param   string   $table     The name of the database table.
+	 * @param   boolean  $typeOnly  True (default) to only return field types.
+	 *
+	 * @return  array  An array of fields by table.
+	 *
+	 * @since   11.3
+	 * @throws  JDatabaseException
+	 */
+	public function getTableColumns($table, $typeOnly = true)
+	{
+		return array();
+	}
+
+	/**
+	 * Shows the table CREATE statement that creates the given tables.
+	 *
+	 * @param   mixed  $tables  A table name or a list of table names.
+	 *
+	 * @return  array  A list of the create SQL for the tables.
+	 *
+	 * @since   11.3
+	 * @throws  JDatabaseException
+	 */
+	public function getTableCreate($tables)
+	{
+		return '';
+	}
+
+	/**
+	 * Retrieves field information about the given tables.
+	 *
+	 * @param   mixed  $tables  A table name or a list of table names.
+	 *
+	 * @return  array  An array of keys for the table(s).
+	 *
+	 * @since   11.3
+	 * @throws  JDatabaseException
+	 */
+	public function getTableKeys($tables)
+	{
+		return array();
+	}
+
+	/**
+	 * Method to get an array of all tables in the database.
+	 *
+	 * @return  array  An array of all the tables in the database.
+	 *
+	 * @since   11.3
+	 * @throws  JDatabaseException
+	 */
+	public function getTableList()
+	{
+		return array();
+	}
+
+	/**
+	 * Get the version of the database connector
+	 *
+	 * @return  string  The database connector version.
+	 *
+	 * @since   11.3
+	 */
+	public function getVersion()
+	{
+		return null;
+	}
+
+	/**
+	 * Determines if the database engine supports UTF-8 character encoding.
+	 *
+	 * @return  boolean  True if supported.
+	 *
+	 * @since   11.3
+	 *
+	 * @deprecated  12.1
+	 */
+	public function hasUTF()
+	{
+		return false;
+	}
+
+	/**
+	 * Method to get the auto-incremented value from the last INSERT statement.
+	 *
+	 * @return  integer  The value of the auto-increment field from the last inserted row.
+	 *
+	 * @since   11.3
+	 */
+	public function insertid()
+	{
+		return 0;
+	}
+
+	/**
+	 * Locks a table in the database.
+	 *
+	 * @param   string  $tableName  The name of the table to unlock.
+	 *
+	 * @return  JDatabase  Returns this object to support chaining.
+	 *
+	 * @since   11.4
+	 * @throws  JDatabaseException
+	 */
+	public function lockTable($tableName)
+	{
+		return $this;
+	}
+
+	/**
+	 * Execute the SQL statement.
+	 *
+	 * @return  mixed  A database cursor resource on success, boolean false on failure.
+	 *
+	 * @since   11.3
+	 * @throws  JDatabaseException
+	 */
+	public function query()
+	{
+		return false;
+	}
+
+	/**
+	 * Execute a query batch.
+	 *
+	 * @param   boolean  $abortOnError     Abort on error.
+	 * @param   boolean  $transactionSafe  Transaction safe queries.
+	 *
+	 * @return  mixed  A database resource if successful, false if not.
+	 *
+	 * @deprecated  12.1
+	 * @since   11.3
+	 */
+	public function queryBatch($abortOnError = true, $transactionSafe = false)
+	{
+		return false;
+	}
+
+	/**
+	 * Renames a table in the database.
+	 *
+	 * @param   string  $oldTable  The name of the table to be renamed
+	 * @param   string  $newTable  The new name for the table.
+	 * @param   string  $backup    Table prefix
+	 * @param   string  $prefix    For the table - used to rename constraints in non-mysql databases
+	 *
+	 * @return  JDatabase  Returns this object to support chaining.
+	 *
+	 * @since   11.4
+	 * @throws  JDatabaseException
+	 */
+	public function renameTable($oldTable, $newTable, $backup = null, $prefix = null)
+	{
+		return $this;
+	}
+
+	/**
+	 * Select a database for use.
+	 *
+	 * @param   string  $database  The name of the database to select for use.
+	 *
+	 * @return  boolean  True if the database was successfully selected.
+	 *
+	 * @since   11.3
+	 * @throws  JDatabaseException
+	 */
+	public function select($database)
+	{
+		return false;
+	}
+
+	/**
+	* Set the connection to use UTF-8 character encoding.
+	*
+	* @return  boolean  True on success.
+	*
+	* @since   11.3
+	*/
+	public function setUTF()
+	{
+		return false;
+	}
+
+	/**
+	 * Test to see if the connector is available.
+	 *
+	 * @return  boolean  True on success, false otherwise.
+	 *
+	 * @since   11.2
+	 */
+	public static function test()
+	{
+		return true;
+	}
+
+	/**
+	 * Method to commit a transaction.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 * @throws  JDatabaseException
+	 */
+	public function transactionCommit()
+	{
+	}
+
+	/**
+	 * Method to roll back a transaction.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 * @throws  JDatabaseException
+	 */
+	public function transactionRollback()
+	{
+	}
+
+	/**
+	 * Method to initialize a transaction.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 * @throws  JDatabaseException
+	 */
+	public function transactionStart()
+	{
+	}
+
+	/**
+	 * Unlocks tables in the database.
+	 *
+	 * @return  JDatabase  Returns this object to support chaining.
+	 *
+	 * @since   11.4
+	 * @throws  JDatabaseException
+	 */
+	public function unlockTables()
+	{
+		return $this;
+	}
+}


### PR DESCRIPTION
Allows for the quoteName method to auto split and quote each part of a dotted string.  For example:

```
$db->quoteName('a.foo');
```

Will return `'a'.'foo'`.

Adds tests for quoteName and improves code coverage of JDatabase.
