### PR TITLE
JLanguage: Avoid BOM error when debug, as BOM is OK when using parse_ini

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -871,6 +871,11 @@ class JLanguage extends JObject
 			while (!$stream->eof())
 			{
 				$line = $stream->gets();
+				// Avoid BOM error as BOM is OK when using parse_ini
+				if($lineNumber == 0)
+				{
+					$line = str_replace("\xEF\xBB\xBF",'',$line);
+				}
 				$lineNumber++;
 
 				// Check that the key is not in the blacklist and that the line format passes the regex.

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -872,9 +872,9 @@ class JLanguage extends JObject
 			{
 				$line = $stream->gets();
 				// Avoid BOM error as BOM is OK when using parse_ini
-				if($lineNumber == 0)
+				if ($lineNumber == 0)
 				{
-					$line = str_replace("\xEF\xBB\xBF",'',$line);
+					$line = str_replace("\xEF\xBB\xBF", '', $line);
 				}
 				$lineNumber++;
 


### PR DESCRIPTION
JLanguage: Avoid BOM error when debug, as BOM is OK when using parse_ini
