### PR TITLE
JUser accesslevel and usergroup caching off empty object var and not object id

### DIFF
--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -431,9 +431,12 @@ class JUser extends JObject
 			$this->_authLevels = array();
 		}
 
-		if (empty($this->_authLevels))
+		static $_authLevels = array();
+
+		if (!isset($_authLevels[$this->id]))
 		{
 			$this->_authLevels = JAccess::getAuthorisedViewLevels($this->id);
+			$_authLevels[$this->id] = $this->_authLevels;
 		}
 
 		return $this->_authLevels;
@@ -452,9 +455,12 @@ class JUser extends JObject
 			$this->_authGroups = array();
 		}
 
-		if (empty($this->_authGroups))
+		static $_authGroups = array();
+
+		if (!isset($_authGroups[$this->id]))
 		{
 			$this->_authGroups = JAccess::getGroupsByUser($this->id);
+			$_authGroups[$this->id] = $this->_authGroups;
 		}
 
 		return $this->_authGroups;


### PR DESCRIPTION
Current implement caches based off object variable being empty or not. This however does not function if you build the user object before a user logs in as it then populates the variable with guest accesslevels and usergroups. Once login is triggered if the object is persisted then it persists with those guest accesslevels and usergroups and prevents menu items for example displayed only to registered users from displaying.

Proposed implemented keeps caching intact, but rather then caching if variable is populated or not it caches based off the object id. This prevents duplicate calls to JAccess::getAuthorisedViewLevels per page load, but maintains accuracy of user accesslevels and usergroups when transitioning from guest to logged in.
