### PR TITLE
Add a message queue to JApplicationWeb

### DIFF
--- a/libraries/joomla/application/application.php
+++ b/libraries/joomla/application/application.php
@@ -53,15 +53,6 @@ class JApplication extends JObject
 	protected $messageQueue = array();
 
 	/**
-	 * The application message queue.
-	 *
-	 * @var    array
-	 * @since  11.1
-	 * @deprecated use $messageQueue or declare as private
-	 */
-	protected $_messageQueue = array();
-
-	/**
 	 * The name of the application.
 	 *
 	 * @var    array
@@ -468,27 +459,19 @@ class JApplication extends JObject
 	 * @param   string  $msg   The message to enqueue.
 	 * @param   string  $type  The message type. Default is message.
 	 *
-	 * @return  void
+	 * @return  JApplication
 	 *
 	 * @since   11.1
 	 */
 	public function enqueueMessage($msg, $type = 'message')
 	{
 		// For empty queue, if messages exists in the session, enqueue them first.
-		if (!count($this->_messageQueue))
-		{
-			$session = JFactory::getSession();
-			$sessionQueue = $session->get('application.queue');
-
-			if (count($sessionQueue))
-			{
-				$this->_messageQueue = $sessionQueue;
-				$session->set('application.queue', null);
-			}
-		}
+		$this->getMessageQueue();
 
 		// Enqueue the message.
-		$this->_messageQueue[] = array('message' => $msg, 'type' => strtolower($type));
+		$this->messageQueue[] = array('message' => $msg, 'type' => strtolower($type));
+
+		return $this;
 	}
 
 	/**
@@ -501,19 +484,19 @@ class JApplication extends JObject
 	public function getMessageQueue()
 	{
 		// For empty queue, if messages exists in the session, enqueue them.
-		if (!count($this->_messageQueue))
+		if (!count($this->messageQueue))
 		{
 			$session = JFactory::getSession();
 			$sessionQueue = $session->get('application.queue');
 
 			if (count($sessionQueue))
 			{
-				$this->_messageQueue = $sessionQueue;
+				$this->messageQueue = $sessionQueue;
 				$session->set('application.queue', null);
 			}
 		}
 
-		return $this->_messageQueue;
+		return $this->messageQueue;
 	}
 
 	/**

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -96,6 +96,12 @@ class JApplicationWeb
 	protected static $instance;
 
 	/**
+	 * @var    array  System message queue.
+	 * @since  ?
+	 */
+	protected $messageQueue;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param   mixed  $input   An optional argument to provide dependency injection for the application's
@@ -1222,6 +1228,49 @@ class JApplicationWeb
 			$this->set('uri.media.full', $this->get('uri.base.full') . 'media/');
 			$this->set('uri.media.path', $this->get('uri.base.path') . 'media/');
 		}
+	}
+
+	/**
+	 * Enqueue a system message.
+	 *
+	 * @param   string  $msg   The message to enqueue.
+	 * @param   string  $type  The message type. Default is message.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.1
+	 */
+	public function enqueueMessage($msg, $type = 'message')
+	{
+		$this->getMessageQueue();
+
+		// Enqueue the message.
+		$this->messageQueue[] = array('message' => $msg, 'type' => strtolower($type));
+	}
+
+	/**
+	 * Get the system message queue.
+	 *
+	 * @return  array  The system message queue.
+	 *
+	 * @since   11.1
+	 */
+	public function getMessageQueue()
+	{
+		// For empty queue, if messages exists in the session, enqueue them.
+		if (!count($this->messageQueue))
+		{
+			$session = JFactory::getSession();
+			$sessionQueue = $session->get('application.queue');
+
+			if (count($sessionQueue))
+			{
+				$this->messageQueue = $sessionQueue;
+				$session->set('application.queue', null);
+			}
+		}
+
+		return $this->messageQueue;
 	}
 }
 


### PR DESCRIPTION
While I was playing with the new toy JApplicationWeb, I found that the system messages would be handy for this type of application.

Also removes some duplicated code from JApplication as well as the deprecated property `$_messageQueue`
