### PR TITLE
Fixed the nameQuote for sqlserver and azure.

### DIFF
--- a/libraries/joomla/database/database/sqlsrv.php
+++ b/libraries/joomla/database/database/sqlsrv.php
@@ -38,7 +38,7 @@ class JDatabaseSQLSrv extends JDatabase
 	 * @var    string
 	 * @since  11.1
 	 */
-	protected $nameQuote;
+	protected $nameQuote = '[]';
 
 	/**
 	 * The null or zero representation of a timestamp for the database driver.  This should be


### PR DESCRIPTION
The fix handles reserved words in sqlserver/azure if they are used.
