### PR TITLE
Added subquery capability for FROM and INSERT elements and their tests.

### DIFF
--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -124,6 +124,55 @@ class JDatabaseQueryTest extends JoomlaTestCase
 	}
 
 	/**
+	 * Test for FROM clause with subquery.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function test__toStringFrom_subquery()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
+		$subq = new JDatabaseQueryInspector($this->dbo);
+		$subq->select('col2')->from('table')->where('a=1');
+
+		$q->select('col')->from($subq, 'alias');
+
+		$this->assertThat(
+					(string) $q,
+					$this->equalTo("\nSELECT col\nFROM ( \nSELECT col2\nFROM table\nWHERE a=1 ) AS `alias`")
+		);
+	}
+
+	/**
+	 * Test for INSERT INTO clause with subquery.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function test__toStringInsert_subquery()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
+		$subq = new JDatabaseQueryInspector($this->dbo);
+		$subq->select('col2')->where('a=1');
+
+		$q->insert('table')->columns('col')->values($subq);
+
+		$this->assertThat(
+					(string) $q,
+					$this->equalTo("\nINSERT INTO table\n(col)\n(\nSELECT col2\nWHERE a=1)")
+		);
+
+		$q->clear();
+		$q->insert('table')->columns('col')->values('3');
+		$this->assertThat(
+					(string) $q,
+					$this->equalTo("\nINSERT INTO table\n(col) VALUES \n(3)")
+		);
+	}
+
+	/**
 	 * Test for year extraction from date.
 	 *
 	 * @return  void


### PR DESCRIPTION
With this pull request it's possible to create queries as following examples.

Using subqueries inside FROM element

<pre><code>$q = new JDatabaseQuery ;
$subq = new JDatabaseQuery;
$subq->select('col2')->from('table')->where('a=1');
$q->select('col')->from($subq, 'alias');</code></pre>


This will be translated to

<pre><code>SELECT col
FROM ( 
SELECT col2
FROM table
WHERE a=1 ) AS `alias`</code></pre>

<hr>

Now an INSERT INTO element example

<pre><code>$q = new JDatabaseQuery;
$subq = new JDatabaseQuery;
$subq->select('col2')->where('a=1');
$q->insert('table')->columns('col')->values($subq);</code></pre>


This will be translated to

<pre><code>INSERT INTO table
(col)
(
SELECT col2
WHERE a=1)</code></pre>


For each element is maintained backward compatibility about use without subqueries.
