### PR TITLE
Joomla CMS [#27280] Invalid foreach in com_content route* 

### DIFF
--- a/libraries/joomla/application/menu.php
+++ b/libraries/joomla/application/menu.php
@@ -259,7 +259,7 @@ class JMenu extends JObject
 	 */
 	public function getItems($attributes, $values, $firstonly = false)
 	{
-		$items = null;
+		$items = array();
 		$attributes = (array) $attributes;
 		$values = (array) $values;
 


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=27280

ContentHelperRoute::_findItem can toss an invalid foreach error (line 135)
thanks to a null result from JMenu::getItems().

This patch causes an empty array to be returned instead of null.
