### PR TITLE
Restore the admin application check for toolbar.

### DIFF
--- a/libraries/joomla/application/component/helper.php
+++ b/libraries/joomla/application/component/helper.php
@@ -357,7 +357,7 @@ class JComponentHelper
 		$contents = self::executeComponent($path);
 
 		// Build the component toolbar
-		if ($path = JApplicationHelper::getPath('toolbar'))
+		if ($path = JApplicationHelper::getPath('toolbar') && $app->isAdmin())
 		{
 			// Get the task again, in case it has changed
 			$task = JRequest::getString('task');


### PR DESCRIPTION
This undoes a previous change (#566) which had backward compatibility issues.
