### PR TITLE
*PHP 5.3.8 Notice for some language packs with iconv.

### DIFF
--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -727,7 +727,7 @@ abstract class JString
 			 * across a character that cannot be represented in the target charset, it can
 			 * be approximated through one or several similarly looking characters.
 			 */
-			return iconv($from_encoding, $to_encoding . '//IGNORE//TRANSLIT', $source);
+			return iconv($from_encoding, $to_encoding . '//IGNORE', $source);
 		}
 
 		return null;

--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -708,6 +708,23 @@ abstract class JString
 	}
 
 	/**
+	 * Catch an error and throw an exception.
+	 *
+	 * @param   integer  $number   Error level
+	 * @param   string   $message  Error message
+	 *
+	 * @return  void
+	 *
+	 * @link    https://bugs.php.net/bug.php?id=48147
+	 *
+	 * @throw   ErrorException
+	 */
+	private static function _iconvErrorHandler($number, $message)
+	{
+		throw new ErrorException($message, 0, $number);
+	}
+
+	/**
 	 * Transcode a string.
 	 *
 	 * @param   string  $source         The string to transcode.
@@ -716,18 +733,34 @@ abstract class JString
 	 *
 	 * @return  mixed  The transcoded string, or null if the source was not a string.
 	 *
+	 * @link    https://bugs.php.net/bug.php?id=48147
+	 *
 	 * @since   11.1
 	 */
 	public static function transcode($source, $from_encoding, $to_encoding)
 	{
 		if (is_string($source))
 		{
-			/*
-			 * "//TRANSLIT" is appended to the $to_encoding to ensure that when iconv comes
-			 * across a character that cannot be represented in the target charset, it can
-			 * be approximated through one or several similarly looking characters.
-			 */
-			return iconv($from_encoding, $to_encoding . '//IGNORE', $source);
+			set_error_handler(array(__CLASS__, '_iconvErrorHandler'), E_NOTICE);
+			try
+			{
+				/*
+				 * "//TRANSLIT//IGNORE" is appended to the $to_encoding to ensure that when iconv comes
+				 * across a character that cannot be represented in the target charset, it can
+				 * be approximated through one or several similarly looking characters or ignored.
+				 */
+				$iconv = iconv($from_encoding, $to_encoding . '//TRANSLIT//IGNORE', $source);
+			}
+			catch (ErrorException $e)
+			{
+				/*
+				 * "//IGNORE" is appended to the $to_encoding to ensure that when iconv comes
+				 * across a character that cannot be represented in the target charset, it is ignored.
+				 */
+				$iconv = iconv($from_encoding, $to_encoding . '//IGNORE', $source);
+			}
+			restore_error_handler();
+			return $iconv;
 		}
 
 		return null;

--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -727,7 +727,7 @@ abstract class JString
 			 * across a character that cannot be represented in the target charset, it can
 			 * be approximated through one or several similarly looking characters.
 			 */
-			return @iconv($from_encoding, $to_encoding . '//TRANSLIT', $source);
+			return iconv($from_encoding, $to_encoding . '//IGNORE//TRANSLIT', $source);
 		}
 
 		return null;

--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -727,7 +727,7 @@ abstract class JString
 			 * across a character that cannot be represented in the target charset, it can
 			 * be approximated through one or several similarly looking characters.
 			 */
-			return iconv($from_encoding, $to_encoding . '//TRANSLIT', $source);
+			return @iconv($from_encoding, $to_encoding . '//TRANSLIT', $source);
 		}
 
 		return null;


### PR DESCRIPTION
Notice: iconv() [function.iconv]: Detected an illegal character in input string in D:\wamp\www\j173\libraries\joomla\utilities\string.php on line 562 (error shown on 1.7.3, same on 2.5 beta)

Looks like an issue specific to that version of PHP. Tested with Cambodian language pack. I see no other solution atm than preventing the Notice display.
