### PR TITLE
Remove legacy code from Installer package

### DIFF
--- a/libraries/joomla/installer/adapters/component.php
+++ b/libraries/joomla/installer/adapters/component.php
@@ -45,7 +45,6 @@ class JInstallerComponent extends JAdapterInstance
 	protected $element = null;
 
 	/**
-	 *
 	 * The list of current files fo the Joomla! CMS administrator that are installed and is read
 	 * from the manifest on disk in the update area to handle doing a diff
 	 * and deleting files that are in the old files list and not in the new
@@ -423,35 +422,6 @@ class JInstallerComponent extends JAdapterInstance
 		 * install method, and append the return value from the custom install
 		 * method to the installation message.
 		 */
-		// Start legacy support
-		if ($this->get('install_script'))
-		{
-			if (is_file($this->parent->getPath('extension_administrator') . '/' . $this->get('install_script')) || $this->parent->isOverwrite())
-			{
-				$notdef = false;
-				$ranwell = false;
-				ob_start();
-				ob_implicit_flush(false);
-
-				require_once $this->parent->getPath('extension_administrator') . '/' . $this->get('install_script');
-
-				if (function_exists('com_install'))
-				{
-					if (com_install() === false)
-					{
-						$this->parent->abort(JText::_('JLIB_INSTALLER_ABORT_COMP_INSTALL_CUSTOM_INSTALL_FAILURE'));
-
-						return false;
-					}
-				}
-
-				$msg .= ob_get_contents(); // append messages
-				ob_end_clean();
-			}
-		}
-
-		// End legacy support
-		// Start Joomla! 1.6
 		ob_start();
 		ob_implicit_flush(false);
 
@@ -872,39 +842,6 @@ class JInstallerComponent extends JAdapterInstance
 		 * install method, and append the return value from the custom install
 		 * method to the installation message.
 		 */
-		// Start legacy support
-		if ($this->get('install_script'))
-		{
-			if (is_file($this->parent->getPath('extension_administrator') . '/' . $this->get('install_script')) || $this->parent->isOverwrite())
-			{
-				$notdef = false;
-				$ranwell = false;
-				ob_start();
-				ob_implicit_flush(false);
-
-				require_once $this->parent->getPath('extension_administrator') . '/' . $this->get('install_script');
-
-				if (function_exists('com_install'))
-				{
-					if (com_install() === false)
-					{
-						$this->parent->abort(JText::_('JLIB_INSTALLER_ABORT_COMP_INSTALL_CUSTOM_INSTALL_FAILURE'));
-
-						return false;
-					}
-				}
-
-				$msg .= ob_get_contents(); // append messages
-				ob_end_clean();
-			}
-		}
-
-		/*
-		 * If we have an update script, let's include it, execute the custom
-		 * update method, and append the return value from the custom update
-		 * method to the installation message.
-		 */
-		// Start Joomla! 1.6
 		ob_start();
 		ob_implicit_flush(false);
 
@@ -1125,40 +1062,6 @@ class JInstallerComponent extends JAdapterInstance
 
 		$msg = ob_get_contents();
 		ob_end_clean();
-
-		/**
-		 * ---------------------------------------------------------------------------------------------
-		 * Custom Uninstallation Script Section; Legacy CMS 1.5 Support
-		 * ---------------------------------------------------------------------------------------------
-		 */
-
-		// Now let's load the uninstall file if there is one and execute the uninstall function if it exists.
-		$uninstallFile = (string) $this->manifest->uninstallfile;
-
-		if ($uninstallFile)
-		{
-			// Element exists, does the file exist?
-			if (is_file($this->parent->getPath('extension_administrator') . '/' . $uninstallFile))
-			{
-				ob_start();
-				ob_implicit_flush(false);
-
-				require_once $this->parent->getPath('extension_administrator') . '/' . $uninstallFile;
-
-				if (function_exists('com_uninstall'))
-				{
-					if (com_uninstall() === false)
-					{
-						JError::raiseWarning(100, JText::_('JLIB_INSTALLER_ERROR_COMP_UNINSTALL_CUSTOM'));
-						$retval = false;
-					}
-				}
-
-				// append this in case there was something else
-				$msg .= ob_get_contents();
-				ob_end_clean();
-			}
-		}
 
 		if ($msg != '')
 		{
@@ -1806,34 +1709,6 @@ class JInstallerComponent extends JAdapterInstance
 		 * install method, and append the return value from the custom install
 		 * method to the installation message.
 		 */
-		// start legacy support
-		if ($this->get('install_script'))
-		{
-
-			if (is_file($this->parent->getPath('extension_administrator') . '/' . $this->get('install_script')))
-			{
-				ob_start();
-				ob_implicit_flush(false);
-
-				require_once $this->parent->getPath('extension_administrator') . '/' . $this->get('install_script');
-
-				if (function_exists('com_install'))
-				{
-
-					if (com_install() === false)
-					{
-						$this->parent->abort(JText::_('JLIB_INSTALLER_ABORT_COMP_INSTALL_CUSTOM_INSTALL_FAILURE'));
-						return false;
-					}
-				}
-				// Append messages
-				$msg .= ob_get_contents();
-				ob_end_clean();
-			}
-		}
-		// End legacy support
-
-		// Start Joomla! 1.6
 		ob_start();
 		ob_implicit_flush(false);
 

--- a/libraries/joomla/installer/adapters/language.php
+++ b/libraries/joomla/installer/adapters/language.php
@@ -54,24 +54,7 @@ class JInstallerLanguage extends JAdapterInstance
 		$root = $this->manifest->document;
 
 		// Get the client application target
-		if ((string) $this->manifest->attributes()->client == 'both')
-		{
-			JError::raiseWarning(42, JText::_('JLIB_INSTALLER_ERROR_DEPRECATED_FORMAT'));
-			$element = $this->manifest->site->files;
-			if (!$this->_install('site', JPATH_SITE, 0, $element))
-			{
-				return false;
-			}
-
-			$element = $this->manifest->administration->files;
-			if (!$this->_install('administrator', JPATH_ADMINISTRATOR, 1, $element))
-			{
-				return false;
-			}
-			// This causes an issue because we have two eid's, *sigh* nasty hacks!
-			return true;
-		}
-		elseif ($cname = (string) $this->manifest->attributes()->client)
+		if ($cname = (string) $this->manifest->attributes()->client)
 		{
 			// Attempt to map the client to a base path
 			$client = JApplicationHelper::getClientInfo($cname, true);

--- a/libraries/joomla/installer/adapters/plugin.php
+++ b/libraries/joomla/installer/adapters/plugin.php
@@ -141,7 +141,7 @@ class JInstallerPlugin extends JAdapterInstance
 		$name = JFilterInput::getInstance()->clean($name, 'string');
 		$this->set('name', $name);
 
-		// Get the component description
+		// Get the plugin description
 		$description = (string) $xml->description;
 		if ($description)
 		{
@@ -558,21 +558,10 @@ class JInstallerPlugin extends JAdapterInstance
 		}
 
 		// Set the plugin root path
-		if (is_dir(JPATH_PLUGINS . '/' . $row->folder . '/' . $row->element))
-		{
-			// Use 1.6 plugins
-			$this->parent->setPath('extension_root', JPATH_PLUGINS . '/' . $row->folder . '/' . $row->element);
-		}
-		else
-		{
-			// Use Legacy 1.5 plugins
-			$this->parent->setPath('extension_root', JPATH_PLUGINS . '/' . $row->folder);
-		}
+		$this->parent->setPath('extension_root', JPATH_PLUGINS . '/' . $row->folder . '/' . $row->element);
 
-		// Because 1.5 plugins don't have their own folders we cannot use the standard method of finding an installation manifest
-		// Since 1.6 they do, however until we move to 1.7 and remove 1.6 legacy we still need to use this method.
-		// When we get there it'll be something like "$this->parent->findManifest();$manifest = $this->parent->getManifest();"
-		$manifestFile = $this->parent->getPath('extension_root') . '/' . $row->element . '.xml';
+		$this->parent->findManifest();
+		$manifestFile = $this->parent->getManifest();
 
 		if (!file_exists($manifestFile))
 		{


### PR DESCRIPTION
Changes made:
- Component adapter: Dropped support for com_install and com_uninstall
- Language adapter: Support for client=both in metafile tag
- Plugin adapter: Removed code which checked for plugins with CMS 1.5 file structure
