### PR TITLE
Modify JDatabaseSQLSrv::getVersion() to use sqlsrv_server_info

### DIFF
--- a/libraries/joomla/database/database/sqlsrv.php
+++ b/libraries/joomla/database/database/sqlsrv.php
@@ -473,8 +473,7 @@ class JDatabaseSQLSrv extends JDatabase
 	 */
 	public function getVersion()
 	{
-		//TODO: Don't hardcode this.
-		return '5.1.0';
+		return sqlsrv_server_info($this->connection);
 	}
 
 	/**


### PR DESCRIPTION
Per the PHP docs, the sqlsrv_server_info appears to be the equivalent PHP function to mysql_get_server_info, so I've modified the getVersion method to use this to get the appropriate information.

@sseshachala, any objections from you?
