### PR TITLE
Add Union method

### DIFF
--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -1265,4 +1265,24 @@ abstract class JDatabaseQuery
 		}
 		return $this;
 	}
+		/**
+	 * Add a query to UNION DISTINCT with the current query. Simply a proxy to Union.
+	 *
+	 * @param   object   The JDatabaseQuery object to union.
+	 *
+	 * @return  mixed    The JDatabaseQuery object on success or boolean false on failure.
+	 *
+	 * @since   12.1
+	 */
+	public function unionDistinct($query)
+	{
+		if (!$query instanceof JDatabaseQuery)
+		{
+			return false;
+		}
+
+		// Apply the distinct flag to the union if set.
+
+		return $this->union($query,'distinct');
+	}
 }

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -345,12 +345,12 @@ abstract class JDatabaseQuery
 
 				if ($this->union)
 				{
-					$query .= (string) $this->union = array();
+					$query .= (string) $this->union;
 				}
 
 				if ($this->unionDistinct)
 				{
-					$query .= (string) $this->unionDistinct = true;
+					$query .= (string) $this->unionDistinct;
 				}
 
 				break;
@@ -1235,54 +1235,58 @@ abstract class JDatabaseQuery
 
 	/**
 	 * Add a query to UNION with the current query.
+	 * Multiple unions each require separate statements.
+	 *
+	 * Usage:
+	 * $query->union('SELECT name FROM  #__foo')
+	 * $query->union('SELECT name FROM  #__foo','distinct')
 	 *
 	 * @param   object   $query     The JDatabaseQuery object to union.
 	 * @param   boolean  $distinct  True to only return distinct rows from the union.
+	 * @param   string   $glue      The glue by which to join the conditions.
 	 *
 	 * @return  mixed    The JDatabaseQuery object on success or boolean false on failure.
 	 *
 	 * @since   12.1
 	 */
-	public function union($query, $distinct = null)
+	public function union($query, $distinct = null, $glue = ' ')
 	{
-		if (!$query instanceof JDatabaseQuery)
-		{
-			return false;
-		}
 
 		// Clear any ORDER BY clause in unioned query.
-		$query->clear('order');
+		if (!is_null($this->order))
+		{
+			$this->clear('order');
+		}
 
 		// Apply the distinct flag to the union if set.
 		if ($distinct !== null)
 		{
-			return ' UNION DISTINCT' . $query;
+			return $this->union = new JDatabaseQueryElement('UNION DISTINCT', $query, $glue);
 		}
-
 		else
 		{
-			return ' UNION ' . $query;
+			return $this->union = new JDatabaseQueryElement('UNION', $query, $glue);
 		}
-		return $this;
 	}
-		/**
-	 * Add a query to UNION DISTINCT with the current query. Simply a proxy to Union.
+
+	/**
+	 * Add a query to UNION DISTINCT with the current query. Simply a proxy to Union with the Distinct clause.
+	 *
+	 * Usage:
+	 * $query->unionDistinct('SELECT name FROM  #__foo')
 	 *
 	 * @param   object  $query  The JDatabaseQuery object to union.
+	 * @param   string  $glue   The glue by which to join the conditions.
 	 *
 	 * @return  mixed   The JDatabaseQuery object on success or boolean false on failure.
 	 *
 	 * @since   12.1
 	 */
-	public function unionDistinct($query)
+	public function unionDistinct($query, $glue = ' ')
 	{
-		if (!$query instanceof JDatabaseQuery)
-		{
-			return false;
-		}
+		$distinct = true;
 
 		// Apply the distinct flag to the union if set.
-
-		return $this->union($query, 'distinct');
+		return $this->union($query, $distinct, $glue);
 	}
 }

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -348,11 +348,6 @@ abstract class JDatabaseQuery
 					$query .= (string) $this->union;
 				}
 
-				if ($this->unionDistinct)
-				{
-					$query .= (string) $this->unionDistinct;
-				}
-
 				break;
 
 			case 'delete':
@@ -550,10 +545,6 @@ abstract class JDatabaseQuery
 				$this->union = null;
 				break;
 
-			case 'unionDistinct':
-				$this->unionDistinct = null;
-				break;
-
 			default:
 				$this->type = null;
 				$this->select = null;
@@ -571,7 +562,6 @@ abstract class JDatabaseQuery
 				$this->values = null;
 				$this->autoIncrementField = null;
 				$this->union = null;
-				$this->unionDistinct = null;
 				break;
 		}
 
@@ -1339,7 +1329,7 @@ abstract class JDatabaseQuery
 
 	/**
 	 * Add a query to UNION with the current query.
-	 * Multiple unions each require separate statements.
+	 * Multiple unions each require separate statements and create an array of unions.
 	 *
 	 * Usage:
 	 * $query->union('SELECT name FROM  #__foo')
@@ -1365,11 +1355,15 @@ abstract class JDatabaseQuery
 		// Apply the distinct flag to the union if set.
 		if ($distinct)
 		{
-			return $this->union = new JDatabaseQueryElement('UNION DISTINCT', $query, $glue);
+			$this->union[] = new JDatabaseQueryElement('UNION DISTINCT', $query, $glue);
+
+			return $this;
 		}
 		else
 		{
-			return $this->union = new JDatabaseQueryElement('UNION', $query, $glue);
+			$this->union[] = new JDatabaseQueryElement('UNION', $query, $glue);
+
+			return $this;
 		}
 	}
 

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -244,7 +244,6 @@ abstract class JDatabaseQuery
 	protected $union = null;
 
 	/**
-	/**
 	 * Magic method to provide method alias support for quote() and quoteName().
 	 *
 	 * @param   string  $method  The called method.
@@ -1363,8 +1362,7 @@ abstract class JDatabaseQuery
 		// Great the JDatabaseQueryElement if it does not exist
 		if (is_null($this->union))
 		{
-
-				$this->union = new JDatabaseQueryElement($name, $query , "$glue");
+				$this->union = new JDatabaseQueryElement($name, $query, "$glue");
 		}
 		// Otherwise append the second UNION.
 		else

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -345,12 +345,12 @@ abstract class JDatabaseQuery
 
 				if ($this->union)
 				{
-					$query .= (string) $this->union = array();
+					$query .= (string) $this->union;
 				}
 
 				if ($this->unionDistinct)
 				{
-					$query .= (string) $this->unionDistinct = true;
+					$query .= (string) $this->unionDistinct;
 				}
 
 				break;
@@ -1339,54 +1339,58 @@ abstract class JDatabaseQuery
 
 	/**
 	 * Add a query to UNION with the current query.
+	 * Multiple unions each require separate statements.
+	 *
+	 * Usage:
+	 * $query->union('SELECT name FROM  #__foo')
+	 * $query->union('SELECT name FROM  #__foo','distinct')
 	 *
 	 * @param   object   $query     The JDatabaseQuery object to union.
 	 * @param   boolean  $distinct  True to only return distinct rows from the union.
+	 * @param   string   $glue      The glue by which to join the conditions.
 	 *
 	 * @return  mixed    The JDatabaseQuery object on success or boolean false on failure.
 	 *
 	 * @since   12.1
 	 */
-	public function union($query, $distinct = null)
+	public function union($query, $distinct = null, $glue = ' ')
 	{
-		if (!$query instanceof JDatabaseQuery)
-		{
-			return false;
-		}
 
 		// Clear any ORDER BY clause in unioned query.
-		$query->clear('order');
+		if (!is_null($this->order))
+		{
+			$this->clear('order');
+		}
 
 		// Apply the distinct flag to the union if set.
 		if ($distinct !== null)
 		{
-			return ' UNION DISTINCT' . $query;
+			return $this->union = new JDatabaseQueryElement('UNION DISTINCT', $query, $glue);
 		}
-
 		else
 		{
-			return ' UNION ' . $query;
+			return $this->union = new JDatabaseQueryElement('UNION', $query, $glue);
 		}
-		return $this;
 	}
-		/**
-	 * Add a query to UNION DISTINCT with the current query. Simply a proxy to Union.
+
+	/**
+	 * Add a query to UNION DISTINCT with the current query. Simply a proxy to Union with the Distinct clause.
+	 *
+	 * Usage:
+	 * $query->unionDistinct('SELECT name FROM  #__foo')
 	 *
 	 * @param   object  $query  The JDatabaseQuery object to union.
+	 * @param   string  $glue   The glue by which to join the conditions.
 	 *
 	 * @return  mixed   The JDatabaseQuery object on success or boolean false on failure.
 	 *
 	 * @since   12.1
 	 */
-	public function unionDistinct($query)
+	public function unionDistinct($query, $glue = ' ')
 	{
-		if (!$query instanceof JDatabaseQuery)
-		{
-			return false;
-		}
+		$distinct = true;
 
 		// Apply the distinct flag to the union if set.
-
-		return $this->union($query, 'distinct');
+		return $this->union($query, $distinct, $glue);
 	}
 }

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -1353,7 +1353,7 @@ abstract class JDatabaseQuery
 	 *
 	 * @since   12.1
 	 */
-	public function union($query, $distinct = null, $glue = ' ')
+	public function union($query, $distinct = false, $glue = ' ')
 	{
 
 		// Clear any ORDER BY clause in unioned query.
@@ -1363,7 +1363,7 @@ abstract class JDatabaseQuery
 		}
 
 		// Apply the distinct flag to the union if set.
-		if ($distinct !== null)
+		if ($distinct)
 		{
 			return $this->union = new JDatabaseQueryElement('UNION DISTINCT', $query, $glue);
 		}

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -1236,8 +1236,8 @@ abstract class JDatabaseQuery
 	/**
 	 * Add a query to UNION with the current query.
 	 *
-	 * @param   object   The JDatabaseQuery object to union.
-	 * @param   boolean  True to only return distinct rows from the union.
+	 * @param   object   $query     The JDatabaseQuery object to union.
+	 * @param   boolean  $distinct  True to only return distinct rows from the union.
 	 *
 	 * @return  mixed    The JDatabaseQuery object on success or boolean false on failure.
 	 *
@@ -1256,21 +1256,21 @@ abstract class JDatabaseQuery
 		// Apply the distinct flag to the union if set.
 		if ($distinct !== null)
 		{
-			return ' UNION DISTINCT'. $query;
+			return ' UNION DISTINCT' . $query;
 		}
 
 		else
 		{
-			return ' UNION '. $query;
+			return ' UNION ' . $query;
 		}
 		return $this;
 	}
 		/**
 	 * Add a query to UNION DISTINCT with the current query. Simply a proxy to Union.
 	 *
-	 * @param   object   The JDatabaseQuery object to union.
+	 * @param   object  $query  The JDatabaseQuery object to union.
 	 *
-	 * @return  mixed    The JDatabaseQuery object on success or boolean false on failure.
+	 * @return  mixed   The JDatabaseQuery object on success or boolean false on failure.
 	 *
 	 * @since   12.1
 	 */
@@ -1283,6 +1283,6 @@ abstract class JDatabaseQuery
 
 		// Apply the distinct flag to the union if set.
 
-		return $this->union($query,'distinct');
+		return $this->union($query, 'distinct');
 	}
 }

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -238,6 +238,18 @@ abstract class JDatabaseQuery
 	protected $autoIncrementField = null;
 
 	/**
+	 * @var    JDatabaseQueryElement  The union element.
+	 * @since  12.1
+	 */
+	protected $union = null;
+
+	/**
+	 * @var    JDatabaseQueryElement  The unionDistinct element.
+	 * @since  12.1
+	 */
+	protected $unionDistinct = null;
+
+	/**
 	 * Magic method to provide method alias support for quote() and quoteName().
 	 *
 	 * @param   string  $method  The called method.
@@ -329,6 +341,16 @@ abstract class JDatabaseQuery
 				if ($this->order)
 				{
 					$query .= (string) $this->order;
+				}
+
+				if ($this->union)
+				{
+					$query .= (string) $this->union = array();
+				}
+
+				if ($this->unionDistinct)
+				{
+					$query .= (string) $this->unionDistinct = true;
 				}
 
 				break;
@@ -524,6 +546,14 @@ abstract class JDatabaseQuery
 				$this->values = null;
 				break;
 
+			case 'union':
+				$this->union = null;
+				break;
+
+			case 'unionDistinct':
+				$this->unionDistinct = null;
+				break;
+
 			default:
 				$this->type = null;
 				$this->select = null;
@@ -540,6 +570,8 @@ abstract class JDatabaseQuery
 				$this->columns = null;
 				$this->values = null;
 				$this->autoIncrementField = null;
+				$this->union = null;
+				$this->unionDistinct = null;
 				break;
 		}
 
@@ -1303,5 +1335,38 @@ abstract class JDatabaseQuery
 				$this->{$k} = unserialize(serialize($v));
 			}
 		}
+	}
+
+	/**
+	 * Add a query to UNION with the current query.
+	 *
+	 * @param   object   The JDatabaseQuery object to union.
+	 * @param   boolean  True to only return distinct rows from the union.
+	 *
+	 * @return  mixed    The JDatabaseQuery object on success or boolean false on failure.
+	 *
+	 * @since   12.1
+	 */
+	public function union($query, $distinct = null)
+	{
+		if (!$query instanceof JDatabaseQuery)
+		{
+			return false;
+		}
+
+		// Clear any ORDER BY clause in unioned query.
+		$query->clear('order');
+
+		// Apply the distinct flag to the union if set.
+		if ($distinct !== null)
+		{
+			return ' UNION DISTINCT'. $query;
+		}
+
+		else
+		{
+			return ' UNION '. $query;
+		}
+		return $this;
 	}
 }

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -244,7 +244,6 @@ abstract class JDatabaseQuery
 	protected $union = null;
 
 	/**
-	/**
 	 * Magic method to provide method alias support for quote() and quoteName().
 	 *
 	 * @param   string  $method  The called method.
@@ -1259,8 +1258,7 @@ abstract class JDatabaseQuery
 		// Great the JDatabaseQueryElement if it does not exist
 		if (is_null($this->union))
 		{
-
-				$this->union = new JDatabaseQueryElement($name, $query , "$glue");
+				$this->union = new JDatabaseQueryElement($name, $query, "$glue");
 		}
 		// Otherwise append the second UNION.
 		else

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -238,6 +238,18 @@ abstract class JDatabaseQuery
 	protected $autoIncrementField = null;
 
 	/**
+	 * @var    JDatabaseQueryElement  The union element.
+	 * @since  12.1
+	 */
+	protected $union = null;
+
+	/**
+	 * @var    JDatabaseQueryElement  The unionDistinct element.
+	 * @since  12.1
+	 */
+	protected $unionDistinct = null;
+
+	/**
 	 * Magic method to provide method alias support for quote() and quoteName().
 	 *
 	 * @param   string  $method  The called method.
@@ -329,6 +341,16 @@ abstract class JDatabaseQuery
 				if ($this->order)
 				{
 					$query .= (string) $this->order;
+				}
+
+				if ($this->union)
+				{
+					$query .= (string) $this->union = array();
+				}
+
+				if ($this->unionDistinct)
+				{
+					$query .= (string) $this->unionDistinct = true;
 				}
 
 				break;
@@ -522,6 +544,14 @@ abstract class JDatabaseQuery
 				$this->values = null;
 				break;
 
+			case 'union':
+				$this->union = null;
+				break;
+
+			case 'unionDistinct':
+				$this->unionDistinct = null;
+				break;
+
 			default:
 				$this->type = null;
 				$this->select = null;
@@ -538,6 +568,8 @@ abstract class JDatabaseQuery
 				$this->columns = null;
 				$this->values = null;
 				$this->autoIncrementField = null;
+				$this->union = null;
+				$this->unionDistinct = null;
 				break;
 		}
 
@@ -1199,5 +1231,38 @@ abstract class JDatabaseQuery
 				$this->{$k} = unserialize(serialize($v));
 			}
 		}
+	}
+
+	/**
+	 * Add a query to UNION with the current query.
+	 *
+	 * @param   object   The JDatabaseQuery object to union.
+	 * @param   boolean  True to only return distinct rows from the union.
+	 *
+	 * @return  mixed    The JDatabaseQuery object on success or boolean false on failure.
+	 *
+	 * @since   12.1
+	 */
+	public function union($query, $distinct = null)
+	{
+		if (!$query instanceof JDatabaseQuery)
+		{
+			return false;
+		}
+
+		// Clear any ORDER BY clause in unioned query.
+		$query->clear('order');
+
+		// Apply the distinct flag to the union if set.
+		if ($distinct !== null)
+		{
+			return ' UNION DISTINCT'. $query;
+		}
+
+		else
+		{
+			return ' UNION '. $query;
+		}
+		return $this;
 	}
 }

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -1340,8 +1340,8 @@ abstract class JDatabaseQuery
 	/**
 	 * Add a query to UNION with the current query.
 	 *
-	 * @param   object   The JDatabaseQuery object to union.
-	 * @param   boolean  True to only return distinct rows from the union.
+	 * @param   object   $query     The JDatabaseQuery object to union.
+	 * @param   boolean  $distinct  True to only return distinct rows from the union.
 	 *
 	 * @return  mixed    The JDatabaseQuery object on success or boolean false on failure.
 	 *
@@ -1360,21 +1360,21 @@ abstract class JDatabaseQuery
 		// Apply the distinct flag to the union if set.
 		if ($distinct !== null)
 		{
-			return ' UNION DISTINCT'. $query;
+			return ' UNION DISTINCT' . $query;
 		}
 
 		else
 		{
-			return ' UNION '. $query;
+			return ' UNION ' . $query;
 		}
 		return $this;
 	}
 		/**
 	 * Add a query to UNION DISTINCT with the current query. Simply a proxy to Union.
 	 *
-	 * @param   object   The JDatabaseQuery object to union.
+	 * @param   object  $query  The JDatabaseQuery object to union.
 	 *
-	 * @return  mixed    The JDatabaseQuery object on success or boolean false on failure.
+	 * @return  mixed   The JDatabaseQuery object on success or boolean false on failure.
 	 *
 	 * @since   12.1
 	 */
@@ -1387,6 +1387,6 @@ abstract class JDatabaseQuery
 
 		// Apply the distinct flag to the union if set.
 
-		return $this->union($query,'distinct');
+		return $this->union($query, 'distinct');
 	}
 }

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -1241,9 +1241,9 @@ abstract class JDatabaseQuery
 	 * $query->union('SELECT name FROM  #__foo')
 	 * $query->union('SELECT name FROM  #__foo','distinct')
 	 *
-	 * @param   JDatabaseQuery   $query     The JDatabaseQuery object to union.
-	 * @param   boolean          $distinct  True to only return distinct rows from the union.
-	 * @param   string           $glue      The glue by which to join the conditions.
+	 * @param   JDatabaseQuery  $query     The JDatabaseQuery object to union.
+	 * @param   boolean         $distinct  True to only return distinct rows from the union.
+	 * @param   string          $glue      The glue by which to join the conditions.
 	 *
 	 * @return  mixed    The JDatabaseQuery object on success or boolean false on failure.
 	 *

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -745,7 +745,7 @@ abstract class JDatabaseQuery
 	 *
 	 * Usage:
 	 * $query->select($query->year($query->quoteName('dateColumn')));
-	 * 
+	 *
 	 * @param   string  $date  Date column containing year to be extracted.
 	 *
 	 * @return  string  Returns string to extract year from a date.
@@ -762,7 +762,7 @@ abstract class JDatabaseQuery
 	 *
 	 * Usage:
 	 * $query->select($query->month($query->quoteName('dateColumn')));
-	 * 
+	 *
 	 * @param   string  $date  Date column containing month to be extracted.
 	 *
 	 * @return  string  Returns string to extract month from a date.
@@ -779,7 +779,7 @@ abstract class JDatabaseQuery
 	 *
 	 * Usage:
 	 * $query->select($query->day($query->quoteName('dateColumn')));
-	 * 
+	 *
 	 * @param   string  $date  Date column containing day to be extracted.
 	 *
 	 * @return  string  Returns string to extract day from a date.
@@ -796,7 +796,7 @@ abstract class JDatabaseQuery
 	 *
 	 * Usage:
 	 * $query->select($query->hour($query->quoteName('dateColumn')));
-	 * 
+	 *
 	 * @param   string  $date  Date column containing hour to be extracted.
 	 *
 	 * @return  string  Returns string to extract hour from a date.
@@ -813,7 +813,7 @@ abstract class JDatabaseQuery
 	 *
 	 * Usage:
 	 * $query->select($query->minute($query->quoteName('dateColumn')));
-	 * 
+	 *
 	 * @param   string  $date  Date column containing minute to be extracted.
 	 *
 	 * @return  string  Returns string to extract minute from a date.
@@ -830,7 +830,7 @@ abstract class JDatabaseQuery
 	 *
 	 * Usage:
 	 * $query->select($query->second($query->quoteName('dateColumn')));
-	 * 
+	 *
 	 * @param   string  $date  Date column containing second to be extracted.
 	 *
 	 * @return  string  Returns string to extract second from a date.
@@ -1337,7 +1337,7 @@ abstract class JDatabaseQuery
 	 *
 	 * @since   12.1
 	 */
-	public function union($query, $distinct = false, $glue = '')
+	public function union(JDatabaseQuery $query, $distinct = false, $glue = '')
 	{
 
 		// Clear any ORDER BY clause in UNION query
@@ -1359,7 +1359,7 @@ abstract class JDatabaseQuery
 			$name = 'UNION ()';
 
 		}
-		// Great the JDatabaseQueryElement if it does not exist
+		// Get the JDatabaseQueryElement if it does not exist
 		if (is_null($this->union))
 		{
 				$this->union = new JDatabaseQueryElement($name, $query, "$glue");
@@ -1387,7 +1387,7 @@ abstract class JDatabaseQuery
 	 *
 	 * @since   12.1
 	 */
-	public function unionDistinct($query, $glue = '')
+	public function unionDistinct(JDatabaseQuery $query, $glue = '')
 	{
 		$distinct = true;
 

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -244,11 +244,6 @@ abstract class JDatabaseQuery
 	protected $union = null;
 
 	/**
-	 * @var    JDatabaseQueryElement  The unionDistinct element.
-	 * @since  12.1
-	 */
-	protected $unionDistinct = null;
-
 	/**
 	 * Magic method to provide method alias support for quote() and quoteName().
 	 *
@@ -343,12 +338,11 @@ abstract class JDatabaseQuery
 					$query .= (string) $this->order;
 				}
 
-				if ($this->union)
-				{
-					$query .= (string) $this->union;
-				}
-
 				break;
+
+			case 'union':
+				$query .= (string) $this->union;
+			break;
 
 			case 'delete':
 				$query .= (string) $this->delete;
@@ -1334,6 +1328,7 @@ abstract class JDatabaseQuery
 	 * Usage:
 	 * $query->union('SELECT name FROM  #__foo')
 	 * $query->union('SELECT name FROM  #__foo','distinct')
+	 * $query->union(array('SELECT name FROM  #__foo','SELECT name FROM  #__bar'))
 	 *
 	 * @param   JDatabaseQuery  $query     The JDatabaseQuery object to union.
 	 * @param   boolean         $distinct  True to only return distinct rows from the union.
@@ -1343,28 +1338,42 @@ abstract class JDatabaseQuery
 	 *
 	 * @since   12.1
 	 */
-	public function union($query, $distinct = false, $glue = ' ')
+	public function union($query, $distinct = false, $glue = '')
 	{
 
-		// Clear any ORDER BY clause in unioned query.
+		// Clear any ORDER BY clause in UNION query
+		// See http://dev.mysql.com/doc/refman/5.0/en/union.html
 		if (!is_null($this->order))
 		{
 			$this->clear('order');
 		}
 
-		// Apply the distinct flag to the union if set.
+		// Set up the DISTINCT flag, the name with parentheses, and the glue.
 		if ($distinct)
 		{
-			$this->union[] = new JDatabaseQueryElement('UNION DISTINCT', $query, $glue);
-
-			return $this;
+			$name = 'UNION DISTINCT ()';
+			$glue = ')' . PHP_EOL . 'UNION DISTINCT (';
 		}
 		else
 		{
-			$this->union[] = new JDatabaseQueryElement('UNION', $query, $glue);
+			$glue = ')' . PHP_EOL . 'UNION (';
+			$name = 'UNION ()';
 
-			return $this;
 		}
+		// Great the JDatabaseQueryElement if it does not exist
+		if (is_null($this->union))
+		{
+
+				$this->union = new JDatabaseQueryElement($name, $query , "$glue");
+		}
+		// Otherwise append the second UNION.
+		else
+		{
+			$glue = '';
+			$this->union->append($query);
+		}
+
+		return $this;
 	}
 
 	/**
@@ -1380,7 +1389,7 @@ abstract class JDatabaseQuery
 	 *
 	 * @since   12.1
 	 */
-	public function unionDistinct($query, $glue = ' ')
+	public function unionDistinct($query, $glue = '')
 	{
 		$distinct = true;
 

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -348,11 +348,6 @@ abstract class JDatabaseQuery
 					$query .= (string) $this->union;
 				}
 
-				if ($this->unionDistinct)
-				{
-					$query .= (string) $this->unionDistinct;
-				}
-
 				break;
 
 			case 'delete':
@@ -548,10 +543,6 @@ abstract class JDatabaseQuery
 				$this->union = null;
 				break;
 
-			case 'unionDistinct':
-				$this->unionDistinct = null;
-				break;
-
 			default:
 				$this->type = null;
 				$this->select = null;
@@ -569,7 +560,6 @@ abstract class JDatabaseQuery
 				$this->values = null;
 				$this->autoIncrementField = null;
 				$this->union = null;
-				$this->unionDistinct = null;
 				break;
 		}
 
@@ -1235,7 +1225,7 @@ abstract class JDatabaseQuery
 
 	/**
 	 * Add a query to UNION with the current query.
-	 * Multiple unions each require separate statements.
+	 * Multiple unions each require separate statements and create an array of unions.
 	 *
 	 * Usage:
 	 * $query->union('SELECT name FROM  #__foo')
@@ -1261,11 +1251,15 @@ abstract class JDatabaseQuery
 		// Apply the distinct flag to the union if set.
 		if ($distinct)
 		{
-			return $this->union = new JDatabaseQueryElement('UNION DISTINCT', $query, $glue);
+			$this->union[] = new JDatabaseQueryElement('UNION DISTINCT', $query, $glue);
+
+			return $this;
 		}
 		else
 		{
-			return $this->union = new JDatabaseQueryElement('UNION', $query, $glue);
+			$this->union[] = new JDatabaseQueryElement('UNION', $query, $glue);
+
+			return $this;
 		}
 	}
 

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -1345,9 +1345,9 @@ abstract class JDatabaseQuery
 	 * $query->union('SELECT name FROM  #__foo')
 	 * $query->union('SELECT name FROM  #__foo','distinct')
 	 *
-	 * @param   object   $query     The JDatabaseQuery object to union.
-	 * @param   boolean  $distinct  True to only return distinct rows from the union.
-	 * @param   string   $glue      The glue by which to join the conditions.
+	 * @param   JDatabaseQuery   $query     The JDatabaseQuery object to union.
+	 * @param   boolean          $distinct  True to only return distinct rows from the union.
+	 * @param   string           $glue      The glue by which to join the conditions.
 	 *
 	 * @return  mixed    The JDatabaseQuery object on success or boolean false on failure.
 	 *
@@ -1379,8 +1379,8 @@ abstract class JDatabaseQuery
 	 * Usage:
 	 * $query->unionDistinct('SELECT name FROM  #__foo')
 	 *
-	 * @param   object  $query  The JDatabaseQuery object to union.
-	 * @param   string  $glue   The glue by which to join the conditions.
+	 * @param   JDatabaseQuery  $query  The object to union.
+	 * @param   string          $glue   The glue by which to join the conditions.
 	 *
 	 * @return  mixed   The JDatabaseQuery object on success or boolean false on failure.
 	 *
@@ -1390,7 +1390,7 @@ abstract class JDatabaseQuery
 	{
 		$distinct = true;
 
-		// Apply the distinct flag to the union if set.
+		// Apply the distinct flag to the union.
 		return $this->union($query, $distinct, $glue);
 	}
 }

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -1249,7 +1249,7 @@ abstract class JDatabaseQuery
 	 *
 	 * @since   12.1
 	 */
-	public function union($query, $distinct = null, $glue = ' ')
+	public function union($query, $distinct = false, $glue = ' ')
 	{
 
 		// Clear any ORDER BY clause in unioned query.
@@ -1259,7 +1259,7 @@ abstract class JDatabaseQuery
 		}
 
 		// Apply the distinct flag to the union if set.
-		if ($distinct !== null)
+		if ($distinct)
 		{
 			return $this->union = new JDatabaseQueryElement('UNION DISTINCT', $query, $glue);
 		}

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -1369,4 +1369,24 @@ abstract class JDatabaseQuery
 		}
 		return $this;
 	}
+		/**
+	 * Add a query to UNION DISTINCT with the current query. Simply a proxy to Union.
+	 *
+	 * @param   object   The JDatabaseQuery object to union.
+	 *
+	 * @return  mixed    The JDatabaseQuery object on success or boolean false on failure.
+	 *
+	 * @since   12.1
+	 */
+	public function unionDistinct($query)
+	{
+		if (!$query instanceof JDatabaseQuery)
+		{
+			return false;
+		}
+
+		// Apply the distinct flag to the union if set.
+
+		return $this->union($query,'distinct');
+	}
 }

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -1345,9 +1345,9 @@ abstract class JDatabaseQuery
 	 * $query->union('SELECT name FROM  #__foo')
 	 * $query->union('SELECT name FROM  #__foo','distinct')
 	 *
-	 * @param   JDatabaseQuery   $query     The JDatabaseQuery object to union.
-	 * @param   boolean          $distinct  True to only return distinct rows from the union.
-	 * @param   string           $glue      The glue by which to join the conditions.
+	 * @param   JDatabaseQuery  $query     The JDatabaseQuery object to union.
+	 * @param   boolean         $distinct  True to only return distinct rows from the union.
+	 * @param   string          $glue      The glue by which to join the conditions.
 	 *
 	 * @return  mixed    The JDatabaseQuery object on success or boolean false on failure.
 	 *

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -1241,9 +1241,9 @@ abstract class JDatabaseQuery
 	 * $query->union('SELECT name FROM  #__foo')
 	 * $query->union('SELECT name FROM  #__foo','distinct')
 	 *
-	 * @param   object   $query     The JDatabaseQuery object to union.
-	 * @param   boolean  $distinct  True to only return distinct rows from the union.
-	 * @param   string   $glue      The glue by which to join the conditions.
+	 * @param   JDatabaseQuery   $query     The JDatabaseQuery object to union.
+	 * @param   boolean          $distinct  True to only return distinct rows from the union.
+	 * @param   string           $glue      The glue by which to join the conditions.
 	 *
 	 * @return  mixed    The JDatabaseQuery object on success or boolean false on failure.
 	 *
@@ -1275,8 +1275,8 @@ abstract class JDatabaseQuery
 	 * Usage:
 	 * $query->unionDistinct('SELECT name FROM  #__foo')
 	 *
-	 * @param   object  $query  The JDatabaseQuery object to union.
-	 * @param   string  $glue   The glue by which to join the conditions.
+	 * @param   JDatabaseQuery  $query  The object to union.
+	 * @param   string          $glue   The glue by which to join the conditions.
 	 *
 	 * @return  mixed   The JDatabaseQuery object on success or boolean false on failure.
 	 *
@@ -1286,7 +1286,7 @@ abstract class JDatabaseQuery
 	{
 		$distinct = true;
 
-		// Apply the distinct flag to the union if set.
+		// Apply the distinct flag to the union.
 		return $this->union($query, $distinct, $glue);
 	}
 }

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -378,6 +378,8 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			'order',
 			'columns',
 			'values',
+			'union',
+			'unionDistinct',
 		);
 
 		$q = new JDatabaseQueryInspector($this->dbo);
@@ -426,6 +428,8 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			'order',
 			'columns',
 			'values',
+			'union',
+			'unionDistinct',
 		);
 
 
@@ -489,6 +493,8 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			'order',
 			'columns',
 			'values',
+			'union',
+			'unionDistinct',
 		);
 
 		$q = new JDatabaseQueryInspector($this->dbo);
@@ -1465,4 +1471,47 @@ class JDatabaseQueryTest extends JoomlaTestCase
 
 		$this->assertFalse($baseElement->testObject === $cloneElement->testObject);
 	}
+
+	/**
+	 * Tests the JDatabaseQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testUnion()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
+		$q->select('foo.name');
+		$
+		$q->union($q->select);
+		$this->assertThat(
+			trim($q->union),
+			$this->equalTo('UNION SELECT name FROM #__foo'),
+			'Tests rendered query with union.'
+		);
+
+		$q->select = null;
+		$q->select(array('foo.name','bar.name'));
+		$
+		$q->union($q->select);
+		$this->assertThat(
+			trim($q->union),
+			$this->equalTo('UNION SELECT name FROM #__foo UNION SELECT name FROM #__bar'),
+			'Tests rendered query with union.'
+		);
+
+		$q->select = null;
+		$q->select('foo.name','distinct');
+		$
+		$q->union($q->select);
+		$this->assertThat(
+			trim($q->union),
+			$this->equalTo('UNION SELECT DISTINCT name FROM #__foo'),
+			'Tests rendered query with union distint.'
+		);
+
+
+	}
+
 }

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -254,6 +254,8 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			'order',
 			'columns',
 			'values',
+			'union',
+			'unionDistinct',
 		);
 
 		$q = new JDatabaseQueryInspector($this->dbo);
@@ -302,6 +304,8 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			'order',
 			'columns',
 			'values',
+			'union',
+			'unionDistinct',
 		);
 
 
@@ -365,6 +369,8 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			'order',
 			'columns',
 			'values',
+			'union',
+			'unionDistinct',
 		);
 
 		$q = new JDatabaseQueryInspector($this->dbo);
@@ -1341,4 +1347,47 @@ class JDatabaseQueryTest extends JoomlaTestCase
 
 		$this->assertFalse($baseElement->testObject === $cloneElement->testObject);
 	}
+
+	/**
+	 * Tests the JDatabaseQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testUnion()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
+		$q->select('foo.name');
+		$
+		$q->union($q->select);
+		$this->assertThat(
+			trim($q->union),
+			$this->equalTo('UNION SELECT name FROM #__foo'),
+			'Tests rendered query with union.'
+		);
+
+		$q->select = null;
+		$q->select(array('foo.name','bar.name'));
+		$
+		$q->union($q->select);
+		$this->assertThat(
+			trim($q->union),
+			$this->equalTo('UNION SELECT name FROM #__foo UNION SELECT name FROM #__bar'),
+			'Tests rendered query with union.'
+		);
+
+		$q->select = null;
+		$q->select('foo.name','distinct');
+		$
+		$q->union($q->select);
+		$this->assertThat(
+			trim($q->union),
+			$this->equalTo('UNION SELECT DISTINCT name FROM #__foo'),
+			'Tests rendered query with union distint.'
+		);
+
+
+	}
+
 }

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -1374,8 +1374,27 @@ class JDatabaseQueryTest extends JoomlaTestCase
 		$this->assertThat(
 			trim($q->union),
 			$this->equalTo("UNION DISTINCT \nSELECT foo.name"),
-			'Tests rendered query with union distint.'
+			'Tests rendered query with union distint as a string.'
 		);
+
+		$q->select = null;
+		$q->select('foo.name');
+		$q->union($q->select, true);
+		$this->assertThat(
+			trim($q->union),
+			$this->equalTo("UNION DISTINCT \nSELECT foo.name"),
+			'Tests rendered query with union distint true.'
+		);
+
+		$q->select = null;
+		$q->select('foo.name');
+		$q->union($q->select, false);
+		$this->assertThat(
+			trim($q->union),
+			$this->equalTo("UNION \nSELECT foo.name"),
+			'Tests rendered query with union distint false.'
+		);
+
 	}
 	/**
 	 * Tests the JDatabaseQuery::unionDistinct method.

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -1498,7 +1498,7 @@ class JDatabaseQueryTest extends JoomlaTestCase
 		$this->assertThat(
 			trim($q->union),
 			$this->equalTo('UNION SELECT name FROM #__foo UNION SELECT name FROM #__bar'),
-			'Tests rendered query with union.'
+			'Tests rendered query with union for an array.'
 		);
 
 		$q->select = null;
@@ -1516,7 +1516,7 @@ class JDatabaseQueryTest extends JoomlaTestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   112.1
+	 * @since   12.1
 	 */
 	public function testUnionDistinct()
 	{
@@ -1524,7 +1524,7 @@ class JDatabaseQueryTest extends JoomlaTestCase
 
 		$q->select = null;
 		$q->select('foo.name');
-		$
+
 		$q->union($q->select);
 		$this->assertThat(
 			trim($q->union),

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -1353,7 +1353,7 @@ class JDatabaseQueryTest extends JoomlaTestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   11.3
+	 * @since   12.1
 	 */
 	public function testUnion()
 	{
@@ -1386,8 +1386,27 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			$this->equalTo('UNION SELECT DISTINCT name FROM #__foo'),
 			'Tests rendered query with union distint.'
 		);
+	}
+	/**
+	 * Tests the JDatabaseQuery::unionDistinct method.
+	 *
+	 * @return  void
+	 *
+	 * @since   112.1
+	 */
+	public function testUnionDistinct()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
 
-
+		$q->select = null;
+		$q->select('foo.name');
+		$
+		$q->union($q->select);
+		$this->assertThat(
+			trim($q->union),
+			$this->equalTo('UNION SELECT DISTINCT name FROM #__foo'),
+			'Tests rendered query with union distint.'
+		);
 	}
 
 }

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -1498,8 +1498,27 @@ class JDatabaseQueryTest extends JoomlaTestCase
 		$this->assertThat(
 			trim($q->union),
 			$this->equalTo("UNION DISTINCT \nSELECT foo.name"),
-			'Tests rendered query with union distint.'
+			'Tests rendered query with union distint as a string.'
 		);
+
+		$q->select = null;
+		$q->select('foo.name');
+		$q->union($q->select, true);
+		$this->assertThat(
+			trim($q->union),
+			$this->equalTo("UNION DISTINCT \nSELECT foo.name"),
+			'Tests rendered query with union distint true.'
+		);
+
+		$q->select = null;
+		$q->select('foo.name');
+		$q->union($q->select, false);
+		$this->assertThat(
+			trim($q->union),
+			$this->equalTo("UNION \nSELECT foo.name"),
+			'Tests rendered query with union distint false.'
+		);
+
 	}
 	/**
 	 * Tests the JDatabaseQuery::unionDistinct method.

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -1374,7 +1374,7 @@ class JDatabaseQueryTest extends JoomlaTestCase
 		$this->assertThat(
 			trim($q->union),
 			$this->equalTo('UNION SELECT name FROM #__foo UNION SELECT name FROM #__bar'),
-			'Tests rendered query with union.'
+			'Tests rendered query with union for an array.'
 		);
 
 		$q->select = null;
@@ -1392,7 +1392,7 @@ class JDatabaseQueryTest extends JoomlaTestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   112.1
+	 * @since   12.1
 	 */
 	public function testUnionDistinct()
 	{
@@ -1400,7 +1400,7 @@ class JDatabaseQueryTest extends JoomlaTestCase
 
 		$q->select = null;
 		$q->select('foo.name');
-		$
+
 		$q->union($q->select);
 		$this->assertThat(
 			trim($q->union),

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -1477,7 +1477,7 @@ class JDatabaseQueryTest extends JoomlaTestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   11.3
+	 * @since   12.1
 	 */
 	public function testUnion()
 	{
@@ -1510,8 +1510,27 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			$this->equalTo('UNION SELECT DISTINCT name FROM #__foo'),
 			'Tests rendered query with union distint.'
 		);
+	}
+	/**
+	 * Tests the JDatabaseQuery::unionDistinct method.
+	 *
+	 * @return  void
+	 *
+	 * @since   112.1
+	 */
+	public function testUnionDistinct()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
 
-
+		$q->select = null;
+		$q->select('foo.name');
+		$
+		$q->union($q->select);
+		$this->assertThat(
+			trim($q->union),
+			$this->equalTo('UNION SELECT DISTINCT name FROM #__foo'),
+			'Tests rendered query with union distint.'
+		);
 	}
 
 }

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -1492,7 +1492,7 @@ class JDatabaseQueryTest extends JoomlaTestCase
 	 *
 	 * @since   12.1
 	 */
-	public function testUnion()
+	public function testUnionChain()
 	{
 		$q = new JDatabaseQueryInspector($this->dbo);
 
@@ -1501,6 +1501,18 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			$this->identicalTo($q),
 			'Tests chaining.'
 		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testUnionClear()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
 
 		$q->union = null;
 		$q->order = null;
@@ -1511,7 +1523,18 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			$this->equalTo(null),
 			'Tests that ORDER BY is cleared with union.'
 		);
+	}
 
+	/**
+	 * Tests the JDatabaseQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testUnionUnion()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
 
 		$q->union = null;
 		$q->union('SELECT name FROM foo');
@@ -1521,6 +1544,18 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			$this->equalTo("\nUNION (SELECT name FROM foo)"),
 			'Tests rendered query with union.'
 		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testUnionDistinctString()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
 
 		$q->union = null;
 		$q->union('SELECT name FROM foo','distinct');
@@ -1530,6 +1565,18 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			$this->equalTo("\nUNION DISTINCT (SELECT name FROM foo)"),
 			'Tests rendered query with union distinct as a string.'
 		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testUnionDistinctTrue()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
 
 		$q->union = null;
 		$q->union('SELECT name FROM foo', true);
@@ -1539,6 +1586,18 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			$this->equalTo("\nUNION DISTINCT (SELECT name FROM foo)"),
 			'Tests rendered query with union distinct true.'
 		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testUnionDistinctFalse()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
 
 		$q->union = null;
 		$q->union('SELECT name FROM foo', false);
@@ -1548,6 +1607,18 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			$this->equalTo("\nUNION (SELECT name FROM foo)"),
 			'Tests rendered query with union distinct false.'
 		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testUnionArray()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
 
 		$q->union = null;
 		$q->union(array('SELECT name FROM foo','SELECT name FROM bar'));
@@ -1555,8 +1626,20 @@ class JDatabaseQueryTest extends JoomlaTestCase
 		$this->assertThat(
 			$teststring,
 			$this->equalTo("\nUNION (SELECT name FROM foo)\nUNION (SELECT name FROM bar)"),
-			'Tests rendered query with two unions from an array.'
+			'Tests rendered query with two unions as an array.'
 		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testUnionTwo()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
 
 		$q->union = null;
 		$q->union('SELECT name FROM foo');
@@ -1567,8 +1650,8 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			$this->equalTo("\nUNION (SELECT name FROM foo)\nUNION (SELECT name FROM bar)"),
 			'Tests rendered query with two unions sequentially.'
 		);
-
 	}
+
 	/**
 	 * Tests the JDatabaseQuery::unionDistinct method.
 	 *
@@ -1588,6 +1671,20 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			$this->equalTo("UNION DISTINCT (SELECT name FROM foo)"),
 			'Tests rendered query with unionDistinct.'
 		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::unionDistinct method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testUnionDistinctArray()
+	{
+
+		$q = new JDatabaseQueryInspector($this->dbo);
+
 		$q->union = null;
 		$q->unionDistinct(array('SELECT name FROM foo','SELECT name FROM bar'));
 		$teststring = (string) $q->union;

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -1482,32 +1482,22 @@ class JDatabaseQueryTest extends JoomlaTestCase
 	public function testUnion()
 	{
 		$q = new JDatabaseQueryInspector($this->dbo);
+
+		$q->select = null;
 		$q->select('foo.name');
-		$
 		$q->union($q->select);
 		$this->assertThat(
 			trim($q->union),
-			$this->equalTo('UNION SELECT name FROM #__foo'),
+			$this->equalTo("UNION \nSELECT foo.name"),
 			'Tests rendered query with union.'
 		);
 
 		$q->select = null;
-		$q->select(array('foo.name','bar.name'));
-		$
-		$q->union($q->select);
+		$q->select('foo.name');
+		$q->union($q->select,'distinct');
 		$this->assertThat(
 			trim($q->union),
-			$this->equalTo('UNION SELECT name FROM #__foo UNION SELECT name FROM #__bar'),
-			'Tests rendered query with union for an array.'
-		);
-
-		$q->select = null;
-		$q->select('foo.name','distinct');
-		$
-		$q->union($q->select);
-		$this->assertThat(
-			trim($q->union),
-			$this->equalTo('UNION SELECT DISTINCT name FROM #__foo'),
+			$this->equalTo("UNION DISTINCT \nSELECT foo.name"),
 			'Tests rendered query with union distint.'
 		);
 	}
@@ -1525,11 +1515,11 @@ class JDatabaseQueryTest extends JoomlaTestCase
 		$q->select = null;
 		$q->select('foo.name');
 
-		$q->union($q->select);
+		$q->unionDistinct($q->select);
 		$this->assertThat(
 			trim($q->union),
-			$this->equalTo('UNION SELECT DISTINCT name FROM #__foo'),
-			'Tests rendered query with union distint.'
+			$this->equalTo("UNION DISTINCT \nSELECT foo.name"),
+			'Tests rendered query with union distinct.'
 		);
 	}
 

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -139,7 +139,7 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			->innerJoin('b ON b.id = a.id')
 			->where('b.id = 1')
 			->group('a.id')
-				->having('COUNT(a.id) > 3')
+			->having('COUNT(a.id) > 3')
 			->order('a.id');
 
 		$this->assertThat(
@@ -155,6 +155,7 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			),
 			'Tests for correct rendering.'
 		);
+
 	}
 
 	/**
@@ -182,6 +183,21 @@ class JDatabaseQueryTest extends JoomlaTestCase
 				"\nWHERE b.id = 1"
 			),
 			'Tests for correct rendering.'
+		);
+	}
+
+	public function test__toStringUnion()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
+
+		$q->union('SELECT id FROM a');
+
+		$this->assertThat(
+			(string) $q->union,
+			$this->equalTo(
+				"\nUNION (SELECT id FROM a)"
+			),
+			'Tests union for correct rendering.'
 		);
 	}
 
@@ -255,7 +271,6 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			'columns',
 			'values',
 			'union',
-			'unionDistinct',
 		);
 
 		$q = new JDatabaseQueryInspector($this->dbo);
@@ -305,7 +320,6 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			'columns',
 			'values',
 			'union',
-			'unionDistinct',
 		);
 
 
@@ -357,6 +371,7 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			'delete',
 			'update',
 			'insert',
+			'union',
 		);
 
 		$clauses = array(
@@ -369,8 +384,6 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			'order',
 			'columns',
 			'values',
-			'union',
-			'unionDistinct',
 		);
 
 		$q = new JDatabaseQueryInspector($this->dbo);
@@ -1359,40 +1372,76 @@ class JDatabaseQueryTest extends JoomlaTestCase
 	{
 		$q = new JDatabaseQueryInspector($this->dbo);
 
-		$q->select = null;
-		$q->select('foo.name');
-		$q->union($q->select);
 		$this->assertThat(
-			trim($q->union),
-			$this->equalTo("UNION \nSELECT foo.name"),
+			$q->union($q),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$q->union = null;
+		$q->order = null;
+		$q->order('bar');
+		$q->union('SELECT name FROM foo');
+		$this->assertThat(
+			$q->order,
+			$this->equalTo(null),
+			'Tests that ORDER BY is cleared with union.'
+		);
+
+
+		$q->union = null;
+		$q->union('SELECT name FROM foo');
+		$teststring = (string) $q->union;
+		$this->assertThat(
+			$teststring,
+			$this->equalTo("\nUNION (SELECT name FROM foo)"),
 			'Tests rendered query with union.'
 		);
 
-		$q->select = null;
-		$q->select('foo.name');
-		$q->union($q->select,'distinct');
+		$q->union = null;
+		$q->union('SELECT name FROM foo','distinct');
+		$teststring = (string) $q->union;
 		$this->assertThat(
-			trim($q->union),
-			$this->equalTo("UNION DISTINCT \nSELECT foo.name"),
-			'Tests rendered query with union distint as a string.'
+			$teststring,
+			$this->equalTo("\nUNION DISTINCT (SELECT name FROM foo)"),
+			'Tests rendered query with union distinct as a string.'
 		);
 
-		$q->select = null;
-		$q->select('foo.name');
-		$q->union($q->select, true);
+		$q->union = null;
+		$q->union('SELECT name FROM foo', true);
+		$teststring = (string) $q->union;
 		$this->assertThat(
-			trim($q->union),
-			$this->equalTo("UNION DISTINCT \nSELECT foo.name"),
-			'Tests rendered query with union distint true.'
+			$teststring,
+			$this->equalTo("\nUNION DISTINCT (SELECT name FROM foo)"),
+			'Tests rendered query with union distinct true.'
 		);
 
-		$q->select = null;
-		$q->select('foo.name');
-		$q->union($q->select, false);
+		$q->union = null;
+		$q->union('SELECT name FROM foo', false);
+		$teststring = (string) $q->union;
 		$this->assertThat(
-			trim($q->union),
-			$this->equalTo("UNION \nSELECT foo.name"),
-			'Tests rendered query with union distint false.'
+			$teststring,
+			$this->equalTo("\nUNION (SELECT name FROM foo)"),
+			'Tests rendered query with union distinct false.'
+		);
+
+		$q->union = null;
+		$q->union(array('SELECT name FROM foo','SELECT name FROM bar'));
+		$teststring = (string) $q->union;
+		$this->assertThat(
+			$teststring,
+			$this->equalTo("\nUNION (SELECT name FROM foo)\nUNION (SELECT name FROM bar)"),
+			'Tests rendered query with two unions from an array.'
+		);
+
+		$q->union = null;
+		$q->union('SELECT name FROM foo');
+		$q->union('SELECT name FROM bar');
+		$teststring = (string) $q->union;
+		$this->assertThat(
+			$teststring,
+			$this->equalTo("\nUNION (SELECT name FROM foo)\nUNION (SELECT name FROM bar)"),
+			'Tests rendered query with two unions sequentially.'
 		);
 
 	}
@@ -1407,14 +1456,21 @@ class JDatabaseQueryTest extends JoomlaTestCase
 	{
 		$q = new JDatabaseQueryInspector($this->dbo);
 
-		$q->select = null;
-		$q->select('foo.name');
-
-		$q->unionDistinct($q->select);
+		$q->union = null;
+		$q->unionDistinct('SELECT name FROM foo');
+		$teststring = (string) $q->union;
 		$this->assertThat(
-			trim($q->union),
-			$this->equalTo("UNION DISTINCT \nSELECT foo.name"),
-			'Tests rendered query with union distinct.'
+			trim($teststring),
+			$this->equalTo("UNION DISTINCT (SELECT name FROM foo)"),
+			'Tests rendered query with unionDistinct.'
+		);
+		$q->union = null;
+		$q->unionDistinct(array('SELECT name FROM foo','SELECT name FROM bar'));
+		$teststring = (string) $q->union;
+		$this->assertThat(
+			$teststring,
+			$this->equalTo("\nUNION DISTINCT (SELECT name FROM foo)\nUNION DISTINCT (SELECT name FROM bar)"),
+			'Tests rendered query with two unions distinct.'
 		);
 	}
 

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -1368,7 +1368,7 @@ class JDatabaseQueryTest extends JoomlaTestCase
 	 *
 	 * @since   12.1
 	 */
-	public function testUnion()
+	public function testUnionChain()
 	{
 		$q = new JDatabaseQueryInspector($this->dbo);
 
@@ -1377,6 +1377,18 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			$this->identicalTo($q),
 			'Tests chaining.'
 		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testUnionClear()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
 
 		$q->union = null;
 		$q->order = null;
@@ -1387,7 +1399,18 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			$this->equalTo(null),
 			'Tests that ORDER BY is cleared with union.'
 		);
+	}
 
+	/**
+	 * Tests the JDatabaseQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testUnionUnion()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
 
 		$q->union = null;
 		$q->union('SELECT name FROM foo');
@@ -1397,6 +1420,18 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			$this->equalTo("\nUNION (SELECT name FROM foo)"),
 			'Tests rendered query with union.'
 		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testUnionDistinctString()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
 
 		$q->union = null;
 		$q->union('SELECT name FROM foo','distinct');
@@ -1406,6 +1441,18 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			$this->equalTo("\nUNION DISTINCT (SELECT name FROM foo)"),
 			'Tests rendered query with union distinct as a string.'
 		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testUnionDistinctTrue()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
 
 		$q->union = null;
 		$q->union('SELECT name FROM foo', true);
@@ -1415,6 +1462,18 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			$this->equalTo("\nUNION DISTINCT (SELECT name FROM foo)"),
 			'Tests rendered query with union distinct true.'
 		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testUnionDistinctFalse()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
 
 		$q->union = null;
 		$q->union('SELECT name FROM foo', false);
@@ -1424,6 +1483,18 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			$this->equalTo("\nUNION (SELECT name FROM foo)"),
 			'Tests rendered query with union distinct false.'
 		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testUnionArray()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
 
 		$q->union = null;
 		$q->union(array('SELECT name FROM foo','SELECT name FROM bar'));
@@ -1431,8 +1502,20 @@ class JDatabaseQueryTest extends JoomlaTestCase
 		$this->assertThat(
 			$teststring,
 			$this->equalTo("\nUNION (SELECT name FROM foo)\nUNION (SELECT name FROM bar)"),
-			'Tests rendered query with two unions from an array.'
+			'Tests rendered query with two unions as an array.'
 		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::union method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testUnionTwo()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
 
 		$q->union = null;
 		$q->union('SELECT name FROM foo');
@@ -1443,8 +1526,8 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			$this->equalTo("\nUNION (SELECT name FROM foo)\nUNION (SELECT name FROM bar)"),
 			'Tests rendered query with two unions sequentially.'
 		);
-
 	}
+
 	/**
 	 * Tests the JDatabaseQuery::unionDistinct method.
 	 *
@@ -1464,6 +1547,20 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			$this->equalTo("UNION DISTINCT (SELECT name FROM foo)"),
 			'Tests rendered query with unionDistinct.'
 		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::unionDistinct method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testUnionDistinctArray()
+	{
+
+		$q = new JDatabaseQueryInspector($this->dbo);
+
 		$q->union = null;
 		$q->unionDistinct(array('SELECT name FROM foo','SELECT name FROM bar'));
 		$teststring = (string) $q->union;

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -1358,32 +1358,22 @@ class JDatabaseQueryTest extends JoomlaTestCase
 	public function testUnion()
 	{
 		$q = new JDatabaseQueryInspector($this->dbo);
+
+		$q->select = null;
 		$q->select('foo.name');
-		$
 		$q->union($q->select);
 		$this->assertThat(
 			trim($q->union),
-			$this->equalTo('UNION SELECT name FROM #__foo'),
+			$this->equalTo("UNION \nSELECT foo.name"),
 			'Tests rendered query with union.'
 		);
 
 		$q->select = null;
-		$q->select(array('foo.name','bar.name'));
-		$
-		$q->union($q->select);
+		$q->select('foo.name');
+		$q->union($q->select,'distinct');
 		$this->assertThat(
 			trim($q->union),
-			$this->equalTo('UNION SELECT name FROM #__foo UNION SELECT name FROM #__bar'),
-			'Tests rendered query with union for an array.'
-		);
-
-		$q->select = null;
-		$q->select('foo.name','distinct');
-		$
-		$q->union($q->select);
-		$this->assertThat(
-			trim($q->union),
-			$this->equalTo('UNION SELECT DISTINCT name FROM #__foo'),
+			$this->equalTo("UNION DISTINCT \nSELECT foo.name"),
 			'Tests rendered query with union distint.'
 		);
 	}
@@ -1401,11 +1391,11 @@ class JDatabaseQueryTest extends JoomlaTestCase
 		$q->select = null;
 		$q->select('foo.name');
 
-		$q->union($q->select);
+		$q->unionDistinct($q->select);
 		$this->assertThat(
 			trim($q->union),
-			$this->equalTo('UNION SELECT DISTINCT name FROM #__foo'),
-			'Tests rendered query with union distint.'
+			$this->equalTo("UNION DISTINCT \nSELECT foo.name"),
+			'Tests rendered query with union distinct.'
 		);
 	}
 


### PR DESCRIPTION
This adds a union method to JDatabaseQuery along with unionDistinct which provides a proxy to the union method with distinct. This is based on the method that was in the JXtended libraries but updated for the current implementation of JDatabaseQuery. Tests included.  
