### PR TITLE
Uninstalling Language pack displays error

### DIFF
--- a/libraries/joomla/installer/adapters/package.php
+++ b/libraries/joomla/installer/adapters/package.php
@@ -462,7 +462,11 @@ class JInstallerPackage extends JAdapterInstance
 		if (!$error)
 		{
 			JFile::delete($manifestFile);
-			JFolder::delete($this->parent->getPath('extension_root'));
+			$folder = $this->parent->getPath('extension_root');
+			if (JFolder::exists($folder))
+			{
+				JFolder::delete($folder);
+			}
 			$row->delete();
 		}
 		else


### PR DESCRIPTION
Sine 2.5
JFolder: :delete: Path is not a folder. Path: ROOT/administrator/manifests/packages/fr-FR
Thanks Christophe for the patch
Creating tracker now
