### PR TITLE
Joomla CMS [#27780] Fixed bug causing duplicate template styles in form field

### DIFF
--- a/libraries/joomla/form/fields/templatestyle.php
+++ b/libraries/joomla/form/fields/templatestyle.php
@@ -72,7 +72,7 @@ class JFormFieldTemplateStyle extends JFormFieldGroupedList
 		}
 		$query->join('LEFT', '#__extensions as e on e.element=s.template');
 		$query->where('e.enabled=1');
-		$query->where('e.type=' . $db->quote('template'));
+		$query->where($db->quoteName('e.type') . '=' . $db->quote('template'));
 
 		// Set the query and load the styles.
 		$db->setQuery($query);

--- a/libraries/joomla/form/fields/templatestyle.php
+++ b/libraries/joomla/form/fields/templatestyle.php
@@ -72,6 +72,7 @@ class JFormFieldTemplateStyle extends JFormFieldGroupedList
 		}
 		$query->join('LEFT', '#__extensions as e on e.element=s.template');
 		$query->where('e.enabled=1');
+		$query->where('e.type=' . $db->quote('template'));
 
 		// Set the query and load the styles.
 		$db->setQuery($query);


### PR DESCRIPTION
Duplicate template styles if other type of extension exists with the same name.

I have added a filter with type=template for the query.

See http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=27780
