### PR TITLE
Reduce dependency on JObject

### DIFF
--- a/libraries/joomla/archive/archive.php
+++ b/libraries/joomla/archive/archive.php
@@ -167,7 +167,7 @@ class JArchive
 	 *
 	 * @param   string  $type  The type of adapter (bzip2|gzip|tar|zip).
 	 *
-	 * @return  object   JObject
+	 * @return  object  JArchiveExtractable
 	 *
 	 * @since   11.1
 	 */

--- a/libraries/joomla/base/object.php
+++ b/libraries/joomla/base/object.php
@@ -53,6 +53,7 @@ class JObject
 	 * @return  string  The classname.
 	 *
 	 * @since   11.1
+	 * @deprecated 12.3  Classes should provide their own __toString() implementation.
 	 */
 	public function __toString()
 	{

--- a/libraries/joomla/client/ftp.php
+++ b/libraries/joomla/client/ftp.php
@@ -1692,7 +1692,7 @@ class JClientFtp
 }
 
 /**
- * Deprecated class placeholder. You should use JClientLdap instead.
+ * Deprecated class placeholder. You should use JClientFtp instead.
  *
  * @package     Joomla.Platform
  * @subpackage  Client

--- a/libraries/joomla/client/ldap.php
+++ b/libraries/joomla/client/ldap.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Client
  * @since       12.1
  */
-class JClientLdap extends JObject
+class JClientLdap
 {
 	/**
 	 * @var    string  Hostname of LDAP server
@@ -354,7 +354,6 @@ class JClientLdap extends JObject
 	 *
 	 * @since   12.1
 	 */
-
 	public function replace($dn, $attribute)
 	{
 		return @ldap_mod_replace($this->_resource, $dn, $attribute);

--- a/libraries/joomla/document/feed/feed.php
+++ b/libraries/joomla/document/feed/feed.php
@@ -246,9 +246,8 @@ class JDocumentFeed extends JDocument
  * @subpackage  Document
  * @since       11.1
  */
-class JFeedItem extends JObject
+class JFeedItem
 {
-
 	/**
 	 * Title item element
 	 *
@@ -393,9 +392,8 @@ class JFeedItem extends JObject
  * @subpackage  Document
  * @since       11.1
  */
-class JFeedEnclosure extends JObject
+class JFeedEnclosure
 {
-
 	/**
 	 * URL enclosure element
 	 *
@@ -434,9 +432,8 @@ class JFeedEnclosure extends JObject
  * @subpackage  Document
  * @since       11.1
  */
-class JFeedImage extends JObject
+class JFeedImage
 {
-
 	/**
 	 * Title image attribute
 	 *

--- a/libraries/joomla/document/opensearch/opensearch.php
+++ b/libraries/joomla/document/opensearch/opensearch.php
@@ -219,9 +219,8 @@ class JDocumentOpensearch extends JDocument
  * @subpackage  Document
  * @since       11.1
  */
-class JOpenSearchUrl extends JObject
+class JOpenSearchUrl
 {
-
 	/**
 	 * Type item element
 	 *
@@ -260,9 +259,8 @@ class JOpenSearchUrl extends JObject
  * @subpackage  Document
  * @since       11.1
  */
-class JOpenSearchImage extends JObject
+class JOpenSearchImage
 {
-
 	/**
 	 * The images MIME type
 	 *

--- a/libraries/joomla/document/renderer.php
+++ b/libraries/joomla/document/renderer.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Document
  * @since       11.1
  */
-class JDocumentRenderer extends JObject
+class JDocumentRenderer
 {
 	/**
 	 * Reference to the JDocument object that instantiated the renderer

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -23,7 +23,7 @@ defined('JPATH_PLATFORM') or die;
  * @since       11.1
  * @deprecated  This API may be changed in the near future and should not be considered stable
  */
-class JBrowser extends JObject
+class JBrowser
 {
 
 	/**

--- a/libraries/joomla/error/profiler.php
+++ b/libraries/joomla/error/profiler.php
@@ -17,7 +17,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Error
  * @since       11.1
  */
-class JProfiler extends JObject
+class JProfiler
 {
 	/**
 	 * @var    integer  The start time.

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Filter
  * @since       11.1
  */
-class JFilterInput extends JObject
+class JFilterInput
 {
 	/**
 	 * @var    array  A container for JFilterInput instances.

--- a/libraries/joomla/html/toolbar.php
+++ b/libraries/joomla/html/toolbar.php
@@ -19,7 +19,7 @@ JLoader::register('JButton', __DIR__ . '/toolbar/button.php');
  * @subpackage  HTML
  * @since       11.1
  */
-class JToolBar extends JObject
+class JToolBar
 {
 	/**
 	 * Toolbar name

--- a/libraries/joomla/html/toolbar/button.php
+++ b/libraries/joomla/html/toolbar/button.php
@@ -18,7 +18,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  HTML
  * @since       11.1
  */
-abstract class JButton extends JObject
+abstract class JButton
 {
 	/**
 	 * element name


### PR DESCRIPTION
Special pull request for @LouisLandry. ;)

The following classes no longer extend JObject
JBrowser
JClientLdap
JDocumentRenderer
JFeedEnclosure
JFeedImage
JFeedItem
JFilterInput
JProfiler
JOpenSearchImage
JOpenSearchUrl
JToolBar

Also deprecate JObject::__toString().
