### PR TITLE
Line 293 : syntax issue in multidb

### DIFF
--- a/libraries/joomla/application/categories.php
+++ b/libraries/joomla/application/categories.php
@@ -290,7 +290,7 @@ class JCategories
 		// Right join with c for category
 		$query->select('c.*');
 		$case_when = ' CASE WHEN ';
-		$case_when .= $query->charLength('c.alias') . '!=0';
+		$case_when .= $query->charLength('c.alias');
 		$case_when .= ' THEN ';
 		$c_id = $query->castAsChar('c.id');
 		$case_when .= $query->concatenate(array($c_id, 'c.alias'), ':');


### PR DESCRIPTION
$case_when .= $query->charLength('c.alias') . '!=0'; modified to    $case_when .= $query->charLength('c.alias');

Not sure if this was done for a reason.
