### PR TITLE
Small Improvement to JDispatcher

### DIFF
--- a/libraries/joomla/event/dispatcher.php
+++ b/libraries/joomla/event/dispatcher.php
@@ -98,7 +98,7 @@ class JDispatcher extends JObject
 	public function register($event, $handler)
 	{
 		// Are we dealing with a class or function type handler?
-		if (function_exists($handler))
+		if (is_callable($handler))
 		{
 			// Ok, function type event handler... let's attach it.
 			$method = array('event' => $event, 'handler' => $handler);

--- a/libraries/joomla/event/dispatcher.php
+++ b/libraries/joomla/event/dispatcher.php
@@ -97,7 +97,7 @@ class JDispatcher extends JObject
 	 */
 	public function register($event, $handler)
 	{
-		// Are we dealing with a class or function type handler?
+		// Are we dealing with a class or callback type handler?
 		if (is_callable($handler))
 		{
 			// Ok, function type event handler... let's attach it.


### PR DESCRIPTION
Changed JDispatcher::register() to use is_callable() instead of function_exists() to support more flexible callbacks.
