### PR TITLE
There is no reason to protect

### DIFF
--- a/libraries/joomla/utilities/date.php
+++ b/libraries/joomla/utilities/date.php
@@ -240,7 +240,7 @@ class JDate extends DateTime
 	 *
 	 * @since   11.1
 	 */
-	protected function dayToString($day, $abbr = false)
+	public function dayToString($day, $abbr = false)
 	{
 		switch ($day)
 		{
@@ -364,7 +364,7 @@ class JDate extends DateTime
 	 *
 	 * @since   11.1
 	 */
-	protected function monthToString($month, $abbr = false)
+	public function monthToString($month, $abbr = false)
 	{
 		switch ($month)
 		{


### PR DESCRIPTION
protected function dayToString($day, $abbr = false)
protected function monthToString($month, $abbr = false)
