### PR TITLE
Update libraries/joomla/html/html/tabs.php

### DIFF
--- a/libraries/joomla/html/html/tabs.php
+++ b/libraries/joomla/html/html/tabs.php
@@ -76,7 +76,7 @@ abstract class JHtmlTabs
 	{
 		static $loaded = array();
 
-		if (!array_key_exists($group, $loaded))
+		if (!array_key_exists((string) $group, $loaded))
 		{
 			// Include MooTools framework
 			JHtml::_('behavior.framework', true);
@@ -114,7 +114,7 @@ abstract class JHtmlTabs
 			$document->addScriptDeclaration($js);
 			JHtml::_('script', 'system/tabs.js', false, true);
 
-			$loaded[$group] = true;
+			$loaded[(string) $group] = true;
 		}
 	}
 }


### PR DESCRIPTION
$group var in libraries/joomla/html/html/tabs.php needs to be typed (string) to avoid  warnings in certain use cases.

This issue has been posted to the Joomla! CMS Issue Tracker and can be found at the following link.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=27958
