### PR TITLE
Make JTable::load() work with JError::$legacy set to false.

### DIFF
--- a/libraries/joomla/database/table.php
+++ b/libraries/joomla/database/table.php
@@ -524,10 +524,21 @@ abstract class JTable extends JObject
 		}
 
 		$this->_db->setQuery($query);
-		$row = $this->_db->loadAssoc();
 
-		// Check for a database error.
-		if ($this->_db->getErrorNum())
+		try
+		{
+			$row = $this->_db->loadAssoc();
+		}
+		catch (JDatabaseException $e)
+		{
+			$je = new JException($e::getMessage());
+			$this->setError($je);
+			return false;
+		}
+
+		// Legacy error handling switch based on the JError::$legacy switch.
+		// @deprecated  12.1
+		if (JError::$legacy && $this->_db->getErrorNum())
 		{
 			$e = new JException($this->_db->getErrorMsg());
 			$this->setError($e);


### PR DESCRIPTION
I need this to make the CMS installation work in the non-legacy mode. it's the last bit of deprecated code in the installation I have to deal with, so it'd be great if we could get this pulled :)
