### PR TITLE
Use JApplicationBase as the foundation for JApplication as well.

### DIFF
--- a/libraries/joomla/application/application.php
+++ b/libraries/joomla/application/application.php
@@ -9,7 +9,6 @@
 
 defined('JPATH_PLATFORM') or die;
 
-jimport('joomla.event.dispatcher');
 jimport('joomla.environment.response');
 
 /**
@@ -23,8 +22,7 @@ jimport('joomla.environment.response');
  * @subpackage  Application
  * @since       11.1
  */
-
-class JApplication extends JObject
+class JApplication extends JApplicationBase
 {
 	/**
 	 * The client identifier.
@@ -102,14 +100,6 @@ class JApplication extends JObject
 	public $startTime = null;
 
 	/**
-	 * The application input object.
-	 *
-	 * @var    JInput
-	 * @since  11.2
-	 */
-	public $input = null;
-
-	/**
 	 * @var    array  JApplication instances container.
 	 * @since  11.3
 	 */
@@ -171,6 +161,8 @@ class JApplication extends JObject
 		{
 			$this->_createSession(self::getHash($config['session_name']));
 		}
+
+		$this->loadDispatcher();
 
 		$this->set('requestTime', gmdate('Y-m-d H:i'));
 
@@ -341,20 +333,6 @@ class JApplication extends JObject
 
 		// Trigger the onAfterRender event.
 		$this->triggerEvent('onAfterRender');
-	}
-
-	/**
-	 * Exit the application.
-	 *
-	 * @param   integer  $code  Exit code
-	 *
-	 * @return  void     Exits the application.
-	 *
-	 * @since    11.1
-	 */
-	public function close($code = 0)
-	{
-		exit($code);
 	}
 
 	/**
@@ -636,39 +614,6 @@ class JApplication extends JObject
 		}
 
 		return $new_state;
-	}
-
-	/**
-	 * Registers a handler to a particular event group.
-	 *
-	 * @param   string  $event    The event name.
-	 * @param   mixed   $handler  The handler, a function or an instance of a event object.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.1
-	 */
-	public static function registerEvent($event, $handler)
-	{
-		$dispatcher = JDispatcher::getInstance();
-		$dispatcher->register($event, $handler);
-	}
-
-	/**
-	 * Calls all handlers associated with an event group.
-	 *
-	 * @param   string  $event  The event name.
-	 * @param   array   $args   An array of arguments.
-	 *
-	 * @return  array  An array of results from each function call.
-	 *
-	 * @since   11.1
-	 */
-	public function triggerEvent($event, $args = null)
-	{
-		$dispatcher = JDispatcher::getInstance();
-
-		return $dispatcher->trigger($event, $args);
 	}
 
 	/**

--- a/libraries/joomla/application/base.php
+++ b/libraries/joomla/application/base.php
@@ -18,7 +18,7 @@ jimport('joomla.event.dispatcher');
  * @subpackage  Application
  * @since       12.1
  */
-abstract class JApplicationBase
+abstract class JApplicationBase extends JObject
 {
 	/**
 	 * The application input object.
@@ -26,23 +26,7 @@ abstract class JApplicationBase
 	 * @var    JInput
 	 * @since  12.1
 	 */
-	public $input;
-
-	/**
-	 * The application configuration object.
-	 *
-	 * @var    JRegistry
-	 * @since  12.1
-	 */
-	protected $config;
-
-	/**
-	 * The character encoding string.
-	 *
-	 * @var    string
-	 * @since  12.1
-	 */
-	protected $charSet = 'utf-8';
+	public $input = null;
 
 	/**
 	 * The application dispatcher object.
@@ -51,14 +35,6 @@ abstract class JApplicationBase
 	 * @since  12.1
 	 */
 	protected $dispatcher;
-
-	/**
-	 * The application instance.
-	 *
-	 * @var    JApplicationBase
-	 * @since  12.1
-	 */
-	protected static $instance;
 
 	/**
 	 * Method to close the application.
@@ -72,66 +48,6 @@ abstract class JApplicationBase
 	public function close($code = 0)
 	{
 		exit($code);
-	}
-
-	/**
-	 * Method to execute the application.
-	 *
-	 * @return  void
-	 *
-	 * @since   12.1
-	 */
-	abstract public function execute();
-
-	/**
-	 * Method to get a property of the application or the default value if the property is not set.
-	 *
-	 * @param   string  $key      The name of the property.
-	 * @param   mixed   $default  The default value (optional) if none is set.
-	 *
-	 * @return  mixed   The value of the configuration.
-	 *
-	 * @since   12.1
-	 */
-	public function get($key, $default = null)
-	{
-		return $this->config->get($key, $default);
-	}
-
-	/**
-	 * Method to get the application character set.
-	 *
-	 * @return  string  The character set.
-	 *
-	 * @since   12.1
-	 */
-	public function getCharacterSet()
-	{
-		return $this->charSet;
-	}
-
-	/**
-	 * Method to load an object or array into the application configuration object.
-	 *
-	 * @param   mixed  $data  Either an array or object to be loaded into the configuration object.
-	 *
-	 * @return  JApplicationBase  The application to allow chaining.
-	 *
-	 * @since   12.1
-	 */
-	public function loadConfiguration($data)
-	{
-		// Load the data into the configuration object.
-		if (is_array($data))
-		{
-			$this->config->loadArray($data);
-		}
-		elseif (is_object($data))
-		{
-			$this->config->loadObject($data);
-		}
-
-		return $this;
 	}
 
 	/**
@@ -155,40 +71,6 @@ abstract class JApplicationBase
 	}
 
 	/**
-	 * Method to set a property of the application, creating it if it does not already exist.
-	 *
-	 * @param   string  $key    The name of the property.
-	 * @param   mixed   $value  The value of the property to set (optional).
-	 *
-	 * @return  mixed   Previous value of the property
-	 *
-	 * @since   12.1
-	 */
-	public function set($key, $value = null)
-	{
-		$previous = $this->config->get($key);
-		$this->config->set($key, $value);
-
-		return $previous;
-	}
-
-	/**
-	 * Method to set the application character set.
-	 *
-	 * @param   string  $charset  The character set.
-	 *
-	 * @return  JApplicationBase  The application to allow chaining.
-	 *
-	 * @since   12.1
-	 */
-	public function setCharacterSet($charset)
-	{
-		$this->charSet = $charset;
-
-		return $this;
-	}
-
-	/**
 	 * Calls all handlers associated with an event group.
 	 *
 	 * @param   string  $event  The event name.
@@ -206,53 +88,6 @@ abstract class JApplicationBase
 		}
 
 		return null;
-	}
-
-	/**
-	 * Method to load a PHP configuration class file based on convention and return the instantiated data object.  You
-	 * will extend this method in child classes to provide configuration data from whatever data source is relevant
-	 * for your specific application.
-	 *
-	 * @param   string  $file   The path and filename of the configuration file. If not provided, configuration.php
-	 *                          in JPATH_BASE will be used.
-	 * @param   string  $class  The class name to instantiate.
-	 *
-	 * @return  mixed   Either an array or object to be loaded into the configuration object.
-	 *
-	 * @since   12.1
-	 */
-	protected function fetchConfigurationData($file = '', $class = 'JConfig')
-	{
-		// Instantiate variables.
-		$config = array();
-
-		if (empty($file) && defined('JPATH_BASE'))
-		{
-			$file = JPATH_BASE . '/configuration.php';
-
-			// Applications can choose not to have any configuration data
-			// by not implementing this method and not having a config file.
-			if (!file_exists($file))
-			{
-				$file = '';
-			}
-		}
-
-		if (!empty($file))
-		{
-			JLoader::register($class, $file);
-
-			if (class_exists($class))
-			{
-				$config = new $class;
-			}
-			else
-			{
-				throw new RuntimeException('Configuration class does not exist.');
-			}
-		}
-
-		return $config;
 	}
 
 	/**

--- a/libraries/joomla/application/cli.php
+++ b/libraries/joomla/application/cli.php
@@ -19,6 +19,18 @@ defined('JPATH_PLATFORM') or die;
 class JApplicationCli extends JApplicationBase
 {
 	/**
+	 * @var    JRegistry  The application configuration object.
+	 * @since  11.1
+	 */
+	protected $config;
+
+	/**
+	 * @var    JApplicationCli  The application instance.
+	 * @since  11.1
+	 */
+	protected static $instance;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param   mixed  $input       An optional argument to provide dependency injection for the application's
@@ -93,6 +105,21 @@ class JApplicationCli extends JApplicationBase
 	}
 
 	/**
+	 * Returns a property of the object or the default value if the property is not set.
+	 *
+	 * @param   string  $key      The name of the property.
+	 * @param   mixed   $default  The default value (optional) if none is set.
+	 *
+	 * @return  mixed   The value of the configuration.
+	 *
+	 * @since   11.3
+	 */
+	public function get($key, $default = null)
+	{
+		return $this->config->get($key, $default);
+	}
+
+	/**
 	 * Returns a reference to the global JApplicationCli object, only creating it if it doesn't already exist.
 	 *
 	 * This method must be invoked as: $cli = JApplicationCli::getInstance();
@@ -141,16 +168,27 @@ class JApplicationCli extends JApplicationBase
 	}
 
 	/**
-	 * Get a value from standard input.
+	 * Load an object or array into the application configuration object.
 	 *
-	 * @return  string  The input string from standard input.
+	 * @param   mixed  $data  Either an array or object to be loaded into the configuration object.
 	 *
-	 * @codeCoverageIgnore
+	 * @return  JApplicationCli  Instance of $this to allow chaining.
+	 *
 	 * @since   11.1
 	 */
-	public function in()
+	public function loadConfiguration($data)
 	{
-		return rtrim(fread(STDIN, 8192), "\n");
+		// Load the data into the configuration object.
+		if (is_array($data))
+		{
+			$this->config->loadArray($data);
+		}
+		elseif (is_object($data))
+		{
+			$this->config->loadObject($data);
+		}
+
+		return $this;
 	}
 
 	/**
@@ -169,6 +207,84 @@ class JApplicationCli extends JApplicationBase
 		fwrite(STDOUT, $text . ($nl ? "\n" : null));
 
 		return $this;
+	}
+
+	/**
+	 * Get a value from standard input.
+	 *
+	 * @return  string  The input string from standard input.
+	 *
+	 * @codeCoverageIgnore
+	 * @since   11.1
+	 */
+	public function in()
+	{
+		return rtrim(fread(STDIN, 8192), "\n");
+	}
+
+	/**
+	 * Modifies a property of the object, creating it if it does not already exist.
+	 *
+	 * @param   string  $key    The name of the property.
+	 * @param   mixed   $value  The value of the property to set (optional).
+	 *
+	 * @return  mixed   Previous value of the property
+	 *
+	 * @since   11.3
+	 */
+	public function set($key, $value = null)
+	{
+		$previous = $this->config->get($key);
+		$this->config->set($key, $value);
+
+		return $previous;
+	}
+
+	/**
+	 * Method to load a PHP configuration class file based on convention and return the instantiated data object.  You
+	 * will extend this method in child classes to provide configuration data from whatever data source is relevant
+	 * for your specific application.
+	 *
+	 * @param   string  $file   The path and filename of the configuration file. If not provided, configuration.php
+	 *                          in JPATH_BASE will be used.
+	 * @param   string  $class  The class name to instantiate.
+	 *
+	 * @return  mixed   Either an array or object to be loaded into the configuration object.
+	 *
+	 * @since   11.1
+	 */
+	protected function fetchConfigurationData($file = '', $class = 'JConfig')
+	{
+		// Instantiate variables.
+		$config = array();
+
+		if (empty($file) && defined('JPATH_BASE'))
+		{
+			$file = JPATH_BASE . '/configuration.php';
+
+			// Applications can choose not to have any configuration data
+			// by not implementing this method and not having a config file.
+			if (!file_exists($file))
+			{
+				$file = '';
+			}
+		}
+
+		if (!empty($file))
+		{
+			JLoader::register($class, $file);
+
+			if (class_exists($class))
+			{
+				$config = new $class;
+			}
+			else
+			{
+				throw new RuntimeException('Configuration class does not exist.');
+			}
+		}
+
+		return $config;
 	}
 
 	/**

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -22,6 +22,12 @@ jimport('joomla.environment.uri');
 class JApplicationWeb extends JApplicationBase
 {
 	/**
+	 * @var    string  Character encoding string.
+	 * @since  11.3
+	 */
+	public $charSet = 'utf-8';
+
+	/**
 	 * @var    string  Response mime type.
 	 * @since  11.3
 	 */
@@ -38,6 +44,12 @@ class JApplicationWeb extends JApplicationBase
 	 * @since  11.3
 	 */
 	public $client;
+
+	/**
+	 * @var    JRegistry  The application configuration object.
+	 * @since  11.3
+	 */
+	protected $config;
 
 	/**
 	 * @var    JDocument  The application document object.
@@ -574,6 +586,63 @@ class JApplicationWeb extends JApplicationBase
 	}
 
 	/**
+	 * Load an object or array into the application configuration object.
+	 *
+	 * @param   mixed  $data  Either an array or object to be loaded into the configuration object.
+	 *
+	 * @return  JApplicationWeb  Instance of $this to allow chaining.
+	 *
+	 * @since   11.3
+	 */
+	public function loadConfiguration($data)
+	{
+		// Load the data into the configuration object.
+		if (is_array($data))
+		{
+			$this->config->loadArray($data);
+		}
+		elseif (is_object($data))
+		{
+			$this->config->loadObject($data);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Returns a property of the object or the default value if the property is not set.
+	 *
+	 * @param   string  $key      The name of the property.
+	 * @param   mixed   $default  The default value (optional) if none is set.
+	 *
+	 * @return  mixed   The value of the configuration.
+	 *
+	 * @since   11.3
+	 */
+	public function get($key, $default = null)
+	{
+		return $this->config->get($key, $default);
+	}
+
+	/**
+	 * Modifies a property of the object, creating it if it does not already exist.
+	 *
+	 * @param   string  $key    The name of the property.
+	 * @param   mixed   $value  The value of the property to set (optional).
+	 *
+	 * @return  mixed   Previous value of the property
+	 *
+	 * @since   11.3
+	 */
+	public function set($key, $value = null)
+	{
+		$previous = $this->config->get($key);
+		$this->config->set($key, $value);
+
+		return $previous;
+	}
+
+	/**
 	 * Set/get cachable state for the response.  If $allow is set, sets the cachable state of the
 	 * response.  Always returns the current state.
 	 *
@@ -864,6 +933,53 @@ class JApplicationWeb extends JApplicationBase
 		}
 
 		return trim($uri);
+	}
+
+	/**
+	 * Method to load a PHP configuration class file based on convention and return the instantiated data object.  You
+	 * will extend this method in child classes to provide configuration data from whatever data source is relevant
+	 * for your specific application.
+	 *
+	 * @param   string  $file   The path and filename of the configuration file. If not provided, configuration.php
+	 *                          in JPATH_BASE will be used.
+	 * @param   string  $class  The class name to instantiate.
+	 *
+	 * @return  mixed   Either an array or object to be loaded into the configuration object.
+	 *
+	 * @since   11.3
+	 */
+	protected function fetchConfigurationData($file = '', $class = 'JConfig')
+	{
+		// Instantiate variables.
+		$config = array();
+
+		if (empty($file) && defined('JPATH_BASE'))
+		{
+			$file = JPATH_BASE . '/configuration.php';
+
+			// Applications can choose not to have any configuration data
+			// by not implementing this method and not having a config file.
+			if (!file_exists($file))
+			{
+				$file = '';
+			}
+		}
+
+		if (!empty($file))
+		{
+			JLoader::register($class, $file);
+
+			if (class_exists($class))
+			{
+				$config = new $class;
+			}
+			else
+			{
+				throw new RuntimeException('Configuration class does not exist.');
+			}
+		}
+
+		return $config;
 	}
 
 	/**


### PR DESCRIPTION
The pull request partly reverts #843.

Instead of just having JApplicationCli and JApplicationWeb share a common base class this makes JApplication also extend JApplicationBase. To limit the amount of API change I only left those methods/variables in JApplicationBase that were shared by all 3 classes.

I think this would be a good first step in consolidating the new and old application classes.
