### PR TITLE
Fixing JApplicationWeb base uri detection.

### DIFF
--- a/tests/suite/joomla/application/JApplicationWebTest.php
+++ b/tests/suite/joomla/application/JApplicationWebTest.php
@@ -92,7 +92,8 @@ class JApplicationWebTest extends JoomlaTestCase
 
 		$_SERVER['HTTP_HOST'] = self::TEST_HTTP_HOST;
 		$_SERVER['HTTP_USER_AGENT'] = self::TEST_USER_AGENT;
-
+		$_SERVER['SCRIPT_NAME'] = '/index.php';
+		
 		// Get a new JApplicationWebInspector instance.
 		$this->inspector = new JApplicationWebInspector;
 
@@ -1219,7 +1220,7 @@ class JApplicationWebTest extends JoomlaTestCase
 
 		$this->assertThat(
 			$this->inspector->getClassProperty('config')->get('uri.base.full'),
-			$this->equalTo('http://joom.la/application/'),
+			$this->equalTo('http://joom.la/'),
 			'Checks the full base uri.'
 		);
 
@@ -1231,19 +1232,19 @@ class JApplicationWebTest extends JoomlaTestCase
 
 		$this->assertThat(
 			$this->inspector->getClassProperty('config')->get('uri.base.path'),
-			$this->equalTo('/application/'),
+			$this->equalTo('/'),
 			'Checks the base uri path.'
 		);
 
 		$this->assertThat(
 			$this->inspector->getClassProperty('config')->get('uri.media.full'),
-			$this->equalTo('http://joom.la/application/media/'),
+			$this->equalTo('http://joom.la/media/'),
 			'Checks the full media uri.'
 		);
 
 		$this->assertThat(
 			$this->inspector->getClassProperty('config')->get('uri.media.path'),
-			$this->equalTo('/application/media/'),
+			$this->equalTo('/media/'),
 			'Checks the media uri path.'
 		);
 	}
@@ -1265,7 +1266,7 @@ class JApplicationWebTest extends JoomlaTestCase
 
 		$this->assertThat(
 			$this->inspector->getClassProperty('config')->get('uri.base.full'),
-			$this->equalTo('http://joom.la/application/'),
+			$this->equalTo('http://joom.la/'),
 			'Checks the full base uri.'
 		);
 
@@ -1277,7 +1278,7 @@ class JApplicationWebTest extends JoomlaTestCase
 
 		$this->assertThat(
 			$this->inspector->getClassProperty('config')->get('uri.base.path'),
-			$this->equalTo('/application/'),
+			$this->equalTo('/'),
 			'Checks the base uri path.'
 		);
 
@@ -1312,7 +1313,7 @@ class JApplicationWebTest extends JoomlaTestCase
 
 		$this->assertThat(
 			$this->inspector->getClassProperty('config')->get('uri.base.full'),
-			$this->equalTo('http://joom.la/application/'),
+			$this->equalTo('http://joom.la/'),
 			'Checks the full base uri.'
 		);
 
@@ -1324,7 +1325,7 @@ class JApplicationWebTest extends JoomlaTestCase
 
 		$this->assertThat(
 			$this->inspector->getClassProperty('config')->get('uri.base.path'),
-			$this->equalTo('/application/'),
+			$this->equalTo('/'),
 			'Checks the base uri path.'
 		);
 


### PR DESCRIPTION
Currently JApplicationWeb doesn't do any detection of a base uri if one isn't given explicitly... it will simply use the incoming URI as the base.  Obviously this won't work in rewrite based request routing, so this has been fixed.  Additionally I've added an 'uri.route' value for the detected non-base path in the incoming URI.
