### PR TITLE
Fix: improper message is displayed on database connection error

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -720,7 +720,13 @@ abstract class JFactory
 
 		if ($db->getErrorNum() > 0)
 		{
-			JError::raiseError(500, JText::sprintf('JLIB_UTIL_ERROR_CONNECT_DATABASE', $db->getErrorNum(), $db->getErrorMsg()));
+			/*
+			* BAND AID ONLY !!
+			* @todo remove as soon as exception handling is properly implemented !
+			*/
+			die(sprintf('Database connection error (%d): %s', $db->getErrorNum(), $db->getErrorMsg()));
+
+// 			JError::raiseError(500, JText::sprintf('JLIB_UTIL_ERROR_CONNECT_DATABASE', $db->getErrorNum(), $db->getErrorMsg()));
 		}
 
 		$db->setDebug($debug);


### PR DESCRIPTION
This is an attempt to solve CMS tracker items [#26550](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=26550) and [#27574](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=27574).

**Symptom:**
If the database connection fails for "some reason" this is not properly reported.

**Results:**
26550: Infinite loop in JError
27574: jos-Error: Application Instantiation Error

Both are not really helpful.

**Possible solution:**
a) (best) Throw a JDatabaseException and handle it properly - not possible yet :(
b) (current) "Throw" a JError::raiseError(500... which is not handled properly and actually ends up as the aforementioned application instantiation error.
c) (proposed) Plain dead `die()` with an appropriate (non JText_ed_) message if the (also deprecated) $db->getErrorNum() function returns "something".

Maybe someone can provide a much cleaner solution, but in the meantime I would find it a bit #%&@¿ if the Joomla! CMS 2.5 stable would be released with this thingy still present...
