### PR TITLE
Remove deprecated warnings for PHPUnit 3.6

### DIFF
--- a/tests/suite/joomla/cache/controller/JCacheControllerCallbackCallbackTest.php
+++ b/tests/suite/joomla/cache/controller/JCacheControllerCallbackCallbackTest.php
@@ -11,7 +11,7 @@
  * A unit test class for SubjectClass
  * The two annotations below are required because we use mocks.  This avoids bringing bogus classes into the main process.
  */
-class JCacheControllerCallbackTest_Callback extends PHPUnit_Extensions_OutputTestCase
+class JCacheControllerCallbackTest_Callback extends PHPUnit_Framework_TestCase
 {
 
 	public function setUp() {

--- a/tests/suite/joomla/log/JLogTest.php
+++ b/tests/suite/joomla/log/JLogTest.php
@@ -20,7 +20,7 @@ require_once __DIR__.'/stubs/log/inspector.php';
  * @subpackage  Log
  * @since       11.1
  */
-class JLogTest extends PHPUnit_Extensions_OutputTestCase
+class JLogTest extends PHPUnit_Framework_TestCase
 {
 	/**
 	 * Overrides the parent tearDown method.

--- a/tests/suite/joomla/log/loggers/JLoggerEchoTest.php
+++ b/tests/suite/joomla/log/loggers/JLoggerEchoTest.php
@@ -12,7 +12,7 @@ require_once JPATH_PLATFORM.'/joomla/log/loggers/echo.php';
 /**
  * Test class for JLoggerEcho.
  */
-class JLoggerEchoTest extends PHPUnit_Extensions_OutputTestCase
+class JLoggerEchoTest extends PHPUnit_Framework_TestCase
 {
 	/**
 	 * Test the JLoggerEcho::addEntry method.


### PR DESCRIPTION
There were a few deprecated warnings being generated by PHPUnit 3.6 that have been cleaned up.  The warning is:

```
The functionality of PHPUnit_Extensions_OutputTestCase has been merged into PHPUnit_Framework_TestCase. Please update your test by extending PHPUnit_Framework_TestCase instead of PHPUnit_Extensions_OutputTestCase.
```
