### PR TITLE
Update libraries/joomla/database/database.php

### DIFF
--- a/libraries/joomla/database/database.php
+++ b/libraries/joomla/database/database.php
@@ -9,7 +9,7 @@
 
 defined('JPATH_PLATFORM') or die;
 
-JLoader::register('JDatabaseException', JPATH_PLATFORM . '/joomla/database/databaseexception.php');
+JLoader::register('JDatabaseException', JPATH_PLATFORM . '/joomla/database/exception.php');
 jimport('joomla.filesystem.folder');
 
 /**


### PR DESCRIPTION
databaseexception.php no longer exists, has been renamed to exception.php.
