### PR TITLE
Fix for JLoggerFormattedText information disclosure

### DIFF
--- a/libraries/joomla/log/loggers/formattedtext.php
+++ b/libraries/joomla/log/loggers/formattedtext.php
@@ -203,6 +203,8 @@ class JLoggerFormattedText extends JLogger
 		// If the no php flag is not set add the php die statement.
 		if (empty($this->options['text_file_no_php']))
 		{
+			// blank line to prevent information disclose: https://bugs.php.net/bug.php?id=60677
+			$head[] = '#';
 			$head[] = '#<?php die(\'Forbidden.\'); ?>';
 		}
 		$head[] = '#Date: ' . gmdate('Y-m-d H:i:s') . ' UTC';


### PR DESCRIPTION
This pull request resolves an issue in JLoggerFormattedText where due to a PHP bug, the contents of a log file could be viewed inadvertently. This pull request introduces a work around for the PHP bug which restores the proper behaviour.

Discussion on Joomla! Bug Squad mailing list:
http://groups.google.com/group/joomlabugsquad/browse_thread/thread/61d2a0979c55b418/908f7fcaee6a723d

PHP bug:
https://bugs.php.net/bug.php?id=60677

Likely impacted PHP versions:
- PHP 5.2
- PHP 5.3

Impacted Joomla! versions:
- CMS 1.5, 1.6, 1.7 and 2.5 Betas
- All Platform releases
