### PR TITLE
Provide a replacement for the deprecated JRequest::checkToken() in JSession.

### DIFF
--- a/libraries/joomla/application/component/controlleradmin.php
+++ b/libraries/joomla/application/component/controlleradmin.php
@@ -227,7 +227,7 @@ class JControllerAdmin extends JController
 	public function reorder()
 	{
 		// Check for request forgeries.
-		JRequest::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
+		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
 		// Initialise variables.
 		$ids = JRequest::getVar('cid', null, 'post', 'array');
@@ -261,7 +261,7 @@ class JControllerAdmin extends JController
 	public function saveorder()
 	{
 		// Check for request forgeries.
-		JRequest::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
+		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
 		// Get the input
 		$pks = JRequest::getVar('cid', null, 'post', 'array');
@@ -303,7 +303,7 @@ class JControllerAdmin extends JController
 	public function checkin()
 	{
 		// Check for request forgeries.
-		JRequest::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
+		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
 		// Initialise variables.
 		$ids = JRequest::getVar('cid', null, 'post', 'array');

--- a/libraries/joomla/application/component/controllerform.php
+++ b/libraries/joomla/application/component/controllerform.php
@@ -297,7 +297,7 @@ class JControllerForm extends JController
 	 */
 	public function cancel($key = null)
 	{
-		JRequest::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
+		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
 		// Initialise variables.
 		$app = JFactory::getApplication();
@@ -557,7 +557,7 @@ class JControllerForm extends JController
 	public function save($key = null, $urlVar = null)
 	{
 		// Check for request forgeries.
-		JRequest::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
+		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
 		// Initialise variables.
 		$app = JFactory::getApplication();

--- a/libraries/joomla/environment/request.php
+++ b/libraries/joomla/environment/request.php
@@ -504,7 +504,7 @@ class JRequest
 	 *
 	 * @return  boolean  True if found and valid, false otherwise.
 	 *
-	 * @deprecated  12.1
+	 * @deprecated  12.1 Use JSession::checkToken() instead.
 	 * @since       11.1
 	 */
 	public static function checkToken($method = 'post')

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -257,6 +257,42 @@ class JSession extends JObject
 	}
 
 	/**
+	 * Checks for a form token in the request.
+	 *
+	 * Use in conjunction with JHtml::_('form.token') or JSession::getFormToken.
+	 *
+	 * @param   string  $method  The request method in which to look for the token key.
+	 *
+	 * @return  boolean  True if found and valid, false otherwise.
+	 *
+	 * @since       12.1
+	 */
+	public static function checkToken($method = 'post')
+	{
+		$token = self::getFormToken();
+		$app = JFactory::getApplication();
+
+		if (!$app->input->$method->get($token, '', 'alnum'))
+		{
+			$session = JFactory::getSession();
+			if ($session->isNew())
+			{
+				// Redirect to login screen.
+				$app->redirect(JRoute::_('index.php'), JText::_('JLIB_ENVIRONMENT_SESSION_EXPIRED'));
+				$app->close();
+			}
+			else
+			{
+				return false;
+			}
+		}
+		else
+		{
+			return true;
+		}
+	}
+
+	/**
 	 * Get session name
 	 *
 	 * @return  string  The session name


### PR DESCRIPTION
This uses JInput so there's no dependency on JRequest introduced.
