### PR TITLE
Fix category field to correctly manage edit.state permissions in combina...

### DIFF
--- a/libraries/joomla/form/fields/category.php
+++ b/libraries/joomla/form/fields/category.php
@@ -45,6 +45,7 @@ class JFormFieldCategory extends JFormFieldList
 		$options = array();
 		$extension = $this->element['extension'] ? (string) $this->element['extension'] : (string) $this->element['scope'];
 		$published = (string) $this->element['published'];
+		$name = (string) $this->element['name'];
 
 		// Load the category options for a given extension.
 		if (!empty($extension))
@@ -67,17 +68,45 @@ class JFormFieldCategory extends JFormFieldList
 				// Get the current user object.
 				$user = JFactory::getUser();
 
-				foreach ($options as $i => $option)
+				// For new items we want a list of categories you are allowed to create in.
+				if (!$this->value[$name])
 				{
-					// To take save or create in a category you need to have create rights for that category
-					// unless the item is already in that category.
-					// Unset the option if the user isn't authorised for it. In this field assets are always categories.
-					if ($user->authorise('core.create', $extension . '.category.' . $option->value) != true)
+					foreach ($options as $i => $option)
 					{
-						unset($options[$i]);
+						// To take save or create in a category you need to have create rights for that category
+						// unless the item is already in that category.
+						// Unset the option if the user isn't authorised for it. In this field assets are always categories.
+						if ($user->authorise('core.create', $extension . '.category.' . $option->value) != true )
+						{
+							unset($options[$i]);
+						}
 					}
 				}
-
+				// If you have an existing category id things are more complex.
+				else
+				{
+					$categoryOld = $this->form->getValue($name);
+					foreach ($options as $i => $option)
+					{
+						// If you are only allowed to edit in this category but not edit.state, you should not get any
+						// option to change the category, but you should be able to save in that category.
+						if ($user->authorise('core.edit.state', $extension . '.category.' . $categoryOld) != true)
+						{
+							if ($option->value != $categoryOld)
+							{
+								unset($options[$i]);
+							}
+						}
+						// However, if you can edit.state you can also move this to another category for which you have
+						// create permission and you should also still be able to save in the current category.
+						elseif
+							(($user->authorise('core.create', $extension . '.category.' . $option->value) != true)
+							&& $option->value != $categoryOld)
+						{
+							unset($options[$i]);
+						}
+					}
+				}
 			}
 
 			if (isset($this->element['show_root']))

--- a/libraries/joomla/form/fields/category.php
+++ b/libraries/joomla/form/fields/category.php
@@ -69,10 +69,9 @@ class JFormFieldCategory extends JFormFieldList
 				$user = JFactory::getUser();
 
 				// For new items we want a list of categories you are allowed to create in.
-				if (!$this->value[$name])
+				if (!$this->form->getValue($name))
 				{
-					foreach ($options as $i => $option)
-					{
+					foreach ($options as $i => $option) {
 						// To take save or create in a category you need to have create rights for that category
 						// unless the item is already in that category.
 						// Unset the option if the user isn't authorised for it. In this field assets are always categories.
@@ -89,7 +88,7 @@ class JFormFieldCategory extends JFormFieldList
 					foreach ($options as $i => $option)
 					{
 						// If you are only allowed to edit in this category but not edit.state, you should not get any
-						// option to change the category, but you should be able to save in that category.
+						// option to change the category.
 						if ($user->authorise('core.edit.state', $extension . '.category.' . $categoryOld) != true)
 						{
 							if ($option->value != $categoryOld)


### PR DESCRIPTION
Fix category field to correctly manage edit.state permissions in combination with other permissions.

Currently when a user has edit for an item but not edit.state the category field returns a blank list of options. There are also situations where the user may have create in other categories but not edit.state in the category of the current item. In that case (contrary to current behavior) the option to change category should not be given but only the current category should be shown. 
