### PR TITLE
Joomla CMS [#27664] SQL Server - Language column in grids displays as "Undefined" if item language set to All 

### DIFF
--- a/libraries/joomla/application/component/modellist.php
+++ b/libraries/joomla/application/component/modellist.php
@@ -133,6 +133,14 @@ class JModelList extends JModel
 			$this->setError($this->_db->getErrorMsg());
 			return false;
 		}
+		//For SQLServer - language has to be trimmed.
+		foreach($items as $item)
+		{
+			if(isset($item->language))
+			{
+				$item->language = trim($item->language);
+			}
+		}
 
 		// Add the items to the internal cache.
 		$this->cache[$store] = $items;


### PR DESCRIPTION
The patch fixes the issue raised in http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=27664
