### PR TITLE
Move JFormFieldMenuitem to the CMS

### DIFF
--- a/libraries/cms/form/field/menuitem.php
+++ b/libraries/cms/form/field/menuitem.php
@@ -21,7 +21,7 @@ require_once realpath(JPATH_ADMINISTRATOR . '/components/com_menus/helpers/menus
  * @subpackage  Form
  * @since       11.1
  */
-class JFormFieldMenuItem extends JFormFieldGroupedList
+class JFormFieldMenuitem extends JFormFieldGroupedList
 {
 	/**
 	 * The form field type.


### PR DESCRIPTION
The class has a dependency on the CMS com_menus.  So, move it.
