### PR TITLE
JText::plural(), dynamic plurals for arbitrary numbers

### DIFF
--- a/libraries/joomla/methods.php
+++ b/libraries/joomla/methods.php
@@ -228,6 +228,7 @@ class JText
 			// Try the key from the language plural potential suffixes
 			$found = false;
 			$suffixes = $lang->getPluralSuffixes((int) $n);
+			array_unshift($suffixes, (int) $n);
 			foreach ($suffixes as $suffix)
 			{
 				$key = $string . '_' . $suffix;

--- a/libraries/joomla/methods.php
+++ b/libraries/joomla/methods.php
@@ -228,6 +228,8 @@ class JText
 			// Try the key from the language plural potential suffixes
 			$found = false;
 			$suffixes = $lang->getPluralSuffixes((int) $n);
+			$suffixes[] = (int) $n;
+			array_unshift($suffixes, (int) $n);
 			foreach ($suffixes as $suffix)
 			{
 				$key = $string . '_' . $suffix;


### PR DESCRIPTION
This oneliner patch allows "dynamic" pluralization of language keys for specific numeric values, eliminating the need to write and assign a callback for `getPluralSuffixes`. Essentially allowing any "magic" number passed into `JText::plural()` to result in more meaningful (semantic, human) phrases if a developer or template/UI designer wishes to do so.

Sample usage, numbers (7, 14, 30) are made up to illustrate the idea:
``` # standard behaviour
 STATISTICS="Statistcs"
 STATISTICS_0="No Statistcs available"
 STATISTICS_1="Todays Statistcs"
 STATISTICS_MORE="All Time Statistcs"
 # enhanced behavior
 STATISTICS_7="Weekly Statistcs"
 STATISTICS_14="Bi-Weekly Statistcs"
 STATISTICS_30="Monthly Statistcs"

``````
In code:
```echo JText::plural('Statistics'); // "Statistics"
echo JText::plural('Statistics', 0); // "No Statistcs Statistics"
echo JText::plural('Statistics', 1); // "Current Statistics"
echo JText::plural('Statistics', 7); // "Weekly Statistics"
echo JText::plural('Statistics', 14); // "Bi-Weekly Statistics"
echo JText::plural('Statistics', 30); // "Monthly Statistics"
echo JText::plural('Statistics', 42); // "All Time Statistics"```
``````
