### PR TITLE
Fix bug in countMenuChildren

### DIFF
--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -493,7 +493,7 @@ class JDocumentHTML extends JDocument
 			$active = $menu->getActive();
 			if ($active)
 			{
-				$query = dbo->getQuery(true);
+				$query = $dbo->getQuery(true);
 				$query->select('COUNT(*)');
 				$query->from('#__menu');
 				$query->where('parent = ' . $active->id);

--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -493,11 +493,11 @@ class JDocumentHTML extends JDocument
 			$active = $menu->getActive();
 			if ($active)
 			{
-				$query->getQuery(true);
-				$query->select('COUNT(*)');
-				$query->from('#__menu');
-				$query->where('parent = ' . $active->id);
-				$query->where('published = 1');
+				$dbo->getQuery(true);
+				$dbo->select('COUNT(*)');
+				$dbo->from('#__menu');
+				$dbo->where('parent = ' . $active->id);
+				$dbo->where('published = 1');
 				$children = $dbo->loadResult();
 			}
 			else

--- a/libraries/joomla/document/html/html.php
+++ b/libraries/joomla/document/html/html.php
@@ -493,11 +493,11 @@ class JDocumentHTML extends JDocument
 			$active = $menu->getActive();
 			if ($active)
 			{
-				$dbo->getQuery(true);
-				$dbo->select('COUNT(*)');
-				$dbo->from('#__menu');
-				$dbo->where('parent = ' . $active->id);
-				$dbo->where('published = 1');
+				$query = dbo->getQuery(true);
+				$query->select('COUNT(*)');
+				$query->from('#__menu');
+				$query->where('parent = ' . $active->id);
+				$query->where('published = 1');
 				$children = $dbo->loadResult();
 			}
 			else


### PR DESCRIPTION
$query was generating an undefined variable error notice and then a fatal error notice because it is not defined previously in that method. After changing that on my site, which I had just upgraded to 2.5.0, it started working again.
