### PR TITLE
Some small improvements for JDocument:

### DIFF
--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -968,6 +968,6 @@ class JDocument extends JObject
 			JResponse::setHeader('Last-Modified', $mdate /* gmdate('D, d M Y H:i:s', time() + 900) . ' GMT' */);
 		}
 
-		JResponse::setHeader('Content-Type', $this->_mime . '; charset=' . $this->_charset);
+		JResponse::setHeader('Content-Type', $this->_mime . ($this->_charset ? '; charset=' . $this->_charset : ''));
 	}
 }

--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -108,7 +108,7 @@ class JDocumentHTML extends JDocument
 		$this->_type = 'html';
 
 		// Set default mime type and document metadata (meta data syncs with mime type by default)
-		$this->setMetaData('Content-Type', 'text/html', true);
+		$this->setMimeEncoding('text/html');
 	}
 
 	/**
@@ -121,16 +121,16 @@ class JDocumentHTML extends JDocument
 	public function getHeadData()
 	{
 		$data = array();
-		$data['title'] = $this->title;
+		$data['title']       = $this->title;
 		$data['description'] = $this->description;
-		$data['link'] = $this->link;
-		$data['metaTags'] = $this->_metaTags;
-		$data['links'] = $this->_links;
+		$data['link']        = $this->link;
+		$data['metaTags']    = $this->_metaTags;
+		$data['links']       = $this->_links;
 		$data['styleSheets'] = $this->_styleSheets;
-		$data['style'] = $this->_style;
-		$data['scripts'] = $this->_scripts;
-		$data['script'] = $this->_script;
-		$data['custom'] = $this->_custom;
+		$data['style']       = $this->_style;
+		$data['scripts']     = $this->_scripts;
+		$data['script']      = $this->_script;
+		$data['custom']      = $this->_custom;
 		return $data;
 	}
 
@@ -298,7 +298,6 @@ class JDocumentHTML extends JDocument
 	 *
 	 * @since   11.1
 	 */
-
 	public function addCustomTag($html)
 	{
 		$this->_custom[] = trim($html);

--- a/libraries/joomla/document/html/renderer/head.php
+++ b/libraries/joomla/document/html/renderer/head.php
@@ -76,11 +76,11 @@ class JDocumentRendererHead extends JDocumentRenderer
 				if ($type == 'http-equiv')
 				{
 					$content .= '; charset=' . $document->getCharset();
-					$buffer .= $tab . '<meta http-equiv="' . $name . '" content="' . htmlspecialchars($content) . '"' . $tagEnd . $lnEnd;
+					$buffer .= $tab . '<meta http-equiv="' . $name . '" content="' . htmlspecialchars($content) . '" />' . $lnEnd;
 				}
 				elseif ($type == 'standard' && !empty($content))
 				{
-					$buffer .= $tab . '<meta name="' . $name . '" content="' . htmlspecialchars($content) . '"' . $tagEnd . $lnEnd;
+					$buffer .= $tab . '<meta name="' . $name . '" content="' . htmlspecialchars($content) . '" />' . $lnEnd;
 				}
 			}
 		}
@@ -92,7 +92,13 @@ class JDocumentRendererHead extends JDocumentRenderer
 			$buffer .= $tab . '<meta name="description" content="' . htmlspecialchars($documentDescription) . '" />' . $lnEnd;
 		}
 
-		$buffer .= $tab . '<meta name="generator" content="' . htmlspecialchars($document->getGenerator()) . '" />' . $lnEnd;
+		// Don't add empty generators
+		$generator = $document->getGenerator();
+		if ($generator)
+		{
+			$buffer .= $tab . '<meta name="generator" content="' . htmlspecialchars($generator) . '" />' . $lnEnd;
+		}
+
 		$buffer .= $tab . '<title>' . htmlspecialchars($document->getTitle(), ENT_COMPAT, 'UTF-8') . '</title>' . $lnEnd;
 
 		// Generate link declarations


### PR DESCRIPTION
-Allow content without a charset to be output (useful for binary data)
-Allow complete removal of the meta generator element.
-Some small code style improvements

These are parts from #683.
