### PR TITLE
Fixed JFormFieldMedia incorrect folder processing

### DIFF
--- a/libraries/joomla/form/fields/media.php
+++ b/libraries/joomla/form/fields/media.php
@@ -98,7 +98,7 @@ class JFormFieldMedia extends JFormField
 		if ($this->value && file_exists(JPATH_ROOT . '/' . $this->value))
 		{
 			$folder = explode('/', $this->value);
-			array_shift($folder);
+			array_diff_assoc($folder, explode('/', JComponentHelper::getParams('com_media')->get('image_path', 'images')));
 			array_pop($folder);
 			$folder = implode('/', $folder);
 		}


### PR DESCRIPTION
**test instructions:**
com_media with configured 'image_path' as a 2+ level directory (ie. media/Pliki),
bug doesn't occur when image_path configured to 1 level directory (images)
(see Content > Media manager > Options > Path to images folder)

**details:**
JFormFieldMedia has a hardcoded method to compute $folder variable by stripping first directory in the image path value and a filename.
$folder variable is then passed in a query 'folder='.$folder when calling com_media component

patch will strip complete configured image_path in the $folder array

Closes #342
