### PR TITLE
Modules assigned to 'all except' should show on pages without itemids.

### DIFF
--- a/libraries/joomla/application/module/helper.php
+++ b/libraries/joomla/application/module/helper.php
@@ -350,9 +350,8 @@ abstract class JModuleHelper
 			{
 				$module = &$modules[$i];
 
-				// The module is excluded if there is an explicit prohibition or if
-				// the Itemid is missing or zero and the module is in exclude mode.
-				$negHit = ($negId === (int) $module->menuid) || (!$negId && (int) $module->menuid < 0);
+				// The module is excluded if there is an explicit prohibition
+				$negHit = ($negId === (int) $module->menuid);
 
 				if (isset($dupes[$module->id]))
 				{


### PR DESCRIPTION
Modules assigned to 'all except' should show on pages without itemids. See CMS tracker issue 28017.
