### PR TITLE
Fix grouping in JHtmlUser::groups

### DIFF
--- a/libraries/joomla/html/html/user.php
+++ b/libraries/joomla/html/html/user.php
@@ -32,7 +32,7 @@ abstract class JHtmlUser
 		$query->select('a.id AS value, a.title AS text, COUNT(DISTINCT b.id) AS level');
 		$query->from($db->quoteName('#__usergroups') . ' AS a');
 		$query->join('LEFT', $db->quoteName('#__usergroups') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
-		$query->group('a.id, a.title, a.lft, b.lft, a.rgt');
+		$query->group('a.id, a.title, a.lft, a.rgt');
 		$query->order('a.lft ASC');
 		$db->setQuery($query);
 		$options = $db->loadObjectList();


### PR DESCRIPTION
While testing joomla/joomla-cms#29, we found that the grouping for the user group selection list was broken.  As it is based on the one used in JHtmlAccess::usergroup, I compared the two and found an extra grouping field.  Removing this field fixed this selection list.
