### PR TITLE
Deprecate JView::escape().

### DIFF
--- a/libraries/joomla/application/component/view.php
+++ b/libraries/joomla/application/component/view.php
@@ -174,14 +174,7 @@ class JView extends JObject
 	 * Callback for escaping.
 	 *
 	 * @var string
-	 */
-	protected $escape = 'htmlspecialchars';
-
-	/**
-	 * Callback for escaping.
-	 *
-	 * @var string
-	 * @deprecated use $escape declare as private
+	 * @deprecated 13.3 Will be removed
 	 */
 	protected $_escape = 'htmlspecialchars';
 
@@ -435,6 +428,7 @@ class JView extends JObject
 	 * @return  mixed  The escaped value.
 	 *
 	 * @since   11.1
+	 * @deprecated 13.3 Use htmlspecialchars()
 	 */
 	public function escape($var)
 	{
@@ -640,6 +634,7 @@ class JView extends JObject
 	 * @return  void
 	 *
 	 * @since   11.1
+	 * @deprecated 13.3 This will be removed without a replacement
 	 */
 	public function setEscape($spec)
 	{


### PR DESCRIPTION
JView::escape() should go the way of the Dodo.

There is little gained by being able to switch between htmlspecialchars() and htmlentities() (I can't think of a situation where I'd use it). It's also a bit inconsistent since modules don't have anything similar.

Last but not least, call_user_func() is comparably slow so there should be a little speed gain when all layouts change.
