### PR TITLE
Remove deprecated code in User package

### DIFF
--- a/libraries/joomla/user/authentication.php
+++ b/libraries/joomla/user/authentication.php
@@ -12,24 +12,6 @@ defined('JPATH_PLATFORM') or die;
 jimport('joomla.event.dispatcher');
 
 /**
- * This is the status code returned when the authentication is success (permit login)
- * @deprecated Use JAuthentication::STATUS_SUCCESS
- */
-define('JAUTHENTICATE_STATUS_SUCCESS', 1);
-
-/**
- * Status to indicate cancellation of authentication (unused)
- * @deprecated
- */
-define('JAUTHENTICATE_STATUS_CANCEL', 2);
-
-/**
- * This is the status code returned when the authentication failed (prevent login if no success)
- * @deprecated Use JAuthentication::STATUS_FAILURE
- */
-define('JAUTHENTICATE_STATUS_FAILURE', 4);
-
-/**
  * Authentication class, provides an interface for the Joomla authentication system
  *
  * @package     Joomla.Platform

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -303,26 +303,6 @@ class JUser extends JObject
 	}
 
 	/**
-	 * Proxy to authorise
-	 *
-	 * @param   string  $action     The name of the action to check for permission.
-	 * @param   string  $assetname  The name of the asset on which to perform the action.
-	 *
-	 * @return  boolean  True if authorised
-	 *
-	 * @deprecated    12.1
-	 * @note    Use the authorise method instead.
-	 * @since   11.1
-	 */
-	public function authorize($action, $assetname = null)
-	{
-		// Deprecation warning.
-		JLog::add('JUser::authorize() is deprecated.', JLog::WARNING, 'deprecated');
-
-		return $this->authorise($action, $assetname);
-	}
-
-	/**
 	 * Method to check JUser object authorisation against an access control
 	 * object and optionally an access extension object
 	 *
@@ -368,23 +348,6 @@ class JUser extends JObject
 		}
 
 		return $this->isRoot ? true : JAccess::check($this->id, $action, $assetname);
-	}
-
-	/**
-	 * Gets an array of the authorised access levels for the user
-	 *
-	 * @return  array
-	 *
-	 * @deprecated  12.1
-	 * @note    Use the getAuthorisedViewLevels method instead.
-	 * @since   11.1
-	 */
-	public function authorisedLevels()
-	{
-		// Deprecation warning.
-		JLog::add('JUser::authorisedLevels() is deprecated.', JLog::WARNING, 'deprecated');
-
-		return $this->getAuthorisedViewLevels();
 	}
 
 	/**


### PR DESCRIPTION
Removes all but the `$usertype` property in JUser.  See http://groups.google.com/group/joomla-dev-platform/t/45fe515e53940db2 for discussion.
