### PR TITLE
Fix a problem with the autoloader when used with multiple SPL loaders.

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -249,6 +249,12 @@ abstract class JLoader
 	 */
 	private static function _autoload($class)
 	{
+		// Only attempt to autoload if the class does not already exist.
+		if (class_exists($class))
+		{
+			return;
+		}
+
 		// Only attempt autoloading if we are dealing with a Joomla Platform class.
 		if ($class[0] == 'J')
 		{


### PR DESCRIPTION
When multiple loaders are registered with the SPL autoloader one might expect that PHP will stop looking once a class is found.  This is not the case, it will continue to iterate through the loaders and if you don't handle the case within the loader you may end up with fatal errors if a class exists in two places.
