### PR TITLE
JDate breaks valid DateTime input

### DIFF
--- a/libraries/joomla/utilities/date.php
+++ b/libraries/joomla/utilities/date.php
@@ -113,9 +113,16 @@ class JDate extends DateTime
 			}
 		}
 
-		// If the date is numeric assume a unix timestamp and convert it.
+		/**
+		 *  @deprecated
+		 *  This test is obsolete, because DateTime supports timestamps
+		 *  if there is a prepended "@" char, so everyone should handle
+		 *  this issue while calling JDate and not JDate itself
+		 */
+		// If the date is numeric and have more than 8 digits
+		// assume a unix timestamp and prepend a '@' char.
 		date_default_timezone_set('UTC');
-		$date = is_numeric($date) ? date('c', $date) : $date;
+		$date = is_numeric($date) && str_len($date) > 8 ? '@'.$date : $date;
 
 		// Call the DateTime constructor.
 		parent::__construct($date, $tz);

--- a/libraries/joomla/utilities/date.php
+++ b/libraries/joomla/utilities/date.php
@@ -122,7 +122,7 @@ class JDate extends DateTime
 		// If the date is numeric and have more than 8 digits
 		// assume a unix timestamp and prepend a '@' char.
 		date_default_timezone_set('UTC');
-		$date = is_numeric($date) && str_len($date) > 8 ? '@'.$date : $date;
+		$date = is_numeric($date) && strlen($date) > 8 ? '@' . $date : $date;
 
 		// Call the DateTime constructor.
 		parent::__construct($date, $tz);


### PR DESCRIPTION
JDate assumes that every number is an unix timestamp, but according to the PHP documentation (see http://www.php.net/manual/en/datetime.formats.date.php) it is possible to use an 8 digit number as valid parameter which is not a timestamp (see ISO8601 Notations). This number consists the year, the month and the day without any separators (e.g. 20120101 for 2012/01/01). It's also valid to use only the year (four digits) as parameter.

So the first step is, that Joomla! should only handle numbers with more than 8 digits as unix timestamp.
The second step should be the removing of the whole test, because DateTime can handle unix timestamps by itself, if the programmer prepend an "@" char to the number (see http://www.php.net/manual/en/datetime.formats.compound.php "Localized Notations"). But this needs further testing, if there are any conflicts in the Joomla! environment. So this requests fixs only the "8 digit problem" and mark the test itself as deprecated.
