### PR TITLE
Fixing issue with sniffer not detecting double quoted params properly

### DIFF
--- a/build/phpcs/Joomla/Sniffs/Classes/InstantiateNewClassesSniff.php
+++ b/build/phpcs/Joomla/Sniffs/Classes/InstantiateNewClassesSniff.php
@@ -70,6 +70,7 @@ class Joomla_Sniffs_Classes_InstantiateNewClassesSniff implements PHP_CodeSniffe
                     case T_STRING :
                     case T_LNUMBER :
                     case T_CONSTANT_ENCAPSED_STRING :
+                    case T_DOUBLE_QUOTED_STRING :
                         if($started)
                         {
                             $valid = true;


### PR DESCRIPTION
The sniffer was not detecting double quoted strings properly and raising errors about classes without parameters.
