### PR TITLE
Add Iterator support to JPath::find()

### DIFF
--- a/libraries/joomla/filesystem/path.php
+++ b/libraries/joomla/filesystem/path.php
@@ -265,7 +265,10 @@ class JPath
 	public static function find($paths, $file)
 	{
 		// Force to array
-		settype($paths, 'array');
+		if (!is_array($paths) && !($paths instanceof Iterator))
+		{
+			settype($paths, 'array');
+		}
 
 		// Start looping through the path set
 		foreach ($paths as $path)


### PR DESCRIPTION
Added support for passing Iterator objects into JPath::find(). Previously, JPath::find() would typecast the input into an array which, in the case of iterators, results in an empty array. 
