### PR TITLE
Make Installer package class vars public

### DIFF
--- a/libraries/joomla/installer/extension.php
+++ b/libraries/joomla/installer/extension.php
@@ -24,7 +24,7 @@ class JExtension extends JObject
 	 * @var    string
 	 * @since  11.1
 	 */
-	protected $filename = '';
+	public $filename = '';
 
 	/**
 	 * Type of the extension
@@ -32,7 +32,7 @@ class JExtension extends JObject
 	 * @var    string
 	 * @since  11.1
 	 */
-	protected $type = '';
+	public $type = '';
 
 	/**
 	 * Unique Identifier for the extension
@@ -40,7 +40,7 @@ class JExtension extends JObject
 	 * @var    string
 	 * @since  11.1
 	 */
-	protected $id = '';
+	public $id = '';
 
 	/**
 	 * The status of the extension
@@ -48,7 +48,7 @@ class JExtension extends JObject
 	 * @var    boolean
 	 * @since  11.1
 	 */
-	protected $published = false;
+	public $published = false;
 
 	/**
 	 * String representation of client. Valid for modules, templates and languages.
@@ -57,7 +57,7 @@ class JExtension extends JObject
 	 * @var    string
 	 * @since  11.1
 	 */
-	protected $client = 'site';
+	public $client = 'site';
 
 	/**
 	 * The group name of the plugin. Not used for other known extension types (only plugins)
@@ -65,7 +65,7 @@ class JExtension extends JObject
 	 * @var string
 	 * @since  11.1
 	 */
-	protected $group = '';
+	public $group = '';
 
 	/**
 	 * An object representation of the manifest file stored metadata
@@ -73,7 +73,7 @@ class JExtension extends JObject
 	 * @var object
 	 * @since  11.1
 	 */
-	protected $manifest_cache = null;
+	public $manifest_cache = null;
 
 	/**
 	 * An object representation of the extension params
@@ -81,7 +81,7 @@ class JExtension extends JObject
 	 * @var    object
 	 * @since  11.1
 	 */
-	protected $params = null;
+	public $params = null;
 
 	/**
 	 * Constructor

--- a/libraries/joomla/installer/librarymanifest.php
+++ b/libraries/joomla/installer/librarymanifest.php
@@ -23,77 +23,77 @@ class JLibraryManifest extends JObject
 	/**
 	 * @var string name Name of Library
 	 */
-	protected $name = '';
+	public $name = '';
 
 	/**
 	 * @var string libraryname File system name of the library
 	 */
-	protected $libraryname = '';
+	public $libraryname = '';
 
 	/**
 	 * @var string version Version of the library
 	 */
-	protected $version = '';
+	public $version = '';
 
 	/**
 	 * @var string description Description of the library
 	 */
-	protected $description = '';
+	public $description = '';
 
 	/**
 	 * @var date creationDate Creation Date of the extension
 	 */
-	protected $creationDate = '';
+	public $creationDate = '';
 
 	/**
 	 * @var string copyright Copyright notice for the extension
 	 */
-	protected $copyright = '';
+	public $copyright = '';
 
 	/**
 	 * @var string license License for the extension
 	 */
-	protected $license = '';
+	public $license = '';
 
 	/**
 	 * @var string author Author for the extension
 	 */
-	protected $author = '';
+	public $author = '';
 
 	/**
 	 * @var string authoremail Author email for the extension
 	 */
-	protected $authoremail = '';
+	public $authoremail = '';
 
 	/**
 	 * @var string authorurl Author url for the extension
 	 */
-	protected $authorurl = '';
+	public $authorurl = '';
 
 	/**
 	 * @var string packager Name of the packager for the library (may also be porter)
 	 */
-	protected $packager = '';
+	public $packager = '';
 
 	/**
 	 * @var string packagerurl URL of the packager for the library (may also be porter)
 	 */
-	protected $packagerurl = '';
+	public $packagerurl = '';
 
 	/**
 	 * @var string update URL of the update site
 	 */
-	protected $update = '';
+	public $update = '';
 
 	/**
 	 * @var string[] filelist List of files in the library
 	 */
-	protected $filelist = array();
+	public $filelist = array();
 
 	/**
 	 * @var string manifest_file Path to manifest file
 	 */
-	protected $manifest_file = '';
+	public $manifest_file = '';
 
 	/**
 	 * Constructor

--- a/libraries/joomla/installer/packagemanifest.php
+++ b/libraries/joomla/installer/packagemanifest.php
@@ -24,57 +24,57 @@ class JPackageManifest extends JObject
 	/**
 	 * @var string name Name of the package
 	 */
-	protected $name = '';
+	public $name = '';
 
 	/**
 	 * @var string packagename Unique name of the package
 	 */
-	protected $packagename = '';
+	public $packagename = '';
 
 	/**
 	 * @var string url Website for the package
 	 */
-	protected $url = '';
+	public $url = '';
 
 	/**
 	 * @var string description Description for the package
 	 */
-	protected $description = '';
+	public $description = '';
 
 	/**
 	 * @var string packager Packager of the package
 	 */
-	protected $packager = '';
+	public $packager = '';
 
 	/**
 	 * @var string packagerurl Packager's URL of the package
 	 */
-	protected $packagerurl = '';
+	public $packagerurl = '';
 
 	/**
 	 * @var string scriptfile Scriptfile for the package
 	 */
-	protected $scriptfile = '';
+	public $scriptfile = '';
 
 	/**
 	 * @var string update Update site for the package
 	 */
-	protected $update = '';
+	public $update = '';
 
 	/**
 	 * @var string version Version of the package
 	 */
-	protected $version = '';
+	public $version = '';
 
 	/**
 	 * @var array filelist List of files in this package
 	 */
-	protected $filelist = array();
+	public $filelist = array();
 
 	/**
 	 * @var string manifest_file Path to the manifest file
 	 */
-	protected $manifest_file = '';
+	public $manifest_file = '';
 
 	/**
 	 * Constructor


### PR DESCRIPTION
Per discussion at http://groups.google.com/group/joomla-dev-platform/browse_thread/thread/e31b5078cb2816db, we need these class vars to be public otherwise PHP Fatal Errors are thrown preventing update/uninstall of Library and Package extension types.
