### PR TITLE
JAccess::getGroupsByUser doesn't work as expected in case of guest user

### DIFF
--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -297,7 +297,7 @@ class JAccess
 				if (empty($userId))
 				{
 					$query->from('#__usergroups AS a');
-					$query->where('a.id = '.(int) JComponentHelper::getParams('com_users')->get('guest_usergroup', 1));
+					$query->where('a.id = ' . (int) JComponentHelper::getParams('com_users')->get('guest_usergroup', 1));
 				}
 				else
 				{

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -281,12 +281,12 @@ class JAccess
 
 		if (!isset(self::$groupsByUser[$storeId]))
 		{
-			// Guest user
-			if (empty($userId))
+			// Guest user (if only the actually assigned group is requested)
+			if (empty($userId) && !$recursive)
 			{
 				$result = array(JComponentHelper::getParams('com_users')->get('guest_usergroup', 1));
 			}
-			// Registered user
+			// Registered user and guest if all groups are requested
 			else
 			{
 				$db = JFactory::getDbo();
@@ -294,9 +294,17 @@ class JAccess
 				// Build the database query to get the rules for the asset.
 				$query = $db->getQuery(true);
 				$query->select($recursive ? 'b.id' : 'a.id');
-				$query->from('#__user_usergroup_map AS map');
-				$query->where('map.user_id = ' . (int) $userId);
-				$query->leftJoin('#__usergroups AS a ON a.id = map.group_id');
+				if (empty($userId))
+				{
+					$query->from('#__usergroups AS a');
+					$query->where('a.id = '.(int) JComponentHelper::getParams('com_users')->get('guest_usergroup', 1));
+				}
+				else
+				{
+					$query->from('#__user_usergroup_map AS map');
+					$query->where('map.user_id = ' . (int) $userId);
+					$query->leftJoin('#__usergroups AS a ON a.id = map.group_id');
+				}
 
 				// If we want the rules cascading up to the global asset node we need a self-join.
 				if ($recursive)


### PR DESCRIPTION
Hi,

I think I found a small problem in method 'JAccess::getGroupsByUser'. By
default, the method returns an array containing every group ID the current user
belongs to (also the inherited ones), but this is not the case for a guest
visiting the site.

As a consequence the bug only occurs if option 'Guest User Group' in user
manager is not set to the default 'Public' group.

I created a patch which tries to fix this issue. 

Test instructions:
1. Create a new user group 'Visitors' with default 'Public' group as parent.
2. Set option 'Guest User Group' in user manager to this new user group.
3. Delete cookies (for cleaning session)
4. Anywhere in the code put following line:

var_dump(JFactory::getUser()->getAuthorisedGroups());

=> Only the group 'Visitors' will be in array.
1. Apply patch
2. Delete cookies (for cleaning session)
3. Refresh page

=> Group 'Visitors' as well as the default 'Public' group should be in the array now.

This is also reported on joomlacode.org:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=27706

Regards
Chraneco
