### PR TITLE
Added JDatabaseQuery function to extract part of timestamp.

### DIFF
--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -724,6 +724,27 @@ abstract class JDatabaseQuery
 	}
 
 	/**
+ 	 * Used to get a string from date column for part (day, month, year) extraction.
+	 *
+	 * Usage:
+	 * $query->select($query->getPartOfDate($query->quoteName('dateColumn'), 'day'));
+	 * $query->select($query->getPartOfDate($query->quoteName('dateColumn'), 'month'));
+	 * $query->select($query->getPartOfDate($query->quoteName('dateColumn'), 'year'));
+	 *
+	 * @param   string  $date  Date column containing part to be extracted.
+	 * @param   string  $part  String of what part of date will be extracted.
+	 *
+	 * @return  string  Returns required string to extract part of date.
+	 *
+	 * @since   12.1
+	 */
+	public function getPartOfDate($date, $part = 'day')
+	{
+		$part = strtoupper($part);
+		return $part . '(' . $date . ')';
+	}
+
+	/**
 	 * Add a grouping column to the GROUP clause of the query.
 	 *
 	 * Usage:

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -724,24 +724,105 @@ abstract class JDatabaseQuery
 	}
 
 	/**
- 	 * Used to get a string from date column for part (day, month, year) extraction.
+	 * Used to get a string to extract year from date column.
 	 *
 	 * Usage:
-	 * $query->select($query->getPartOfDate($query->quoteName('dateColumn'), 'day'));
-	 * $query->select($query->getPartOfDate($query->quoteName('dateColumn'), 'month'));
-	 * $query->select($query->getPartOfDate($query->quoteName('dateColumn'), 'year'));
+	 * $query->select($query->year($query->quoteName('dateColumn')));
+	 * 
+	 * @param   string  $date  Date column containing year to be extracted.
 	 *
-	 * @param   string  $date  Date column containing part to be extracted.
-	 * @param   string  $part  String of what part of date will be extracted.
-	 *
-	 * @return  string  Returns required string to extract part of date.
+	 * @return  string  Returns string to extract year from a date.
 	 *
 	 * @since   12.1
 	 */
-	public function getPartOfDate($date, $part = 'day')
+	public function year($date)
 	{
-		$part = strtoupper($part);
-		return $part . '(' . $date . ')';
+		return 'YEAR(' . $date . ')';
+	}
+
+	/**
+	 * Used to get a string to extract month from date column.
+	 *
+	 * Usage:
+	 * $query->select($query->month($query->quoteName('dateColumn')));
+	 * 
+	 * @param   string  $date  Date column containing month to be extracted.
+	 *
+	 * @return  string  Returns string to extract month from a date.
+	 *
+	 * @since   12.1
+	 */
+	public function month($date)
+	{
+		return 'MONTH(' . $date . ')';
+	}
+
+	/**
+	 * Used to get a string to extract day from date column.
+	 *
+	 * Usage:
+	 * $query->select($query->day($query->quoteName('dateColumn')));
+	 * 
+	 * @param   string  $date  Date column containing day to be extracted.
+	 *
+	 * @return  string  Returns string to extract day from a date.
+	 *
+	 * @since   12.1
+	 */
+	public function day($date)
+	{
+		return 'DAY(' . $date . ')';
+	}
+
+	/**
+	 * Used to get a string to extract hour from date column.
+	 *
+	 * Usage:
+	 * $query->select($query->hour($query->quoteName('dateColumn')));
+	 * 
+	 * @param   string  $date  Date column containing hour to be extracted.
+	 *
+	 * @return  string  Returns string to extract hour from a date.
+	 *
+	 * @since   12.1
+	 */
+	public function hour($date)
+	{
+		return 'HOUR(' . $date . ')';
+	}
+
+	/**
+	 * Used to get a string to extract minute from date column.
+	 *
+	 * Usage:
+	 * $query->select($query->minute($query->quoteName('dateColumn')));
+	 * 
+	 * @param   string  $date  Date column containing minute to be extracted.
+	 *
+	 * @return  string  Returns string to extract minute from a date.
+	 *
+	 * @since   12.1
+	 */
+	public function minute($date)
+	{
+		return 'MINUTE(' . $date . ')';
+	}
+
+	/**
+	 * Used to get a string to extract seconds from date column.
+	 *
+	 * Usage:
+	 * $query->select($query->second($query->quoteName('dateColumn')));
+	 * 
+	 * @param   string  $date  Date column containing second to be extracted.
+	 *
+	 * @return  string  Returns string to extract second from a date.
+	 *
+	 * @since   12.1
+	 */
+	public function second($date)
+	{
+		return 'SECOND(' . $date . ')';
 	}
 
 	/**

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -124,6 +124,44 @@ class JDatabaseQueryTest extends JoomlaTestCase
 	}
 
 	/**
+	 * Test for parte of date extraction.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function test__toStringGetPartOfDate()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
+
+		// day case
+		$q->select($q->getPartOfDate($q->quoteName('col'), 'day'))->from('table');
+
+		$this->assertThat(
+					(string) $q,
+					$this->equalTo("\nSELECT DAY(\"col\")\nFROM table")
+		);
+
+		// month case
+		$q->clear('select');
+		$q->select($q->getPartOfDate($q->quoteName('col'), 'month'));
+
+		$this->assertThat(
+					(string) $q,
+					$this->equalTo("\nSELECT MONTH(\"col\")\nFROM table")
+		);
+
+		// year case
+		$q->clear('select');
+		$q->select($q->getPartOfDate($q->quoteName('col'), 'year'));
+
+		$this->assertThat(
+					(string) $q,
+					$this->equalTo("\nSELECT YEAR(\"col\")\nFROM table")
+		);
+	}
+
+	/**
 	 * Test for the JDatabaseQuery::__string method for a 'select' case.
 	 *
 	 * @return  void

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -139,7 +139,7 @@ class JDatabaseQueryTest extends JoomlaTestCase
 
 		$this->assertThat(
 					(string) $q,
-					$this->equalTo("\nSELECT DAY(\"col\")\nFROM table")
+					$this->equalTo("\nSELECT DAY(`col`)\nFROM table")
 		);
 
 		// month case
@@ -148,7 +148,7 @@ class JDatabaseQueryTest extends JoomlaTestCase
 
 		$this->assertThat(
 					(string) $q,
-					$this->equalTo("\nSELECT MONTH(\"col\")\nFROM table")
+					$this->equalTo("\nSELECT MONTH(`col`)\nFROM table")
 		);
 
 		// year case
@@ -157,7 +157,7 @@ class JDatabaseQueryTest extends JoomlaTestCase
 
 		$this->assertThat(
 					(string) $q,
-					$this->equalTo("\nSELECT YEAR(\"col\")\nFROM table")
+					$this->equalTo("\nSELECT YEAR(`col`)\nFROM table")
 		);
 	}
 

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -124,40 +124,116 @@ class JDatabaseQueryTest extends JoomlaTestCase
 	}
 
 	/**
-	 * Test for parte of date extraction.
+	 * Test for year extraction from date.
 	 *
 	 * @return  void
 	 *
 	 * @since   12.1
 	 */
-	public function test__toStringGetPartOfDate()
+	public function test__toStringYear()
 	{
 		$q = new JDatabaseQueryInspector($this->dbo);
 
-		// day case
-		$q->select($q->getPartOfDate($q->quoteName('col'), 'day'))->from('table');
+		$q->select($q->year($q->quoteName('col')))->from('table');
 
 		$this->assertThat(
 					(string) $q,
-					$this->equalTo("\nSELECT DAY(`col`)\nFROM table")
+					$this->equalTo("\nSELECT YEAR(`col`)\nFROM table")
 		);
+	}
 
-		// month case
-		$q->clear('select');
-		$q->select($q->getPartOfDate($q->quoteName('col'), 'month'));
+	/**
+	 * Test for month extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function test__toStringMonth()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
+
+		$q->select($q->month($q->quoteName('col')))->from('table');
 
 		$this->assertThat(
 					(string) $q,
 					$this->equalTo("\nSELECT MONTH(`col`)\nFROM table")
 		);
+	}
 
-		// year case
-		$q->clear('select');
-		$q->select($q->getPartOfDate($q->quoteName('col'), 'year'));
+	/**
+	 * Test for day extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function test__toStringDay()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
+
+		$q->select($q->day($q->quoteName('col')))->from('table');
 
 		$this->assertThat(
 					(string) $q,
-					$this->equalTo("\nSELECT YEAR(`col`)\nFROM table")
+					$this->equalTo("\nSELECT DAY(`col`)\nFROM table")
+		);
+	}
+
+	/**
+	 * Test for hour extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function test__toStringHour()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
+
+		$q->select($q->hour($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+					(string) $q,
+					$this->equalTo("\nSELECT HOUR(`col`)\nFROM table")
+		);
+	}
+
+	/**
+	 * Test for minute extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function test__toStringMinute()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
+
+		$q->select($q->minute($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+					(string) $q,
+					$this->equalTo("\nSELECT MINUTE(`col`)\nFROM table")
+		);
+	}
+
+	/**
+	 * Test for seconds extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function test__toStringSecond()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
+
+		$q->select($q->second($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+					(string) $q,
+					$this->equalTo("\nSELECT SECOND(`col`)\nFROM table")
 		);
 	}
 


### PR DESCRIPTION
This function is used to extract part of date from timestamp in a database independent manner.
Added MySQL test of element string conversion.

Usage:
$query->day($query->quoteName('dateColumn'))
for MySQL will return "DAY( dateColumn )"

$query->month($query->quoteName('dateColumn'))
for MySQL will return "MONTH( dateColumn )"

$query->year($query->quoteName('dateColumn'))
for MySQL will return "YEAR( dateColumn )"

$query->hour($query->quoteName('dateColumn'))
for MySQL will return "HOUR( dateColumn )"

$query->minute($query->quoteName('dateColumn'))
for MySQL will return "MINUTE( dateColumn )"

$query->second($query->quoteName('dateColumn'))
for MySQL will return "SECOND( dateColumn )"
