### PR TITLE
Fix some PHPMD warnings.

### DIFF
--- a/libraries/joomla/document/feed/feed.php
+++ b/libraries/joomla/document/feed/feed.php
@@ -188,6 +188,7 @@ class JDocumentFeed extends JDocument
 	 * @return  The rendered data
 	 *
 	 * @since  11.1
+	 * @todo   Make this cacheable
 	 */
 	public function render($cache = false, $params = array())
 	{
@@ -195,13 +196,6 @@ class JDocumentFeed extends JDocument
 
 		// Get the feed type
 		$type = JRequest::getCmd('type', 'rss');
-
-		/*
-		 * Cache TODO In later release
-		 */
-		$cache = 0;
-		$cache_time = 3600;
-		$cache_path = JPATH_CACHE;
 
 		// set filename for rss feeds
 		$file = strtolower(str_replace('.', '', $type));

--- a/libraries/joomla/filesystem/archive/tar.php
+++ b/libraries/joomla/filesystem/archive/tar.php
@@ -68,7 +68,7 @@ class JArchiveTar extends JObject
 	 *
 	 * @since   11.1
 	 */
-	public function extract($archive, $destination, $options = array ())
+	public function extract($archive, $destination, $options = array())
 	{
 		// Initialise variables.
 		$this->_data = null;

--- a/libraries/joomla/filesystem/archive/zip.php
+++ b/libraries/joomla/filesystem/archive/zip.php
@@ -197,7 +197,7 @@ class JArchiveZip extends JObject
 	 *
 	 * @since   11.1
 	 */
-	protected function _extract($archive, $destination, $options)
+	private function _extract($archive, $destination, $options)
 	{
 		// Initialise variables.
 		$this->_data = null;
@@ -217,7 +217,7 @@ class JArchiveZip extends JObject
 			return false;
 		}
 
-		if (!$this->_getZipInfo($this->_data))
+		if (!$this->_readZipInfo($this->_data))
 		{
 			$this->set('error.message', JText::_('JLIB_FILESYSTEM_ZIP_INFO_FAILED'));
 
@@ -264,7 +264,7 @@ class JArchiveZip extends JObject
 	 *
 	 * @since   11.1
 	 */
-	protected function _extractNative($archive, $destination, $options)
+	private function _extractNative($archive, $destination, $options)
 	{
 		if ($zip = zip_open($archive))
 		{
@@ -337,7 +337,7 @@ class JArchiveZip extends JObject
 	 *
 	 * @since   11.1
 	 */
-	protected function _getZipInfo(&$data)
+	private function _readZipInfo(&$data)
 	{
 		// Initialise variables.
 		$entries = array();
@@ -448,7 +448,7 @@ class JArchiveZip extends JObject
 	 *
 	 * @since   11.1
 	 */
-	protected function _getFileData($key)
+	private function _getFileData($key)
 	{
 		if ($this->_metadata[$key]['_method'] == 0x8)
 		{
@@ -495,7 +495,7 @@ class JArchiveZip extends JObject
 	 *
 	 * @since   11.1
 	 */
-	protected function _unix2DOSTime($unixtime = null)
+	private function _unix2DOSTime($unixtime = null)
 	{
 		$timearray = (is_null($unixtime)) ? getdate() : getdate($unixtime);
 
@@ -526,7 +526,7 @@ class JArchiveZip extends JObject
 	 *
 	 * @todo    Review and finish implementation
 	 */
-	protected function _addToZIPFile(&$file, &$contents, &$ctrldir)
+	private function _addToZIPFile(&$file, &$contents, &$ctrldir)
 	{
 		$data = &$file['data'];
 		$name = str_replace('\\', '/', $file['name']);
@@ -636,7 +636,7 @@ class JArchiveZip extends JObject
 	 *
 	 * @todo	Review and finish implementation
 	 */
-	protected function _createZIPFile(&$contents, &$ctrlDir, $path)
+	private function _createZIPFile(&$contents, &$ctrlDir, $path)
 	{
 		$data = implode('', $contents);
 		$dir = implode('', $ctrlDir);


### PR DESCRIPTION
Note there are some backward incompatible changes in JArchiveZip. Since we already made the internal variables private the impact shouldn't be high.
