### PR TITLE
Fixing bug introduced in the fix https://github.com/joomla/joomla-platform/commit/a962ad7ed99cc46c5407377e07efa01f06e58bfa

### DIFF
--- a/libraries/joomla/application/component/helper.php
+++ b/libraries/joomla/application/component/helper.php
@@ -357,7 +357,8 @@ class JComponentHelper
 		$contents = self::executeComponent($path);
 
 		// Build the component toolbar
-		if ($path = JApplicationHelper::getPath('toolbar') && $app->isAdmin())
+		$path = JApplicationHelper::getPath('toolbar');
+		if ($path && $app->isAdmin())
 		{
 			// Get the task again, in case it has changed
 			$task = JRequest::getString('task');


### PR DESCRIPTION
Fixing https://github.com/joomla/joomla-platform/commit/a962ad7ed99cc46c5407377e07efa01f06e58bfa for checking Restore the admin application check for toolbar: As there was a "hidden" unclean assignment inside the "if", the "&&" added to the "if" was not applying to the if but to $path, making it a boolean instead of the required string, and that stopped all toolbars from working in backend.
