### PR TITLE
JInstaller improvements/adjustments

### DIFF
--- a/libraries/joomla/installer/adapters/language.php
+++ b/libraries/joomla/installer/adapters/language.php
@@ -183,7 +183,7 @@ class JInstallerLanguage extends JAdapterInstance
 			// Update function available or
 			// Update tag detected
 			if ($this->parent->isUpgrade() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
-				|| is_a($updateElement, 'JXMLElement'))
+				|| $updateElement)
 			{
 				return $this->update(); // transfer control to the update function
 			}

--- a/libraries/joomla/installer/adapters/module.php
+++ b/libraries/joomla/installer/adapters/module.php
@@ -243,7 +243,7 @@ class JInstallerModule extends JAdapterInstance
 			// Update function available or
 			// Update tag detected
 			if ($this->parent->isUpgrade() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
-				|| is_a($updateElement, 'JXMLElement'))
+				|| $updateElement)
 			{
 				// Force this one
 				$this->parent->setOverwrite(true);

--- a/libraries/joomla/installer/adapters/package.php
+++ b/libraries/joomla/installer/adapters/package.php
@@ -179,7 +179,8 @@ class JInstallerPackage extends JAdapterInstance
 					$package = JInstallerHelper::unpack($file);
 				}
 				$tmpInstaller = new JInstaller;
-				if (!$tmpInstaller->install($package['dir']))
+				$installResult = $tmpInstaller->install($package['dir']);
+				if (!$installResult)
 				{
 					$this->parent->abort(
 						JText::sprintf(
@@ -193,7 +194,7 @@ class JInstallerPackage extends JAdapterInstance
 				{
 					$results[$i] = array(
 						'name' => $tmpInstaller->manifest->name,
-						'result' => $tmpInstaller->install($package['dir'])
+						'result' => $installResult
 					);
 				}
 				$i++;

--- a/libraries/joomla/installer/adapters/plugin.php
+++ b/libraries/joomla/installer/adapters/plugin.php
@@ -210,7 +210,7 @@ class JInstallerPlugin extends JAdapterInstance
 			// Update function available or
 			// Update tag detected
 			if ($this->parent->isUpgrade() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
-				|| is_a($updateElement, 'JXMLElement'))
+				|| $updateElement)
 			{
 				// Force this one
 				$this->parent->setOverwrite(true);

--- a/libraries/joomla/installer/adapters/template.php
+++ b/libraries/joomla/installer/adapters/template.php
@@ -80,7 +80,7 @@ class JInstallerTemplate extends JAdapterInstance
 	{
 		// Get a database connector object
 		$db = $this->parent->getDbo();
-		
+
 		$lang = JFactory::getLanguage();
 		$xml = $this->parent->getManifest();
 
@@ -111,13 +111,13 @@ class JInstallerTemplate extends JAdapterInstance
 		$element = strtolower(str_replace(" ", "_", $name));
 		$this->set('name', $name);
 		$this->set('element', $element);
-		
+
 		// Check to see if a template by the same name is already installed.
 		$query = $db->getQuery(true);
 		$query->select($query->qn('extension_id'))->from($query->qn('#__extensions'));
 		$query->where($query->qn('type') . ' = ' . $query->q('template'));
 		$query->where($query->qn('element') . ' = ' . $query->q($element));
-		$db->setQuery($query);	
+		$db->setQuery($query);
 
 		try
 		{

--- a/libraries/joomla/installer/adapters/template.php
+++ b/libraries/joomla/installer/adapters/template.php
@@ -121,16 +121,23 @@ class JInstallerTemplate extends JAdapterInstance
 
 		try
 		{
-			$db->Query();
+			$id = $db->loadResult();
 		}
-		catch (JException $e)
+		catch (JDatabaseException $e)
 		{
 			// Install failed, roll back changes
-			$this->parent
-			->abort(JText::sprintf('JLIB_INSTALLER_ABORT_TPL_INSTALL_ROLLBACK', JText::_('JLIB_INSTALLER_' . $this->route), $db->stderr(true)));
+			$this->parent->abort(JText::sprintf('JLIB_INSTALLER_ABORT_TPL_INSTALL_ROLLBACK'), $e->getMessage());
 			return false;
 		}
-		$id = $db->loadResult();
+
+		// Legacy error handling switch based on the JError::$legacy switch.
+		// @deprecated  12.1
+		if (JError::$legacy && $db->getErrorNum())
+		{
+			// Install failed, roll back changes
+			$this->parent->abort(JText::sprintf('JLIB_INSTALLER_ABORT_TPL_INSTALL_ROLLBACK', $db->stderr(true)));
+			return false;
+		}
 
 		// Set the template root path
 		$this->parent->setPath('extension_root', $basePath . '/templates/' . $element);

--- a/libraries/joomla/installer/adapters/template.php
+++ b/libraries/joomla/installer/adapters/template.php
@@ -127,7 +127,7 @@ class JInstallerTemplate extends JAdapterInstance
 		{
 			// Install failed, roll back changes
 			$this->parent
-			->abort(JText::sprintf('JLIB_INSTALLER_ABORT_PLG_INSTALL_ROLLBACK', JText::_('JLIB_INSTALLER_' . $this->route), $db->stderr(true)));
+			->abort(JText::sprintf('JLIB_INSTALLER_ABORT_TPL_INSTALL_ROLLBACK', JText::_('JLIB_INSTALLER_' . $this->route), $db->stderr(true)));
 			return false;
 		}
 		$id = $db->loadResult();
@@ -161,7 +161,7 @@ class JInstallerTemplate extends JAdapterInstance
 				$this->parent
 					->abort(
 					JText::sprintf(
-						'JLIB_INSTALLER_ABORT_PLG_INSTALL_DIRECTORY', JText::_('JLIB_INSTALLER_' . $this->route),
+						'JLIB_INSTALLER_ABORT_TPL_INSTALL_ANOTHER_TEMPLATE_USING_DIRECTORY', JText::_('JLIB_INSTALLER_' . $this->route),
 						$this->parent->getPath('extension_root')
 					)
 				);

--- a/libraries/joomla/installer/adapters/template.php
+++ b/libraries/joomla/installer/adapters/template.php
@@ -143,7 +143,7 @@ class JInstallerTemplate extends JAdapterInstance
 			// Update function available or
 			// Update tag detected
 			if ($this->parent->isUpgrade() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
-				|| is_a($updateElement, 'JXMLElement'))
+				|| $updateElement)
 			{
 				// Force this one
 				$this->parent->setOverwrite(true);


### PR DESCRIPTION
1. The package adapter executes the install method twice. This can insert dublicate database entries.
   See: http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=27802
2. On some install adapters a check is_a($updateElement, 'JXMLElement') return always true and force an update. This is not desirable.
3. The template install adapter never return an existing extension id (setQuery was not set). This forces and update also and create dublicate database entries in the extensions table (also template styles). Updated query with exception and direct rollback.
