### PR TITLE
Fix $sef ignoring $live_site value

### DIFF
--- a/libraries/joomla/environment/uri.php
+++ b/libraries/joomla/environment/uri.php
@@ -294,7 +294,14 @@ class JURI extends JObject
 		// Get the current URL.
 		if (empty(self::$current))
 		{
-			$uri = self::getInstance();
+			$config = JFactory::getConfig();
+			$live_site = $config->get('live_site');
+			if (trim($live_site) != '') {
+				$uri = self::getInstance($live_site);
+			}
+			else {
+				$uri = self::getInstance();
+			}
 			self::$current = $uri->toString(array('scheme', 'host', 'port', 'path'));
 		}
 

--- a/libraries/joomla/methods.php
+++ b/libraries/joomla/methods.php
@@ -51,6 +51,14 @@ class JRoute
 		$uri = $router->build($url);
 		$url = $uri->toString(array('path', 'query', 'fragment'));
 
+		if (JPATH_BASE == JPATH_ADMINISTRATOR) {
+			$config = JFactory::getConfig();
+			$live_site = $config->get('live_site');
+			if (trim($live_site) != '') {
+				$url = JURI::current() . $url;
+			}
+		}
+
 		// Replace spaces.
 		$url = preg_replace('/\s/u', '%20', $url);
 


### PR DESCRIPTION
The value of $live_site is discarded when $sef is enabled.  This is
particularly problematic if the Joomla hosted server is behind a proxy server.

I've traced it down to the JURI::current().  This function is called to get the
base uri when SEF is enabled.  When the self::$current value is empty (first
time) it's defaulted with a call to self::getInstance().  This doesn't take
into account whether a $live_site has been set.

Checking for live_site in JURI::current() fixes this bug.  I'm still too new to
Joomla to know if this fixes or breaks links elsewhere in the application.
