### PR TITLE
Adding 'behavior.jquery' to Joomla Framework with deep non-conflict mode and support for concurrent jQuery versions running

### DIFF
--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -474,9 +474,9 @@ class JDocument extends JObject
 	/**
 	 * Removes a linked script from the page (useful for replacing it by e.g. a newer version)
 	 *
-	 * @param   string   $url         URL to the linked script to remove
+	 * @param   string  $url  URL to the linked script to remove
 	 *
-	 * @return  JDocument instance of $this to allow chaining
+	 * @return  JDocument  instance of $this to allow chaining
 	 *
 	 * @since   11.5
 	 */

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -449,20 +449,40 @@ class JDocument extends JObject
 	/**
 	 * Adds a linked script to the page
 	 *
-	 * @param   string   $url    URL to the linked script
-	 * @param   string   $type   Type of script. Defaults to 'text/javascript'
-	 * @param   boolean  $defer  Adds the defer attribute.
-	 * @param   boolean  $async  Adds the async attribute.
+	 * @param   string   $url         URL to the linked script
+	 * @param   string   $type        Type of script. Defaults to 'text/javascript'
+	 * @param   boolean  $defer       Adds the defer attribute.
+	 * @param   boolean  $async       Adds the async attribute.
+	 * @param   string   $preScript   Javascript code that must be just before the file inclusion [since 11.5]
+	 * @param   string   $postScript  Javascript code that must be just after the file [since 11.5]
 	 *
 	 * @return  JDocument instance of $this to allow chaining
 	 *
 	 * @since   11.1
 	 */
-	public function addScript($url, $type = "text/javascript", $defer = false, $async = false)
+	public function addScript($url, $type = "text/javascript", $defer = false, $async = false, $preScript = null, $postScript = null)
 	{
 		$this->_scripts[$url]['mime'] = $type;
 		$this->_scripts[$url]['defer'] = $defer;
 		$this->_scripts[$url]['async'] = $async;
+		$this->_scripts[$url]['preScript'] = $preScript;
+		$this->_scripts[$url]['postScript'] = $postScript;
+
+		return $this;
+	}
+
+	/**
+	 * Removes a linked script from the page (useful for replacing it by e.g. a newer version)
+	 *
+	 * @param   string   $url         URL to the linked script to remove
+	 *
+	 * @return  JDocument instance of $this to allow chaining
+	 *
+	 * @since   11.5
+	 */
+	public function removeScript($url)
+	{
+		unset($this->_scripts[$url]);
 
 		return $this;
 	}
@@ -963,7 +983,8 @@ class JDocument extends JObject
 	 */
 	public function render($cache = false, $params = array())
 	{
-		if ($mdate = $this->getModifiedDate())
+		$mdate = $this->getModifiedDate();
+		if ($mdate)
 		{
 			JResponse::setHeader('Last-Modified', $mdate /* gmdate('D, d M Y H:i:s', time() + 900) . ' GMT' */);
 		}

--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -478,7 +478,7 @@ class JDocumentHTML extends JDocument
 	 */
 	public function countMenuChildren()
 	{
-		static $children;
+		static $children = null;
 
 		if (!isset($children))
 		{
@@ -488,7 +488,8 @@ class JDocumentHTML extends JDocument
 			$active = $menu->getActive();
 			if ($active)
 			{
-				$query->getQuery(true);
+				$db		= JFactory::getDbo();
+				$query	= $db->getQuery(true);
 				$query->select('COUNT(*)');
 				$query->from('#__menu');
 				$query->where('parent_id = ' . $active->id);

--- a/libraries/joomla/document/html/renderer/head.php
+++ b/libraries/joomla/document/html/renderer/head.php
@@ -41,15 +41,16 @@ class JDocumentRendererHead extends JDocumentRenderer
 		return $buffer;
 	}
 	/**
-	 * 
-	 * 
+	 * Render a javascript statement inline.
+	 *
 	 * @param   JDocument  $document  The document for which the head will be created
 	 * @param   string     $content   The script content
 	 * @param   string     $type      The type of script (default is 'text/javascript')
 	 *
 	 * @return  string  The head hTML
 	 */
-	private function renderInlineScript( $document, $content, $type = 'text/javascript' ) {
+	private function renderInlineScript( $document, $content, $type = 'text/javascript' )
+	{
 		// Get line endings
 		$lnEnd = $document->_getLineEnd();
 		$tab = $document->_getTab();
@@ -189,14 +190,14 @@ class JDocumentRendererHead extends JDocumentRenderer
 		{
 			// Javascript that must be just before the file inclusion:
 			if (($strAttr['preScript'] && ($strAttr['preScript'] != $previousPreScript))
-			||($pendingPostScript && ($strAttr['postScript'] != $pendingPostScript)))
+				||($pendingPostScript && ($strAttr['postScript'] != $pendingPostScript)))
 			{
 				$preScript = ( $pendingPostScript ? $pendingPostScript . $lnEnd : '' ) . $strAttr['preScript'];
 				$pendingPostScript = null;
 				$buffer .= $this->renderInlineScript($document, $preScript);
 			}
 			$previousPreScript = $strAttr['preScript'];
-			
+
 			$buffer .= $tab . '<script src="' . $strSrc . '"';
 			if (!is_null($strAttr['mime']))
 			{
@@ -213,7 +214,7 @@ class JDocumentRendererHead extends JDocumentRenderer
 			$buffer .= '></script>' . $lnEnd;
 
 			// Javascript that must be just after the file:
-			if($strAttr['postScript'])
+			if ($strAttr['postScript'])
 			{
 				// delaying: $buffer .= $this->renderInlineScript($document, $strAttr['postScript']);
 				$pendingPostScript = $strAttr['postScript'];

--- a/libraries/joomla/document/html/renderer/head.php
+++ b/libraries/joomla/document/html/renderer/head.php
@@ -40,7 +40,39 @@ class JDocumentRendererHead extends JDocumentRenderer
 
 		return $buffer;
 	}
+	/**
+	 * 
+	 * 
+	 * @param   JDocument  $document  The document for which the head will be created
+	 * @param   string     $content   The script content
+	 * @param   string     $type      The type of script (default is 'text/javascript')
+	 *
+	 * @return  string  The head hTML
+	 */
+	private function renderInlineScript( $document, $content, $type = 'text/javascript' ) {
+		// Get line endings
+		$lnEnd = $document->_getLineEnd();
+		$tab = $document->_getTab();
 
+		$buffer = $tab . '<script type="' . $type . '">' . $lnEnd;
+
+		// This is for full XHTML support.
+		if ($document->_mime != 'text/html')
+		{
+			$buffer .= $tab . $tab . '<![CDATA[' . $lnEnd;
+		}
+
+		$buffer .= $content . $lnEnd;
+
+		// See above note
+		if ($document->_mime != 'text/html')
+		{
+			$buffer .= $tab . $tab . ']]>' . $lnEnd;
+		}
+		$buffer .= $tab . '</script>' . $lnEnd;
+
+		return $buffer;
+	}
 	/**
 	 * Generates the head HTML and return the results as a string
 	 *
@@ -105,7 +137,8 @@ class JDocumentRendererHead extends JDocumentRenderer
 		foreach ($document->_links as $link => $linkAtrr)
 		{
 			$buffer .= $tab . '<link href="' . $link . '" ' . $linkAtrr['relType'] . '="' . $linkAtrr['relation'] . '"';
-			if ($temp = JArrayHelper::toString($linkAtrr['attribs']))
+			$temp = JArrayHelper::toString($linkAtrr['attribs']);
+			if ($temp)
 			{
 				$buffer .= ' ' . $temp;
 			}
@@ -120,7 +153,8 @@ class JDocumentRendererHead extends JDocumentRenderer
 			{
 				$buffer .= ' media="' . $strAttr['media'] . '" ';
 			}
-			if ($temp = JArrayHelper::toString($strAttr['attribs']))
+			$temp = JArrayHelper::toString($strAttr['attribs']);
+			if ($temp)
 			{
 				$buffer .= ' ' . $temp;
 			}
@@ -149,8 +183,20 @@ class JDocumentRendererHead extends JDocumentRenderer
 		}
 
 		// Generate script file links
+		$previousPreScript	=	null;
+		$pendingPostScript	=	null;
 		foreach ($document->_scripts as $strSrc => $strAttr)
 		{
+			// Javascript that must be just before the file inclusion:
+			if (($strAttr['preScript'] && ($strAttr['preScript'] != $previousPreScript))
+			||($pendingPostScript && ($strAttr['postScript'] != $pendingPostScript)))
+			{
+				$preScript = ( $pendingPostScript ? $pendingPostScript . $lnEnd : '' ) . $strAttr['preScript'];
+				$pendingPostScript = null;
+				$buffer .= $this->renderInlineScript($document, $preScript);
+			}
+			$previousPreScript = $strAttr['preScript'];
+			
 			$buffer .= $tab . '<script src="' . $strSrc . '"';
 			if (!is_null($strAttr['mime']))
 			{
@@ -165,27 +211,23 @@ class JDocumentRendererHead extends JDocumentRenderer
 				$buffer .= ' async="async"';
 			}
 			$buffer .= '></script>' . $lnEnd;
+
+			// Javascript that must be just after the file:
+			if($strAttr['postScript'])
+			{
+				// delaying: $buffer .= $this->renderInlineScript($document, $strAttr['postScript']);
+				$pendingPostScript = $strAttr['postScript'];
+			}
+		}
+		if ($pendingPostScript)
+		{
+			$buffer .= $this->renderInlineScript($document, $pendingPostScript);
 		}
 
 		// Generate script declarations
 		foreach ($document->_script as $type => $content)
 		{
-			$buffer .= $tab . '<script type="' . $type . '">' . $lnEnd;
-
-			// This is for full XHTML support.
-			if ($document->_mime != 'text/html')
-			{
-				$buffer .= $tab . $tab . '<![CDATA[' . $lnEnd;
-			}
-
-			$buffer .= $content . $lnEnd;
-
-			// See above note
-			if ($document->_mime != 'text/html')
-			{
-				$buffer .= $tab . $tab . ']]>' . $lnEnd;
-			}
-			$buffer .= $tab . '</script>' . $lnEnd;
+			$buffer .= $this->renderInlineScript($document, $content, $type);
 		}
 
 		// Generate script language declarations.

--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -108,7 +108,8 @@ abstract class JHtml
 		if (!class_exists($className))
 		{
 			jimport('joomla.filesystem.path');
-			if ($path = JPath::find(JHtml::$includePaths, strtolower($file) . '.php'))
+			$path = JPath::find(JHtml::$includePaths, strtolower($file) . '.php');
+			if ($path)
 			{
 				require_once $path;
 
@@ -139,6 +140,43 @@ abstract class JHtml
 			JError::raiseError(500, JText::sprintf('JLIB_HTML_ERROR_NOTSUPPORTED', $className, $func));
 			return false;
 		}
+	}
+
+	/**
+	 * Checks if a JHtml::_($key) call can be made.
+	 * If the function is not registered, tries to load the corresponding class without registering the function.
+	 * 
+	 * @param   string  $key  The name of helper method to load, (prefix).(class).function
+	 *                        prefix and class are optional and can be used to load custom
+	 *                        html helpers.
+	 *
+	 * @return  boolean      True: $key function is implemented, False: is not.
+	 */
+	public static function isCallable_($key)
+	{
+		// Do same as the function _($key) above but just checking without calling nor registering nor raising errors:
+
+		list($key, $prefix, $file, $func) = self::extract($key);
+		if (array_key_exists($key, self::$registry))
+		{
+			return true;
+		}
+
+		$className = $prefix . ucfirst($file);
+
+		if (!class_exists($className))
+		{
+			jimport('joomla.filesystem.path');
+			$path = JPath::find(JHtml::$includePaths, strtolower($file) . '.php');
+			if ($path)
+			{
+				require_once $path;
+			}
+		}
+
+		$toCall = array($className, $func);
+
+		return is_callable($toCall);
 	}
 
 	/**
@@ -850,7 +888,7 @@ abstract class JHtml
 	 */
 	public static function calendar($value, $name, $id, $format = '%Y-%m-%d', $attribs = null)
 	{
-		static $done;
+		static $done = null;
 
 		if ($done === null)
 		{

--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -145,7 +145,7 @@ abstract class JHtml
 	/**
 	 * Checks if a JHtml::_($key) call can be made.
 	 * If the function is not registered, tries to load the corresponding class without registering the function.
-	 * 
+	 *
 	 * @param   string  $key  The name of helper method to load, (prefix).(class).function
 	 *                        prefix and class are optional and can be used to load custom
 	 *                        html helpers.

--- a/libraries/joomla/html/html/behavior.php
+++ b/libraries/joomla/html/html/behavior.php
@@ -88,27 +88,36 @@ abstract class JHtmlBehavior
 	 */
 	/**
 	 * Method to load jQuery frameworks and non-conflicting javascript code into the document head
-	 * Loading and use is done in "deep non-conflict mode", which allows several concurent versions of jQuery to be loaded and run simultaneously with any other javascript framework, including another conflicting jQuery instance.
-	 * It means that the window's Javascript global namespace is not used in a fixed way: neither $ nor jQuery global variables are used. Reference: http://api.jquery.com/jQuery.noConflict/
-	 * 
+	 * Loading and use is done in "deep non-conflict mode", which allows several concurent versions of jQuery to be loaded
+	 * and run simultaneously with any other javascript framework, including another conflicting jQuery instance.
+	 * It means that the window's Javascript global namespace is not used in a fixed way: neither $ nor jQuery global variables
+	 * are used. Reference: http://api.jquery.com/jQuery.noConflict/
+	 *
 	 * Calling and params:
 	 * JHTml::_('behavior.jquery', $fullVersion, $relativePathToRoot, $listofPlugins, $javascriptCodeToRunInNonConflictMode);
-	 * 
+	 *
 	 * Use: Example:
 	 * JHTml::_('behavior.jquery', '1.6.1', 'media/jquery/', null, '$("p").css("color","red")');
 	 * JHTml::_('behavior.jquery', '1.7.0', 'media/othercompon/js/', array('jquery.flot','jquery.form'));;
 	 * JHTml::_('behavior.jquery', '1.7.1', 'media/mycomponent/jquery/', array('jquery.ui-all','jquery.form'),'$("h1,h2,h3").css("color","green")');
-	 * Will load jQuery 1.6.1 with ui and form from the 1.7.1 folder media/mycomponent/jquery, and and jQuery 1.7.1 with flot and form from the 1.7.0 folder media/othercompon/jquery
+	 * Will load jQuery 1.6.1 with ui and form from the 1.7.1 folder media/mycomponent/jquery,
+	 * and jQuery 1.7.1 with flot and form from the 1.7.0 folder media/othercompon/jquery
 	 *
 	 * If debugging mode is on an uncompressed version of jQuery is included for easier debugging.
 	 * Files: 2 files are mandatory for jquery and jQuery plugins, and do follow the jQuery naming:
 	 * jQuery: jquery-1.7.1.js for uncompressed and jquery-1.7.1.min.js
 	 * jQuery plugins: "$path/$pluginname[.min].js"
 	 *
-	 * @param   string         $version        x.y.z jQuery-Version (not jQuery plugins versions, but always jQuery one) corresponding to the file to load (highest sub-version Z of same x.y release will be loaded in the end) [MANDATORY]
-	 * @param   string         $path           Path to file from root of website (no / at start but / at end) so that it can be appended to absolute files path or live site [MANDATORY ONCE AT LEAST]
-	 * @param   array|null     $jQueryPlugins  Array of filenames (without .js or .min.js extension) of jQuery plugins or other Javascript files with jQuery code (which need the jQuery and $ to be defined correctly) [optional]
-	 * @param   string|null    $jqCode         jQuery Javascript code outputed in context with jQuery and $ defined and on dom ready [optional]
+	 * @param   string       $version        x.y.z jQuery-Version (not jQuery plugins versions, but always jQuery one)
+	 *                                       corresponding to the file to load (highest sub-version Z of same x.y release
+	 *                                       will be loaded in the end) [MANDATORY]
+	 * @param   string       $path           Path to file from root of website (no / at start but / at end) so that
+	 *                                       it can be appended to absolute files path or live site [MANDATORY ONCE AT LEAST]
+	 * @param   array|null   $jQueryPlugins  Array of filenames (without .js or .min.js extension) of jQuery plugins
+	 *                                       or other Javascript files with jQuery code (which need the jQuery
+	 *                                       and $ to be defined correctly) [optional]
+	 * @param   string|null  $jqCode         jQuery Javascript code outputed in context with jQuery and $ defined
+	 *                                       and on dom ready [optional]
 	 *
 	 * @return  void
 	 *
@@ -118,7 +127,7 @@ abstract class JHtmlBehavior
 	{
 		list($x, $y, $maintenanceVersion) = explode('.', $version);
 		$majorVersion = $x . '_' . $y;
-		
+
 		// Add (or replace if $version is newer) the base jQuery plugin with newest $version as provided in $path:
 		if ($path)
 		{
@@ -145,23 +154,28 @@ abstract class JHtmlBehavior
 			. '  ' . $jqCode . $lnEnd
 			. '});';
 
-			$document->addScriptDeclaration( $js );
+			$document->addScriptDeclaration($js);
 		}
 	}
 
 	/**
 	 * Array of jQuery and jQuery plugins by major version and by plugin their path.
 	 * E.g. self::$jQueryPlugins['1.7']['jquery'] = 'media/mycomponent/js/'
-	 * E.g. array('1.5' => array( 'jquery' => 'media/mycomponent/js/' ), '1.7' =>  array( 'jquery' => 'media/anothercomponent/jquery/', 'jquery.form' => 'media/anothercomponent/jquery/' ) )
+	 * E.g. array('1.5' => array('jquery' => 'media/mycomponent/js/' )
+	 *          , '1.7' => array('jquery' => 'media/anothercomponent/jquery/'
+	 *                         , 'jquery.form' => 'media/anothercomponent/jquery/')
+	 *            )
 	 * @var array
 	 */
 	protected static $jQueryPlugins				=	array();
+
 	/**
 	 * Array of subversions to vote for highest maintenance version within a main jquery version
 	 * E.g. self::$jQueryPluginsVersion['1.7']['jquery'] = '1.7.1'
 	 * @var array
 	 */
 	protected static $jQueryPluginsVersion		=	array();
+
 	/**
 	 * Array of paths added for each jQuery major version, that way, if a more recent maintenance version gets announced, these files can be reverted.
 	 * E.g. self::$jQueryPluginsPathsAdded = array( 'media/mycomponent/js/jquery-1.7.1.min.js'
@@ -171,12 +185,13 @@ abstract class JHtmlBehavior
 
 	/**
 	 * Internal function adding a plugin to the list of plugins to load
-	 * 
-	 * @param   string  $plugin               Name of the jQuery plugin ('jquery' for main one)
-	 * @param   string  $majorVersion         Major Version of the file to load (formatted '1_7' instead of '1.7')
-	 * @param   string  $maintenanceVersion   Maintenance Version of the file to load (number)
-	 * @param   string  $path                 Path to file from root of website (including leading / ) so that it can be appended to absolute files path or live site
-	 * 
+	 *
+	 * @param   string  $plugin              Name of the jQuery plugin ('jquery' for main one)
+	 * @param   string  $majorVersion        Major Version of the file to load (formatted '1_7' instead of '1.7')
+	 * @param   string  $maintenanceVersion  Maintenance Version of the file to load (number)
+	 * @param   string  $path                Path to file from root of website (including leading / )
+	 *                                       so that it can be appended to absolute files path or live site
+	 *
 	 * @return  void
 	 */
 	protected static function addPlugin($plugin, $majorVersion, $maintenanceVersion, $path)
@@ -202,11 +217,12 @@ abstract class JHtmlBehavior
 	}
 
 	/**
-	 * Internal function returning the global Javascript variable name for that jquery instance corresponding to the major version
+	 * Internal function returning the global Javascript variable name for that jquery instance
+	 * corresponding to the major version.
 	 * Global variable name is of the form Joomla_jQuery_1_7 but can change in future.
-	 * 
-	 * @param   string  $majorVersion
-	 * 
+	 *
+	 * @param   string  $majorVersion  The version number.
+	 *
 	 * @return  string
 	 */
 	protected static function jqueryGlobalVarName($majorVersion)
@@ -216,10 +232,10 @@ abstract class JHtmlBehavior
 
 	/**
 	 * Internal function adding the scripts code to header in a deeply non-conflcting mode
-	 * 
+	 *
 	 * @param   string      $majorVersion  E.g. '1_7'
 	 * @param   array|null  $paths         Paths to add, Null means reload all paths for that major version
-	 * 
+	 *
 	 * @return  void
 	 */
 	protected static function jqAddPaths($majorVersion, $paths = null)
@@ -240,13 +256,17 @@ abstract class JHtmlBehavior
 		$jsVarName = self::jqueryGlobalVarName($majorVersion);
 
 		// Now adds the $paths asked:
-		foreach ( $paths as $plugin => $pluginPath) {
+		foreach ( $paths as $plugin => $pluginPath)
+		{
 			if ($plugin == 'jquery')
 			{
 				// Special case for jQuery itself: build the standard jQuery name 'jquery-1.7.1.min.js' or 'jquery-1.7.1.js':
-				$file = self::$jQueryPlugins[$majorVersion]['jquery'] . 'jquery-' . str_replace( '_', '.', $majorVersion ) . '.' . self::$jQueryPluginsVersion[$majorVersion]['jquery'] . $fileExtension;
+				$file = self::$jQueryPlugins[$majorVersion]['jquery']
+					. 'jquery-' . str_replace('_', '.', $majorVersion)
+					. '.' . self::$jQueryPluginsVersion[$majorVersion]['jquery'] . $fileExtension;
 
-				// Adds code immediately after the script file for deep noConflict mode: means neither $ nor jQuery global variables are used: http://api.jquery.com/jQuery.noConflict/
+				// Adds code immediately after the script file for deep noConflict mode:
+				// means neither $ nor jQuery global variables are used: http://api.jquery.com/jQuery.noConflict/
 				$preScript = null;
 				$postScript = 'var ' . $jsVarName . ' = jQuery.noConflict(true);';
 			}
@@ -255,7 +275,8 @@ abstract class JHtmlBehavior
 				// Case of jQuery plugins or other Javascript files with jQuery code
 				$file = $pluginPath . $plugin . $fileExtension;
 
-				// These need the jQuery and $ to be defined correctly): Thus defined them before inserting the script file:
+				// These need the jQuery and $ to be defined correctly):
+				// Thus defined them before inserting the script file:
 				$preScript	= 'window.Joomla_tmp_save_jquery = window.jQuery;'
 							. 'window.Joomla_tmp_save_$ = window.$;'
 							. 'window.jQuery = window.$ = ' . $jsVarName;
@@ -265,7 +286,8 @@ abstract class JHtmlBehavior
 							. 'window.$ = window.Joomla_tmp_save_$;';
 			}
 
-			// Compute relative filename using JHtml script helper, but do not add to header as we need the $preScript and $postScript codes:
+			// Compute relative filename using JHtml script helper, but do not add to header
+			// as we need the $preScript and $postScript codes:
 			$include = JHtml::_('script', $file, false, false, true, false, false);
 			if ($include)
 			{
@@ -274,7 +296,7 @@ abstract class JHtmlBehavior
 
 				// Adds to document jQuery in noConflict mode:
 				$document->addScript($include, 'text/javascript', false, false, $preScript, $postScript);
-	
+
 				// Remember the path added so that it can be removed when replaced by a newer maintenance version:
 				self::$jQueryPluginsPathsAdded[$majorVersion][] = $include;
 			}
@@ -283,23 +305,24 @@ abstract class JHtmlBehavior
 	/**
 	 * Remove all jQuery files for a given $majorVersion
 	 * Used when a newever maintenance version for $majorVersion is added by an extension.
-	 * 
-	 * @param   string  $majorVersion
-	 * 
+	 *
+	 * @param   string  $majorVersion  The version number.
+	 *
 	 * @return  void
 	 */
 	protected static function removeAllAddedPaths($majorVersion)
 	{
 		$document = JFactory::getDocument();
-		foreach (self::$jQueryPluginsPathsAdded[$majorVersion] as $include) {
+		foreach (self::$jQueryPluginsPathsAdded[$majorVersion] as $include)
+		{
 			$document->removeScript($include);
 		}
 	}
 	/**
 	 * Adds ?v=HASHFROMFILEMODTIME... to file name so that caches get updated when file changes
-	 * 
-	 * @param   string  $include   Path and file (.js or .css)
-	 * 
+	 *
+	 * @param   string  $include  Path and file (.js or .css)
+	 *
 	 * @return  string             $inlcude with '?v=HASH' added
 	 */
 	protected static function addVersionFileUrl( $include )
@@ -311,13 +334,13 @@ abstract class JHtmlBehavior
 			if ( ! $cache)
 			{
 				// We cache the constant part for the site and Joomla version to save some time:
-				$cache = JPlatform::getLongVersion() . filemtime( __FILE__ ) . JURI::root();
+				$cache = JPlatform::getLongVersion() . filemtime(__FILE__) . JURI::root();
 			}
 			// Comute filesystem path+filename corresponding to the http path+filename:
 			$file = JPATH_ROOT . '/' . substr($include, strlen(JURI::root(true)) + 1);
 
 			// And compute the hash from the constant and from the variable part:
-			$include .= '?v=' . substr( md5( filemtime( $file ) . $cache ), 0, 16 );
+			$include .= '?v=' . substr(md5(filemtime($file) . $cache), 0, 16);
 		}
 		return $include;
 	}

--- a/libraries/joomla/html/html/behavior.php
+++ b/libraries/joomla/html/html/behavior.php
@@ -84,6 +84,248 @@ abstract class JHtmlBehavior
 	}
 
 	/**
+	 * JQUERY BEHAVIOR HANDLER:
+	 */
+	/**
+	 * Method to load jQuery frameworks and non-conflicting javascript code into the document head
+	 * Loading and use is done in "deep non-conflict mode", which allows several concurent versions of jQuery to be loaded and run simultaneously with any other javascript framework, including another conflicting jQuery instance.
+	 * It means that the window's Javascript global namespace is not used in a fixed way: neither $ nor jQuery global variables are used. Reference: http://api.jquery.com/jQuery.noConflict/
+	 * 
+	 * Calling and params:
+	 * JHTml::_('behavior.jquery', $fullVersion, $relativePathToRoot, $listofPlugins, $javascriptCodeToRunInNonConflictMode);
+	 * 
+	 * Use: Example:
+	 * JHTml::_('behavior.jquery', '1.6.1', 'media/jquery/', null, '$("p").css("color","red")');
+	 * JHTml::_('behavior.jquery', '1.7.0', 'media/othercompon/js/', array('jquery.flot','jquery.form'));;
+	 * JHTml::_('behavior.jquery', '1.7.1', 'media/mycomponent/jquery/', array('jquery.ui-all','jquery.form'),'$("h1,h2,h3").css("color","green")');
+	 * Will load jQuery 1.6.1 with ui and form from the 1.7.1 folder media/mycomponent/jquery, and and jQuery 1.7.1 with flot and form from the 1.7.0 folder media/othercompon/jquery
+	 *
+	 * If debugging mode is on an uncompressed version of jQuery is included for easier debugging.
+	 * Files: 2 files are mandatory for jquery and jQuery plugins, and do follow the jQuery naming:
+	 * jQuery: jquery-1.7.1.js for uncompressed and jquery-1.7.1.min.js
+	 * jQuery plugins: "$path/$pluginname[.min].js"
+	 *
+	 * @param   string         $version        x.y.z jQuery-Version (not jQuery plugins versions, but always jQuery one) corresponding to the file to load (highest sub-version Z of same x.y release will be loaded in the end) [MANDATORY]
+	 * @param   string         $path           Path to file from root of website (no / at start but / at end) so that it can be appended to absolute files path or live site [MANDATORY ONCE AT LEAST]
+	 * @param   array|null     $jQueryPlugins  Array of filenames (without .js or .min.js extension) of jQuery plugins or other Javascript files with jQuery code (which need the jQuery and $ to be defined correctly) [optional]
+	 * @param   string|null    $jqCode         jQuery Javascript code outputed in context with jQuery and $ defined and on dom ready [optional]
+	 *
+	 * @return  void
+	 *
+	 * @since   11.5
+	 */
+	public static function jquery($version, $path, $jQueryPlugins = null, $jqCode = null)
+	{
+		list($x, $y, $maintenanceVersion) = explode('.', $version);
+		$majorVersion = $x . '_' . $y;
+		
+		// Add (or replace if $version is newer) the base jQuery plugin with newest $version as provided in $path:
+		if ($path)
+		{
+			self::addPlugin('jquery', $majorVersion, $maintenanceVersion, $path);
+		}
+
+		// Go through each jQuery plugin listed here and add them to the list:
+		if ($jQueryPlugins)
+		{
+			foreach ($jQueryPlugins as $jQueryPlugin)
+			{
+				self::addPlugin($jQueryPlugin, $majorVersion, $maintenanceVersion, $path);
+			}
+		}
+
+		// Output code with the proper context:
+		if ($jqCode)
+		{
+			$document = JFactory::getDocument();
+			$lnEnd = $document->_getLineEnd();
+
+			$js = self::jqueryGlobalVarName($majorVersion) . '(document).ready(function($){'
+			. '  var jQuery = $;' . $lnEnd . $lnEnd
+			. '  ' . $jqCode . $lnEnd
+			. '});';
+
+			$document->addScriptDeclaration( $js );
+		}
+	}
+
+	/**
+	 * Array of jQuery and jQuery plugins by major version and by plugin their path.
+	 * E.g. self::$jQueryPlugins['1.7']['jquery'] = 'media/mycomponent/js/'
+	 * E.g. array('1.5' => array( 'jquery' => 'media/mycomponent/js/' ), '1.7' =>  array( 'jquery' => 'media/anothercomponent/jquery/', 'jquery.form' => 'media/anothercomponent/jquery/' ) )
+	 * @var array
+	 */
+	protected static $jQueryPlugins				=	array();
+	/**
+	 * Array of subversions to vote for highest maintenance version within a main jquery version
+	 * E.g. self::$jQueryPluginsVersion['1.7']['jquery'] = '1.7.1'
+	 * @var array
+	 */
+	protected static $jQueryPluginsVersion		=	array();
+	/**
+	 * Array of paths added for each jQuery major version, that way, if a more recent maintenance version gets announced, these files can be reverted.
+	 * E.g. self::$jQueryPluginsPathsAdded = array( 'media/mycomponent/js/jquery-1.7.1.min.js'
+	 * @var array
+	 */
+	protected static $jQueryPluginsPathsAdded	=	array();
+
+	/**
+	 * Internal function adding a plugin to the list of plugins to load
+	 * 
+	 * @param   string  $plugin               Name of the jQuery plugin ('jquery' for main one)
+	 * @param   string  $majorVersion         Major Version of the file to load (formatted '1_7' instead of '1.7')
+	 * @param   string  $maintenanceVersion   Maintenance Version of the file to load (number)
+	 * @param   string  $path                 Path to file from root of website (including leading / ) so that it can be appended to absolute files path or live site
+	 * 
+	 * @return  void
+	 */
+	protected static function addPlugin($plugin, $majorVersion, $maintenanceVersion, $path)
+	{
+		$existed = isset(self::$jQueryPluginsVersion[$majorVersion][$plugin]);
+		if (( ! $existed) || ($maintenanceVersion > self::$jQueryPluginsVersion[$majorVersion][$plugin]))
+		{
+			if ($existed)
+			{
+				self::removeAllAddedPaths($majorVersion);
+			}
+			self::$jQueryPlugins[$majorVersion][$plugin] = $path;
+			self::$jQueryPluginsVersion[$majorVersion][$plugin] = $maintenanceVersion;
+			if ($existed)
+			{
+				self::jqAddPaths($majorVersion);
+			}
+			else
+			{
+				self::jqAddPaths($majorVersion, array($plugin => $path));
+			}
+		}
+	}
+
+	/**
+	 * Internal function returning the global Javascript variable name for that jquery instance corresponding to the major version
+	 * Global variable name is of the form Joomla_jQuery_1_7 but can change in future.
+	 * 
+	 * @param   string  $majorVersion
+	 * 
+	 * @return  string
+	 */
+	protected static function jqueryGlobalVarName($majorVersion)
+	{
+		return 'Joomla_jQuery_' . $majorVersion;
+	}
+
+	/**
+	 * Internal function adding the scripts code to header in a deeply non-conflcting mode
+	 * 
+	 * @param   string      $majorVersion  E.g. '1_7'
+	 * @param   array|null  $paths         Paths to add, Null means reload all paths for that major version
+	 * 
+	 * @return  void
+	 */
+	protected static function jqAddPaths($majorVersion, $paths = null)
+	{
+		if (! $paths)
+		{
+			// No $paths given: load all plugins for that major version:
+			$paths = self::$jQueryPlugins[$majorVersion];
+		}
+
+		$document = JFactory::getDocument();
+
+		// Selects .js or .min.js as extension depending on Joomla debug mode:
+		$debug = JFactory::getConfig()->get('debug');
+		$fileExtension = ( $debug ? '.js' : '.min.js' );
+
+		// Adds ?v=HASH so that caches get reloaded when file or version changes:
+		$jsVarName = self::jqueryGlobalVarName($majorVersion);
+
+		// Now adds the $paths asked:
+		foreach ( $paths as $plugin => $pluginPath) {
+			if ($plugin == 'jquery')
+			{
+				// Special case for jQuery itself: build the standard jQuery name 'jquery-1.7.1.min.js' or 'jquery-1.7.1.js':
+				$file = self::$jQueryPlugins[$majorVersion]['jquery'] . 'jquery-' . str_replace( '_', '.', $majorVersion ) . '.' . self::$jQueryPluginsVersion[$majorVersion]['jquery'] . $fileExtension;
+
+				// Adds code immediately after the script file for deep noConflict mode: means neither $ nor jQuery global variables are used: http://api.jquery.com/jQuery.noConflict/
+				$preScript = null;
+				$postScript = 'var ' . $jsVarName . ' = jQuery.noConflict(true);';
+			}
+			else
+			{
+				// Case of jQuery plugins or other Javascript files with jQuery code
+				$file = $pluginPath . $plugin . $fileExtension;
+
+				// These need the jQuery and $ to be defined correctly): Thus defined them before inserting the script file:
+				$preScript	= 'window.Joomla_tmp_save_jquery = window.jQuery;'
+							. 'window.Joomla_tmp_save_$ = window.$;'
+							. 'window.jQuery = window.$ = ' . $jsVarName;
+
+				// And restore the temporarily saved value after:
+				$postScript = 'window.jQuery = window.Joomla_tmp_save_jquery;'
+							. 'window.$ = window.Joomla_tmp_save_$;';
+			}
+
+			// Compute relative filename using JHtml script helper, but do not add to header as we need the $preScript and $postScript codes:
+			$include = JHtml::_('script', $file, false, false, true, false, false);
+			if ($include)
+			{
+				// File exists: Computes the caching hash for the file:
+				$include = self::addVersionFileUrl($include);
+
+				// Adds to document jQuery in noConflict mode:
+				$document->addScript($include, 'text/javascript', false, false, $preScript, $postScript);
+	
+				// Remember the path added so that it can be removed when replaced by a newer maintenance version:
+				self::$jQueryPluginsPathsAdded[$majorVersion][] = $include;
+			}
+		}
+	}
+	/**
+	 * Remove all jQuery files for a given $majorVersion
+	 * Used when a newever maintenance version for $majorVersion is added by an extension.
+	 * 
+	 * @param   string  $majorVersion
+	 * 
+	 * @return  void
+	 */
+	protected static function removeAllAddedPaths($majorVersion)
+	{
+		$document = JFactory::getDocument();
+		foreach (self::$jQueryPluginsPathsAdded[$majorVersion] as $include) {
+			$document->removeScript($include);
+		}
+	}
+	/**
+	 * Adds ?v=HASHFROMFILEMODTIME... to file name so that caches get updated when file changes
+	 * 
+	 * @param   string  $include   Path and file (.js or .css)
+	 * 
+	 * @return  string             $inlcude with '?v=HASH' added
+	 */
+	protected static function addVersionFileUrl( $include )
+	{
+		static $cache = null;;
+
+		if ((substr($include, -3) == '.js') || (substr($include, -4) == '.css'))
+		{
+			if ( ! $cache)
+			{
+				// We cache the constant part for the site and Joomla version to save some time:
+				$cache = JPlatform::getLongVersion() . filemtime( __FILE__ ) . JURI::root();
+			}
+			// Comute filesystem path+filename corresponding to the http path+filename:
+			$file = JPATH_ROOT . '/' . substr($include, strlen(JURI::root(true)) + 1);
+
+			// And compute the hash from the constant and from the variable part:
+			$include .= '?v=' . substr( md5( filemtime( $file ) . $cache ), 0, 16 );
+		}
+		return $include;
+	}
+	/*
+	 * END OF JQUERY BEHAVIOR HANDLER:
+	 */
+
+	/**
 	 * Add unobtrusive javascript support for image captions.
 	 *
 	 * @param   string  $selector  The selector for which a caption behaviour is to be applied.


### PR DESCRIPTION
Hi Joomla Framework team,

I have spent last 2 days designing and implementing a method to load jQuery frameworks, plugins and files, and non-conflicting javascript code into the document head.

The files are provided by extensions, and multiple versions are supported concurrently.

There are only 2 new public methods, one to use it and one to check that it is available (or any other JHtml::_() helper.

I have tested it with multiple jQuery frameworks and with a modified Community Builder version too.

I feel that the changes to existing code and functionality (including minor bug fixes and php-lint fixes) are safe enough for Joomla 2.5.

Please review and comment, main description is below:

Best Regards,
Beat

```
/**
 * Method to load jQuery frameworks and non-conflicting javascript code into the document head
 * Loading and use is done in "deep non-conflict mode", which allows several concurent versions of jQuery to be loaded and run simultaneously with any other javascript framework, including another conflicting jQuery instance.
 * It means that the window's Javascript global namespace is not used in a fixed way: neither $ nor jQuery global variables are used. Reference: http://api.jquery.com/jQuery.noConflict/
 * 
 * Calling and params:
 * JHTml::_('behavior.jquery', $fullVersion, $relativePathToRoot, $listofPlugins, $javascriptCodeToRunInNonConflictMode);
 * 
 * Use: Example:
 * JHTml::_('behavior.jquery', '1.6.1', 'media/jquery/', null, '$("p").css("color","red")');
 * JHTml::_('behavior.jquery', '1.7.0', 'media/othercompon/js/', array('jquery.flot','jquery.form'));;
 * JHTml::_('behavior.jquery', '1.7.1', 'media/mycomponent/jquery/', array('jquery.ui-all','jquery.form'),'$("h1,h2,h3").css("color","green")');
 * Will load jQuery 1.6.1 with ui and form from the 1.7.1 folder media/mycomponent/jquery, and and jQuery 1.7.1 with flot and form from the 1.7.0 folder media/othercompon/jquery
 *
 * If debugging mode is on an uncompressed version of jQuery is included for easier debugging.
 * Files: 2 files are mandatory for jquery and jQuery plugins, and do follow the jQuery naming:
 * jQuery: jquery-1.7.1.js for uncompressed and jquery-1.7.1.min.js
 * jQuery plugins: "$path/$pluginname[.min].js"
 *
 * @param   string         $version        x.y.z jQuery-Version (not jQuery plugins versions, but always jQuery one) corresponding to the file to load (highest sub-version Z of same x.y release will be loaded in the end) [MANDATORY]
 * @param   string         $path           Path to file from root of website (no / at start but / at end) so that it can be appended to absolute files path or live site [MANDATORY ONCE AT LEAST]
 * @param   array|null     $jQueryPlugins  Array of filenames (without .js or .min.js extension) of jQuery plugins or other Javascript files with jQuery code (which need the jQuery and $ to be defined correctly) [optional]
 * @param   string|null    $jqCode         jQuery Javascript code outputed in context with jQuery and $ defined and on dom ready [optional]
 *
 * @return  void
 *
 * @since   11.5
 */


/**
 * Checks if a JHtml::_($key) call can be made.
 * If the function is not registered, tries to load the corresponding class without registering the function.
 * 
 * @param   string  $key  The name of helper method to load, (prefix).(class).function
 *                        prefix and class are optional and can be used to load custom
 *                        html helpers.
 *
 * @return  boolean      True: $key function is implemented, False: is not.
 */
JHtml::isCallable_($key)
```
