### PR TITLE
Be positive: Allow experimental database drivers to be installed to the application

### DIFF
--- a/libraries/joomla/form/fields/databaseconnection.php
+++ b/libraries/joomla/form/fields/databaseconnection.php
@@ -36,6 +36,8 @@ class JFormFieldDatabaseConnection extends JFormFieldList
 	 *
 	 * This method produces a drop down list of available databases supported
 	 * by JDatabase drivers that are also supported by the application.
+	 * Applications may specify either a comma separated list of "supported" or "unsupported"
+	 * database drivers.
 	 *
 	 * @return  array    The field option objects.
 	 *
@@ -52,10 +54,18 @@ class JFormFieldDatabaseConnection extends JFormFieldList
 		 */
 		$unsupported = explode(',', $this->element['unsupported']);
 
+		$supported = ((string) $this->element['supported']) ? explode(',', $this->element['supported']) : array();
+
 		// This gets the connectors available in the platform and supported by the server and the application.
 		foreach (JDatabase::getConnectors() as $connector)
 		{
-			if(in_array($connector, $unsupported))
+			if (in_array($connector, $unsupported))
+			{
+				// The connector is not supported by the application
+				continue;
+			}
+
+			if (count($supported) && ! in_array($connector, $supported))
 			{
 				// The connector is not supported by the application
 				continue;

--- a/libraries/joomla/form/fields/databaseconnection.php
+++ b/libraries/joomla/form/fields/databaseconnection.php
@@ -40,38 +40,28 @@ class JFormFieldDatabaseConnection extends JFormFieldList
 	 * @return  array    The field option objects.
 	 *
 	 * @since   11.3
-	 * @see		JDatabase
+	 * @see     JDatabase
 	 */
 	protected function getOptions()
 	{
-		// Initialize variables.
-		// This gets the connectors available in the platform and supported by the server.
-		$available = JDatabase::getConnectors();
-
 		/**
-		 * This gets the list of database types supported by the application.
+		 * This gets the list of database types unsupported by the application.
 		 * This should be entered in the form definition as a comma separated list.
-		 * If no supported databases are listed, it is assumed all available databases
+		 * If no unsupported databases are listed, it is assumed all available databases
 		 * are supported.
 		 */
-		$supported = $this->element['supported'];
-		if (!empty($supported))
+		$unsupported = explode(',', $this->element['unsupported']);
+
+		// This gets the connectors available in the platform and supported by the server and the application.
+		foreach (JDatabase::getConnectors() as $connector)
 		{
-			$supported = explode(',', $supported);
-			foreach ($supported as $support)
+			if(in_array($connector, $unsupported))
 			{
-				if (in_array($support, $available))
-				{
-					$options[$support] = ucfirst($support);
-				}
+				// The connector is not supported by the application
+				continue;
 			}
-		}
-		else
-		{
-			foreach ($available as $support)
-			{
-				$options[$support] = ucfirst($support);
-			}
+
+			$options[$connector] = ucfirst($connector);
 		}
 
 		// This will come into play if an application is installed that requires
@@ -80,6 +70,7 @@ class JFormFieldDatabaseConnection extends JFormFieldList
 		{
 			$options[''] = JText::_('JNONE');
 		}
+
 		return $options;
 	}
 }

--- a/libraries/joomla/form/fields/databaseconnection.php
+++ b/libraries/joomla/form/fields/databaseconnection.php
@@ -54,6 +54,12 @@ class JFormFieldDatabaseConnection extends JFormFieldList
 		 */
 		$unsupported = explode(',', $this->element['unsupported']);
 
+		/**
+		 * This gets the list of database types supported by the application.
+		 * This should be entered in the form definition as a comma separated list.
+		 * If no supported databases are listed, it is assumed all available databases
+		 * are supported.
+		 */
 		$supported = ((string) $this->element['supported']) ? explode(',', $this->element['supported']) : array();
 
 		// This gets the connectors available in the platform and supported by the server and the application.


### PR DESCRIPTION
This will allow the installation and testing of new experimental database drivers.

With the current approach we have a list of hard coded "supported" database drivers. <del>Select lists will return this even if the driver is not supported by the server.</del>

It is also impossible to install drivers for other databases, even if they are actually "supported" by the server _and_ the application (namely PostgreSQL and SQLite)

The currently available database drivers in the platform as of version 11.4 are all supported by the CMS, so I believe there is no need to have them hard coded.

This patch will change the list from "supported to "unsupported" (currently none), so if there appears a database driver in one of the upcoming platform releases that gets merged into the CMS and is not supported by the CMS its name can be added to the list.

Experimental drivers (so far)
- PostgreSQL: https://github.com/gpongelli/joomla-cms/tree/postgresql
- SQLite: https://github.com/elkuku/joomla-cms/tree/sqlite

CMS tracker: [#27690](http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=27690)
