### PR TITLE
Remove the deprecated JError::isError().

### DIFF
--- a/libraries/joomla/error/error.php
+++ b/libraries/joomla/error/error.php
@@ -62,27 +62,6 @@ abstract class JError
 	protected static $stack = array();
 
 	/**
-	 * Method to determine if a value is an exception object.  This check supports
-	 * both JException and PHP5 Exception objects
-	 *
-	 * @param   mixed  &$object  Object to check
-	 *
-	 * @return  boolean  True if argument is an exception, false otherwise.
-	 *
-	 * @since   11.1
-	 *
-	 * @deprecated  12.1
-	 */
-	public static function isError(& $object)
-	{
-		// Deprecation warning.
-		JLog::add('JError::isError() is deprecated.', JLog::WARNING, 'deprecated');
-
-		// Supports PHP 5 exception handling
-		return $object instanceof Exception;
-	}
-
-	/**
 	 * Method for retrieving the last exception object in the error stack
 	 *
 	 * @param   boolean  $unset  True to remove the error from the stack.

--- a/tests/includes/JoomlaDatabaseTestCase.php
+++ b/tests/includes/JoomlaDatabaseTestCase.php
@@ -197,7 +197,7 @@ abstract class JoomlaDatabaseTestCase extends PHPUnit_Extensions_Database_TestCa
 			{
 			}
 
-			if (JError::isError(self::$dbo))
+			if (self::$dbo instanceof Exception)
 			{
 				//ignore errors
 				define('DB_NOT_AVAILABLE', true);

--- a/tests/suite/joomla/error/JErrorTest.php
+++ b/tests/suite/joomla/error/JErrorTest.php
@@ -36,16 +36,6 @@ class JErrorTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @todo Implement testIsError().
-     */
-    public function testIsError() {
-        // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-                'This test has not been implemented yet.'
-        );
-    }
-
-    /**
      * @todo Implement testGetError().
      */
     public function testGetError() {


### PR DESCRIPTION
We probably need to keep JError for a while since it is used all over the place but the isError() method is easy to replace and can be safely removed.
