### PR TITLE
Always use db instances declared by devs

### DIFF
--- a/libraries/joomla/database/table.php
+++ b/libraries/joomla/database/table.php
@@ -624,7 +624,7 @@ abstract class JTable extends JObject
 		$name = $this->_getAssetName();
 		$title = $this->_getAssetTitle();
 
-		$asset = JTable::getInstance('Asset', 'JTable', array('dbo' => $this->getDbo()) );
+		$asset = JTable::getInstance('Asset', 'JTable', array('dbo' => $this->getDbo()));
 		$asset->loadByName($name);
 
 		// Re-inject the asset id.

--- a/libraries/joomla/database/table.php
+++ b/libraries/joomla/database/table.php
@@ -624,7 +624,7 @@ abstract class JTable extends JObject
 		$name = $this->_getAssetName();
 		$title = $this->_getAssetTitle();
 
-		$asset = JTable::getInstance('Asset', 'JTable', array('dbo' => $this->getDbo() );
+		$asset = JTable::getInstance('Asset', 'JTable', array('dbo' => $this->getDbo()) );
 		$asset->loadByName($name);
 
 		// Re-inject the asset id.

--- a/libraries/joomla/database/table.php
+++ b/libraries/joomla/database/table.php
@@ -624,7 +624,7 @@ abstract class JTable extends JObject
 		$name = $this->_getAssetName();
 		$title = $this->_getAssetTitle();
 
-		$asset = JTable::getInstance('Asset');
+		$asset = JTable::getInstance('Asset', 'JTable', array('dbo' => $this->getDbo() );
 		$asset->loadByName($name);
 
 		// Re-inject the asset id.

--- a/libraries/joomla/database/table/category.php
+++ b/libraries/joomla/database/table/category.php
@@ -216,7 +216,7 @@ class JTableCategory extends JTableNested
 			$this->created_user_id = $user->get('id');
 		}
 		// Verify that the alias is unique
-		$table = JTable::getInstance('Category', 'JTable', array('dbo' => $this->getDbo()) );
+		$table = JTable::getInstance('Category', 'JTable', array('dbo' => $this->getDbo()));
 		if ($table->load(array('alias' => $this->alias, 'parent_id' => $this->parent_id, 'extension' => $this->extension))
 			&& ($table->id != $this->id || $this->id == 0))
 		{

--- a/libraries/joomla/database/table/category.php
+++ b/libraries/joomla/database/table/category.php
@@ -216,7 +216,7 @@ class JTableCategory extends JTableNested
 			$this->created_user_id = $user->get('id');
 		}
 		// Verify that the alias is unique
-		$table = JTable::getInstance('Category', 'JTable');
+		$table = JTable::getInstance('Category', 'JTable', array('dbo' => $this->getDbo()) );
 		if ($table->load(array('alias' => $this->alias, 'parent_id' => $this->parent_id, 'extension' => $this->extension))
 			&& ($table->id != $this->id || $this->id == 0))
 		{


### PR DESCRIPTION
If you try to create a new asset or category using a different prefix, the JTableAsset and JTableCategories returns an error because it create a new instance instead of the created by user
