### PR TITLE
Fix a bug in JDocument.

### DIFF
--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -405,13 +405,12 @@ class JDocument extends JObject
 	 * @param   string   $name        Value of name or http-equiv tag
 	 * @param   string   $content     Value of the content tag
 	 * @param   boolean  $http_equiv  META type "http-equiv" defaults to null
-	 * @param   boolean  $sync        Should http-equiv="content-type" by synced with HTTP-header?
 	 *
 	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
-	public function setMetaData($name, $content, $http_equiv = false, $sync = true)
+	public function setMetaData($name, $content, $http_equiv = false)
 	{
 		$name = strtolower($name);
 
@@ -428,12 +427,6 @@ class JDocument extends JObject
 			if ($http_equiv == true)
 			{
 				$this->_metaTags['http-equiv'][$name] = $content;
-
-				// Syncing with HTTP-header
-				if ($sync && strtolower($name) == 'content-type')
-				{
-					$this->setMimeEncoding($content, false);
-				}
 			}
 			else
 			{
@@ -811,7 +804,7 @@ class JDocument extends JObject
 		// Syncing with meta-data
 		if ($sync)
 		{
-			$this->setMetaData('content-type', $type, true, false);
+			$this->setMetaData('content-type', $type . '; charset=' . $this->_charset, true);
 		}
 
 		return $this;

--- a/libraries/joomla/document/html/renderer/head.php
+++ b/libraries/joomla/document/html/renderer/head.php
@@ -76,7 +76,6 @@ class JDocumentRendererHead extends JDocumentRenderer
 			{
 				if ($type == 'http-equiv')
 				{
-					$content .= '; charset=' . $document->getCharset();
 					$buffer .= $tab . '<meta http-equiv="' . $name . '" content="' . htmlspecialchars($content) . '" />' . $lnEnd;
 				}
 				elseif ($type == 'standard' && !empty($content))


### PR DESCRIPTION
Fix the bug that meta elements with the attribute http-equiv weren't set corretly. This breaks API compatability on JDocument::SetMetadata().
