### PR TITLE
Changed quoteName function.

### DIFF
--- a/libraries/joomla/database/database.php
+++ b/libraries/joomla/database/database.php
@@ -1240,28 +1240,74 @@ abstract class JDatabase implements JDatabaseInterface
 	 * Wrap an SQL statement identifier name such as column, table or database names in quotes to prevent injection
 	 * risks and reserved word conflicts.
 	 *
-	 * @param   mixed  $name  The identifier name to wrap in quotes, or an array of parts to quote with dot-notation.
+	 * @param   mixed  $name  The identifier name to wrap in quotes, or an array of identifier names to wrap in quotes.
+	 * 							Each type supports dot-notation name.
+	 * @param   mixed  $as    The AS query part associated to $name. It can be string or array, in latter case it has to be
+	 * 							same length of $name; if is null there will not be any AS part for string or array element.
 	 *
-	 * @return  string  The quote wrapped name.
+	 * @return  mixed  The quote wrapped name, same type of $name.
 	 *
 	 * @since   11.1
 	 */
-	public function quoteName($name)
+	public function quoteName($name, $as = null)
 	{
 		if (is_string($name))
 		{
-			$name = explode('.', $name);
-		}
-		elseif (!is_array($name))
-		{
-			settype($name, 'array');
-		}
+			$quotedName = $this->quoteNameStr(explode('.', $name));
 
+			$quotedAs = '';
+			if (!is_null($as))
+			{
+				settype($as, 'array');
+				$quotedAs .= ' AS ' . $this->quoteNameStr($as);
+			}
+
+			return $quotedName . $quotedAs;
+		}
+		else
+		{
+			$fin = array();
+
+			if (is_null($as))
+			{
+				foreach ($name as $str)
+				{
+					$fin[] = $this->quoteName($str);
+				}
+			}
+			elseif (is_array($name) && (count($name) == count($as)))
+			{
+				for ($i = 0; $i < count($name); $i++)
+				{
+					$fin[] = $this->quoteName($name[$i], $as[$i]);
+				}
+			}
+
+			return $fin;
+		}
+	}
+
+	/**
+	 * Quote strings coming from quoteName call.
+	 * 
+	 * @param   array  $strArr  Array of strings coming from quoteName dot-explosion.
+	 *
+	 * @return  string  Dot-imploded string of quoted parts.
+	 * 
+	 * @since 11.3
+	 */
+	protected function quoteNameStr($strArr)
+	{
 		$parts = array();
 		$q = $this->nameQuote;
 
-		foreach ($name as $part)
+		foreach ($strArr as $part)
 		{
+			if (is_null($part))
+			{
+				continue;
+			}
+
 			if (strlen($q) == 1)
 			{
 				$parts[] = $q . $part . $q;

--- a/tests/suite/joomla/database/JDatabaseTest.php
+++ b/tests/suite/joomla/database/JDatabaseTest.php
@@ -352,13 +352,31 @@ class JDatabaseTest extends PHPUnit_Framework_TestCase
 
 		$this->assertThat(
 			$this->db->quoteName(array('a', 'test')),
-			$this->equalTo('[a].[test]'),
+			$this->equalTo(array('[a]', '[test]')),
+			'Tests the left-right quotes on an array.'
+		);
+
+		$this->assertThat(
+			$this->db->quoteName(array('a.b', 'test.quote')),
+			$this->equalTo(array('[a].[b]', '[test].[quote]')),
+			'Tests the left-right quotes on an array.'
+		);
+
+		$this->assertThat(
+			$this->db->quoteName(array('a.b', 'test.quote'), array(null, 'alias')),
+			$this->equalTo(array('[a].[b]', '[test].[quote] AS [alias]')),
+			'Tests the left-right quotes on an array.'
+		);
+
+		$this->assertThat(
+			$this->db->quoteName(array('a.b', 'test.quote'), array('alias1', 'alias2')),
+			$this->equalTo(array('[a].[b] AS [alias1]', '[test].[quote] AS [alias2]')),
 			'Tests the left-right quotes on an array.'
 		);
 
 		$this->assertThat(
 			$this->db->quoteName((object) array('a', 'test')),
-			$this->equalTo('[a].[test]'),
+			$this->equalTo(array('[a]', '[test]')),
 			'Tests the left-right quotes on an object.'
 		);
 


### PR DESCRIPTION
Now quoteName can take an array of names to quote and each can have dot notation.
Added alias support "AS" as second parameter, same type of first parameter, so if first parameter is a string second need to be a string, if first parameter is an array second need to be an array.
Special mention to first parameter array: each array element will be quoted and can be aliased with second parameter array that must be same length and contain null value for those element that doesn't need alias, so for example

<pre><code>$db->quoteName( array('a', 'b'), array('alias_a', 'alias_b') );</code></pre>

using " as quote character, this call will return an array with

<pre><code>Array
(
    [0] => '"a" AS "alias_a"'
    [1] => '"b" AS "alias_b"'
)</code></pre>


<p>
while this example

<pre><code>$db->quoteName( array('a', 'b'), array(null, 'alias_b') );</code></pre>

using " as quote character, this call will return an array with

<pre><code>Array
(
    [0] => '"a"'
    [1] => '"b" AS "alias_b"'
)</code></pre>

<p>
More complex example

<pre><code>$db->quoteName( array('a.c', 'b.d'), array(null, 'alias_b_d') );</code></pre>

will return an array with

<pre><code>Array
(
    [0] => '"a"."c"'
    [1] => '"b"."d" AS "alias_b_d"'
)</code></pre>


<p>
This pull request contain also changes to relative quoteName test to try array quote and alias parameter.
