### PR TITLE
Fixing undefined index 'CLIENT', probably a regression bug #136

### DIFF
--- a/libraries/joomla/updater/adapters/collection.php
+++ b/libraries/joomla/updater/adapters/collection.php
@@ -121,13 +121,13 @@ class JUpdaterCollection extends JUpdateAdapter
 					if (!array_key_exists($col, $attrs))
 					{
 						$attrs[$col] = '';
-						if ($col == 'CLIENT')
+						if ($col == 'CLIENT_ID')
 						{
 							$attrs[$col] = 'site';
 						}
 					}
 				}
-				$client = JApplicationHelper::getClientInfo($attrs['CLIENT'], 1);
+				$client = JApplicationHelper::getClientInfo($attrs['CLIENT_ID'], 1);
 				$attrs['CLIENT_ID'] = $client->id;
 				// Lower case all of the fields
 				foreach ($attrs as $key => $attr)


### PR DESCRIPTION
In the CMS, the 'collection' adapter for the updater fails. This re-implements the fix from earlier.
