### PR TITLE
Adds uninstall support for related media files

### DIFF
--- a/libraries/joomla/installer/adapters/library.php
+++ b/libraries/joomla/installer/adapters/library.php
@@ -302,6 +302,7 @@ class JInstallerLibrary extends JAdapterInstance
 			}
 		}
 
+		$this->parent->removeFiles($xml->media);
 		$this->parent->removeFiles($xml->languages);
 
 		$row->delete($row->extension_id);


### PR DESCRIPTION
While un-/installing a few extension types, i noticed that media files won't be catched for the uninstall process of libraries.
