### PR TITLE
Fix the modal behavior.

### DIFF
--- a/libraries/joomla/html/html/behavior.php
+++ b/libraries/joomla/html/html/behavior.php
@@ -284,7 +284,7 @@ abstract class JHtmlBehavior
 		if (!isset(self::$loaded[__METHOD__]))
 		{
 			// Include MooTools framework
-			self::framework();
+			self::framework(true);
 
 			// Load the javascript and css
 			JHtml::_('script', 'system/modal.js', true, true);

--- a/tests/suite/joomla/html/html/JHtmlBehaviorTest.php
+++ b/tests/suite/joomla/html/html/JHtmlBehaviorTest.php
@@ -332,7 +332,7 @@ class JHtmlBehaviorTest extends JoomlaTestCase
 		$data = array(
 			array(
 				array(
-					'JHtmlBehavior::framework' => array('core' => true),
+					'JHtmlBehavior::framework' => array('core' => true, 'more' => true),
 					'JHtmlBehavior::modal' => array(
 						md5(serialize(array('a.modal', array()))) => true
 					)
@@ -340,7 +340,7 @@ class JHtmlBehaviorTest extends JoomlaTestCase
 			),
 			array(
 				array(
-					'JHtmlBehavior::framework' => array('core' => true),
+					'JHtmlBehavior::framework' => array('core' => true, 'more' => true),
 					'JHtmlBehavior::modal' => array(
 						md5(serialize(array('a.modal2', array()))) => true
 					)
@@ -349,7 +349,7 @@ class JHtmlBehaviorTest extends JoomlaTestCase
 			),
 			array(
 				array(
-					'JHtmlBehavior::framework' => array('core' => true),
+					'JHtmlBehavior::framework' => array('core' => true, 'more' => true),
 					'JHtmlBehavior::modal' => array(
 						md5(serialize(array('a.modal2', array('size' => 1000)))) => true
 					)


### PR DESCRIPTION
Modals now require MooTools More because with 1.3 Hash moved to More.
It may be possible to fixe Squeezebox but for this fixes the immediate issue.
