### PR TITLE
Add INFOURL to _updatecols

### DIFF
--- a/libraries/joomla/updater/updateadapter.php
+++ b/libraries/joomla/updater/updateadapter.php
@@ -46,7 +46,7 @@ class JUpdateAdapter extends JAdapterInstance
 	 * @var    array
 	 * @since  11.1
 	 */
-	protected $_updatecols = array('NAME', 'ELEMENT', 'TYPE', 'FOLDER', 'CLIENT', 'VERSION', 'DESCRIPTION');
+	protected $_updatecols = array('NAME', 'ELEMENT', 'TYPE', 'FOLDER', 'CLIENT', 'VERSION', 'DESCRIPTION', 'INFOURL');
 
 	/**
 	 * Gets the reference to the current direct parent


### PR DESCRIPTION
Per the change with joomla/joomla-cms#65, we need to add INFOURL to the _updatecols array.
