### PR TITLE
Remove deprecated methods in JLanguage

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -1269,25 +1269,6 @@ class JLanguage extends JObject
 	/**
 	 * Searches for language directories within a certain base dir.
 	 *
-	 * @param   string  $dir  Directory of files.
-	 *
-	 * @return  array  Array holding the found languages as filename => real name pairs.
-	 *
-	 * @deprecated    12.1
-	 * @note    Use parseLanguageFiles instead.
-	 * @since   11.1
-	 */
-	public static function _parseLanguageFiles($dir = null)
-	{
-		// Deprecation warning.
-		JLog::add('JLanguage::_parseLanguageFiles() is deprecated.', JLog::WARNING, 'deprecated');
-
-		return self::parseLanguageFiles($dir);
-	}
-
-	/**
-	 * Searches for language directories within a certain base dir.
-	 *
 	 * @param   string  $dir  directory of files.
 	 *
 	 * @return  array  Array holding the found languages as filename => real name pairs.
@@ -1309,26 +1290,6 @@ class JLanguage extends JObject
 		}
 
 		return $languages;
-	}
-
-	/**
-	 * Parses XML files for language information.
-	 *
-	 * @param   string  $dir  Directory of files.
-	 *
-	 * @return  array  Array holding the found languages as filename => metadata array.
-	 *
-	 * @note    Use parseXMLLanguageFiles instead.
-	 * @since   11.1
-	 *
-	 * @deprecated  12.1
-	 */
-	public static function _parseXMLLanguageFiles($dir = null)
-	{
-		// Deprecation warning.
-		JLog::add('JLanguage::_parseXMLLanguageFiles() is deprecated.', JLog::WARNING, 'deprecated');
-
-		return self::parseXMLLanguageFiles($dir);
 	}
 
 	/**
@@ -1364,22 +1325,6 @@ class JLanguage extends JObject
 		}
 
 		return $languages;
-	}
-
-	/**
-	 * Parse XML file for language information.
-	 *
-	 * @param   string  $path  Path to the XML files.
-	 *
-	 * @return  array  Array holding the found metadata as a key => value pair.
-	 *
-	 * @deprecated    12.1
-	 * @note    Use parseXMLLanguageFile instead.
-	 * @since   11.1
-	 */
-	public static function _parseXMLLanguageFile($path)
-	{
-		return self::parseXMLLanguageFile($path);
 	}
 
 	/**


### PR DESCRIPTION
Per roadmap, removed deprecated methods from JLanguage.
