### PR TITLE
get_table_constraints renamed to getTableConstraints to support backups ...

### DIFF
--- a/libraries/joomla/database/database/sqlsrv.php
+++ b/libraries/joomla/database/database/sqlsrv.php
@@ -1028,7 +1028,7 @@ class JDatabaseSQLSrv extends JDatabase
 
 		if (!is_null($prefix) && !is_null($backup))
 		{
-			$constraints = $this->get_table_constraints($oldTable);
+			$constraints = $this->getTableConstraints($oldTable);
 		}
 		if (!empty($constraints))
 		{


### PR DESCRIPTION
get_table_constraints renamed to getTableConstraints to support backups ...

Can we get this merged to joomla:staging?
Please let me know if there are discrepancies.
