### PR TITLE
Change JDatabaseDriver, JCacheStorage and JSessionStorage to use isSupported() instead of test().

### DIFF
--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -106,14 +106,15 @@ class JCache extends JObject
 		foreach ($handlers as $handler)
 		{
 			$name = substr($handler, 0, strrpos($handler, '.'));
-			$class = 'JCacheStorage' . $name;
+			$class = 'JCacheStorage' . ucfirst(trim($name));
 
 			if (!class_exists($class))
 			{
 				include_once __DIR__ . '/storage/' . $name . '.php';
 			}
 
-			if (call_user_func_array(array(trim($class), 'test'), array()))
+			// @deprecated 12.3 Stop checking with test()
+			if ($class::isSupported() || $class::test())
 			{
 				$names[] = $name;
 			}

--- a/libraries/joomla/cache/storage.php
+++ b/libraries/joomla/cache/storage.php
@@ -243,11 +243,26 @@ class JCacheStorage
 	 *
 	 * @return   boolean  True on success, false otherwise
 	 *
-	 * @since    11.1.
+	 * @since    12.1.
+	 */
+	public static function isSupported()
+	{
+		return true;
+	}
+
+	/**
+	 * Test to see if the storage handler is available.
+	 *
+	 * @return  boolean  True on success, false otherwise.
+	 *
+	 * @since   11.1
+	 * @deprecated  12.3
 	 */
 	public static function test()
 	{
-		return true;
+		JLog::add('JCacheStorage::test() is deprecated. Use JCacheStorage::isSupported() instead.', JLog::WARNING, 'deprecated');
+
+		return static::isSupported();
 	}
 
 	/**

--- a/libraries/joomla/cache/storage/apc.php
+++ b/libraries/joomla/cache/storage/apc.php
@@ -171,9 +171,9 @@ class JCacheStorageApc extends JCacheStorage
 	 *
 	 * @return  boolean  True on success, false otherwise.
 	 *
-	 * @since   11.1
+	 * @since   12.1
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		return extension_loaded('apc');
 	}

--- a/libraries/joomla/cache/storage/cachelite.php
+++ b/libraries/joomla/cache/storage/cachelite.php
@@ -316,9 +316,9 @@ class JCacheStorageCachelite extends JCacheStorage
 	 *
 	 * @return  boolean  True on success, false otherwise.
 	 *
-	 * @since   11.1
+	 * @since   12.1
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		@include_once 'Cache/Lite.php';
 

--- a/libraries/joomla/cache/storage/eaccelerator.php
+++ b/libraries/joomla/cache/storage/eaccelerator.php
@@ -182,9 +182,9 @@ class JCacheStorageEaccelerator extends JCacheStorage
 	 *
 	 * @return boolean  True on success, false otherwise.
 	 *
-	 * @since   11.1
+	 * @since   12.1
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		return (extension_loaded('eaccelerator') && function_exists('eaccelerator_get'));
 	}

--- a/libraries/joomla/cache/storage/file.php
+++ b/libraries/joomla/cache/storage/file.php
@@ -243,9 +243,9 @@ class JCacheStorageFile extends JCacheStorage
 	 *
 	 * @return  boolean  True on success, false otherwise.
 	 *
-	 * @since   11.1
+	 * @since   12.1
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		$conf = JFactory::getConfig();
 		return is_writable($conf->get('cache_path', JPATH_CACHE));

--- a/libraries/joomla/cache/storage/memcache.php
+++ b/libraries/joomla/cache/storage/memcache.php
@@ -293,8 +293,10 @@ class JCacheStorageMemcache extends JCacheStorage
 	 * Test to see if the cache storage is available.
 	 *
 	 * @return  boolean  True on success, false otherwise.
+	 *
+	 * @since   12.1
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		if ((extension_loaded('memcache') && class_exists('Memcache')) != true)
 		{

--- a/libraries/joomla/cache/storage/memcached.php
+++ b/libraries/joomla/cache/storage/memcached.php
@@ -302,8 +302,10 @@ class JCacheStorageMemcached extends JCacheStorage
 	 * Test to see if the cache storage is available.
 	 *
 	 * @return  boolean  True on success, false otherwise.
+	 *
+	 * @since   12.1
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		if ((extension_loaded('memcached') && class_exists('Memcached')) != true)
 		{

--- a/libraries/joomla/cache/storage/wincache.php
+++ b/libraries/joomla/cache/storage/wincache.php
@@ -183,8 +183,10 @@ class JCacheStorageWincache extends JCacheStorage
 	 * Test to see if the cache storage is available.
 	 *
 	 * @return boolean  True on success, false otherwise.
+	 *
+	 * @since   12.1
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		$test = extension_loaded('wincache') && function_exists('wincache_ucache_get') && !strcmp(ini_get('wincache.ucenabled'), '1');
 		return $test;

--- a/libraries/joomla/cache/storage/xcache.php
+++ b/libraries/joomla/cache/storage/xcache.php
@@ -200,9 +200,9 @@ class JCacheStorageXcache extends JCacheStorage
 	 *
 	 * @return  boolean  True on success, false otherwise.
 	 *
-	 * @since   11.1
+	 * @since   12.1
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		return (extension_loaded('xcache'));
 	}

--- a/libraries/joomla/database/database.php
+++ b/libraries/joomla/database/database.php
@@ -29,7 +29,6 @@ abstract class JDatabase
 	 */
 	public function query()
 	{
-		// Deprecation warning.
 		JLog::add('JDatabase::query() is deprecated, use JDatabaseDriver::execute() instead.', JLog::NOTICE, 'deprecated');
 
 		return $this->execute();
@@ -47,8 +46,7 @@ abstract class JDatabase
 	 */
 	public function getErrorMsg($escaped = false)
 	{
-		// Deprecation warning.
-		JLog::add('JDatabaseDriver::getErrorMsg() is deprecated, use exception handling instead.', JLog::WARNING, 'deprecated');
+		JLog::add('JDatabase::getErrorMsg() is deprecated, use exception handling instead.', JLog::WARNING, 'deprecated');
 
 		if ($escaped)
 		{
@@ -70,8 +68,7 @@ abstract class JDatabase
 	 */
 	public function getErrorNum()
 	{
-		// Deprecation warning.
-		JLog::add('JDatabaseDriver::getErrorNum() is deprecated, use exception handling instead.', JLog::WARNING, 'deprecated');
+		JLog::add('JDatabase::getErrorNum() is deprecated, use exception handling instead.', JLog::WARNING, 'deprecated');
 
 		return $this->errorNum;
 	}
@@ -95,7 +92,6 @@ abstract class JDatabase
 	 */
 	public static function getInstance($options = array())
 	{
-		// Deprecation warning.
 		JLog::add('JDatabase::getInstance() is deprecated, use JDatabaseDriver::getInstance() instead.', JLog::NOTICE, 'deprecated');
 
 		return JDatabaseDriver::getInstance($options);
@@ -108,13 +104,12 @@ abstract class JDatabase
 	 *
 	 * @return  string  The error message for the most recent query.
 	 *
-	 * @deprecated  12.1
 	 * @since   11.1
+	 * @deprecated  12.1
 	 */
 	public function stderr($showSQL = false)
 	{
-		// Deprecation warning.
-		JLog::add('JDatabaseDriver::stderr() is deprecated.', JLog::WARNING, 'deprecated');
+		JLog::add('JDatabase::stderr() is deprecated.', JLog::WARNING, 'deprecated');
 
 		if ($this->errorNum != 0)
 		{
@@ -125,5 +120,20 @@ abstract class JDatabase
 		{
 			return JText::_('JLIB_DATABASE_FUNCTION_NOERROR');
 		}
+	}
+
+	/**
+	 * Test to see if the connector is available.
+	 *
+	 * @return  boolean  True on success, false otherwise.
+	 *
+	 * @since   11.1
+	 * @deprecated  12.3 Use JDatabaseDriver::isSupported() instead.
+	 */
+	public static function test()
+	{
+		JLog::add('JDatabase::test() is deprecated. Use JDatabaseDriver::isSupported() instead.', JLog::WARNING, 'deprecated');
+
+		return static::isSupported();
 	}
 }

--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -27,7 +27,7 @@ interface JDatabaseInterface
 	 *
 	 * @since   11.2
 	 */
-	public static function test();
+	public static function isSupported();
 }
 
 /**
@@ -199,7 +199,8 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 			}
 
 			// Sweet!  Our class exists, so now we just need to know if it passes it's test method.
-			if ($class::test())
+			// @deprecated 12.3 Stop checking with test()
+			if ($class::isSupported() || $class::test())
 			{
 				// Connector names should not have file extensions.
 				$connectors[] = str_ireplace('.php', '', $type);
@@ -826,7 +827,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 *
 	 * @since   12.1
 	 */
-	public function isSupported()
+	public function isMinimumVersion()
 	{
 		return version_compare($this->getVersion(), static::$dbMinimum) >= 0;
 	}

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -157,7 +157,7 @@ class JDatabaseDriverMysql extends JDatabaseDriver
 	 *
 	 * @since   12.1
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		return (function_exists('mysql_connect'));
 	}

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -176,7 +176,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriverMysql
 	 *
 	 * @since   12.1
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		return (function_exists('mysqli_connect'));
 	}

--- a/libraries/joomla/database/driver/oracle.php
+++ b/libraries/joomla/database/driver/oracle.php
@@ -465,7 +465,7 @@ class JDatabaseDriverOracle extends JDatabaseDriverPdo
 	 *
 	 * @since   12.1
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		return in_array('oci', PDO::getAvailableDrivers());
 	}

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -269,7 +269,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		$connectionString = str_replace($replace, $with, $format);
 
 		// Make sure the PDO extension for PHP is installed and enabled.
-		if (!self::test())
+		if (!self::isSupported())
 		{
 			// Legacy error handling switch based on the JError::$legacy switch.
 			// @deprecated  12.1
@@ -502,7 +502,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	 *
 	 * @since   12.1
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		return defined('PDO::ATTR_DRIVER_NAME');
 	}

--- a/libraries/joomla/database/driver/sqlite.php
+++ b/libraries/joomla/database/driver/sqlite.php
@@ -333,7 +333,7 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 	 *
 	 * @since   12.1
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		return in_array('sqlite', PDO::getAvailableDrivers());
 	}

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -60,7 +60,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	 *
 	 * @since   12.1
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		return (function_exists('sqlsrv_connect'));
 	}

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -347,7 +347,8 @@ class JSession extends JObject
 				require_once __DIR__ . '/storage/' . $name . '.php';
 			}
 
-			if (call_user_func_array(array(trim($class), 'test'), array()))
+			// @deprecated 12.3 Stop checking with test()
+			if ($class::isSupported() || $class::test())
 			{
 				$names[] = $name;
 			}

--- a/libraries/joomla/session/storage.php
+++ b/libraries/joomla/session/storage.php
@@ -185,10 +185,25 @@ abstract class JSessionStorage extends JObject
 	 *
 	 * @return  boolean  True on success, false otherwise.
 	 *
+	 * @since   12.1
+	 */
+	public static function isSupported()
+	{
+		return true;
+	}
+
+	/**
+	 * Test to see if the SessionHandler is available.
+	 *
+	 * @return  boolean  True on success, false otherwise.
+	 *
 	 * @since   11.1
+	 * @deprecated  12.3 Use JSessionStorage::isSupported() instead.
 	 */
 	public static function test()
 	{
-		return true;
+		JLog::add('JSessionStorage::test() is deprecated. Use JSessionStorage::isSupported() instead.', JLog::WARNING, 'deprecated');
+
+		return static::isSupported();
 	}
 }

--- a/libraries/joomla/session/storage/apc.php
+++ b/libraries/joomla/session/storage/apc.php
@@ -28,7 +28,7 @@ class JSessionStorageApc extends JSessionStorage
 	 */
 	public function __construct($options = array())
 	{
-		if (!$this->test())
+		if (!self::isSupported())
 		{
 			return JError::raiseError(404, JText::_('JLIB_SESSION_APC_EXTENSION_NOT_AVAILABLE'));
 		}
@@ -124,8 +124,10 @@ class JSessionStorageApc extends JSessionStorage
 	 * Test to see if the SessionHandler is available.
 	 *
 	 * @return boolean  True on success, false otherwise.
+	 *
+	 * @since   12.1
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		return extension_loaded('apc');
 	}

--- a/libraries/joomla/session/storage/eaccelerator.php
+++ b/libraries/joomla/session/storage/eaccelerator.php
@@ -28,7 +28,7 @@ class JSessionStorageEaccelerator extends JSessionStorage
 	 */
 	public function __construct($options = array())
 	{
-		if (!$this->test())
+		if (!self::isSupported())
 		{
 			return JError::raiseError(404, JText::_('JLIB_SESSION_EACCELERATOR_EXTENSION_NOT_AVAILABLE'));
 		}
@@ -122,8 +122,10 @@ class JSessionStorageEaccelerator extends JSessionStorage
 	 * Test to see if the SessionHandler is available.
 	 *
 	 * @return boolean  True on success, false otherwise.
+	 *
+	 * @since   12.1
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		return (extension_loaded('eaccelerator') && function_exists('eaccelerator_get'));
 	}

--- a/libraries/joomla/session/storage/memcache.php
+++ b/libraries/joomla/session/storage/memcache.php
@@ -54,7 +54,7 @@ class JSessionStorageMemcache extends JSessionStorage
 	 */
 	public function __construct($options = array())
 	{
-		if (!$this->test())
+		if (!self::isSupported())
 		{
 			return JError::raiseError(404, JText::_('JLIB_SESSION_MEMCACHE_EXTENSION_NOT_AVAILABLE'));
 		}
@@ -191,8 +191,10 @@ class JSessionStorageMemcache extends JSessionStorage
 	 * Test to see if the SessionHandler is available.
 	 *
 	 * @return boolean  True on success, false otherwise.
+	 *
+	 * @since   12.1
 	 */
-	static public function test()
+	static public function isSupported()
 	{
 		return (extension_loaded('memcache') && class_exists('Memcache'));
 	}

--- a/libraries/joomla/session/storage/memcached.php
+++ b/libraries/joomla/session/storage/memcached.php
@@ -54,7 +54,7 @@ class JSessionStorageMemcached extends JSessionStorage
 	 */
 	public function __construct($options = array())
 	{
-		if (!$this->test())
+		if (!self::isSupported())
 		{
 			return JError::raiseError(404, JText::_('JLIB_SESSION_MEMCACHE_EXTENSION_NOT_AVAILABLE'));
 		}
@@ -192,8 +192,10 @@ class JSessionStorageMemcached extends JSessionStorage
 	 * Test to see if the SessionHandler is available.
 	 *
 	 * @return boolean  True on success, false otherwise.
+	 *
+	 * @since   12.1
 	 */
-	static public function test()
+	static public function isSupported()
 	{
 		return (extension_loaded('memcached') && class_exists('Memcached'));
 	}

--- a/libraries/joomla/session/storage/none.php
+++ b/libraries/joomla/session/storage/none.php
@@ -124,9 +124,9 @@ class JSessionStorageNone extends JSessionStorage
 	 *
 	 * @return  boolean  True on if available, false otherwise.
 	 *
-	 * @since   11.1
+	 * @since   12.1
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		return true;
 	}

--- a/libraries/joomla/session/storage/wincache.php
+++ b/libraries/joomla/session/storage/wincache.php
@@ -28,7 +28,7 @@ class JSessionStorageWincache extends JSessionStorage
 	 */
 	public function __construct($options = array())
 	{
-		if (!$this->test())
+		if (!self::isSupported())
 		{
 			return JError::raiseError(404, JText::_('JLIB_SESSION_WINCACHE_EXTENSION_NOT_AVAILABLE'));
 		}
@@ -119,8 +119,10 @@ class JSessionStorageWincache extends JSessionStorage
 	 * Test to see if the SessionHandler is available.
 	 *
 	 * @return boolean  True on success, false otherwise.
+	 *
+	 * @since   12.1
 	 */
-	static public function test()
+	static public function isSupported()
 	{
 		return (extension_loaded('wincache') && function_exists('wincache_ucache_get') && !strcmp(ini_get('wincache.ucenabled'), "1"));
 	}

--- a/libraries/joomla/session/storage/xcache.php
+++ b/libraries/joomla/session/storage/xcache.php
@@ -27,7 +27,7 @@ class JSessionStorageXcache extends JSessionStorage
 	 */
 	public function __construct($options = array())
 	{
-		if (!$this->test())
+		if (!self::isSupported())
 		{
 			return JError::raiseError(404, JText::_('JLIB_SESSION_XCACHE_EXTENSION_NOT_AVAILABLE'));
 		}
@@ -137,8 +137,10 @@ class JSessionStorageXcache extends JSessionStorage
 	 * Test to see if the SessionHandler is available.
 	 *
 	 * @return boolean  True on success, false otherwise.
+	 *
+	 * @since   12.1
 	 */
-	static public function test()
+	static public function isSupported()
 	{
 		return (extension_loaded('xcache'));
 	}

--- a/tests/includes/mocks/JDatabaseMock.php
+++ b/tests/includes/mocks/JDatabaseMock.php
@@ -82,6 +82,7 @@ class JDatabaseGlobalMock
 			'setUTF',
 			'splitSql',
 			'test',
+			'isSupported',
 			'transactionCommit',
 			'transactionRollback',
 			'transactionStart',

--- a/tests/suite/joomla/cache/JCacheStorageTest.php
+++ b/tests/suite/joomla/cache/JCacheStorageTest.php
@@ -307,5 +307,17 @@ class JCacheStorageTest extends JoomlaTestCase
 			$this->isTrue()
 		);
 	}
+
+	/**
+	 * Testing isSupported().
+	 *
+	 * @return void
+	 */
+	public function testIsSupported()
+	{
+		$this->assertThat(
+			$this->object->isSupported(),
+			$this->isTrue()
+		);
+	}
 }
-?>

--- a/tests/suite/joomla/cache/storage/JCacheStorageApcTest.php
+++ b/tests/suite/joomla/cache/storage/JCacheStorageApcTest.php
@@ -126,14 +126,14 @@ class JCacheStorageApcTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Testing test().
+	 * Testing isSupported().
 	 *
 	 * @return void
 	 */
-	public function testTest()
+	public function testIsSupported()
 	{
 		$this->assertThat(
-			$this->object->test(),
+			$this->object->isSupported(),
 			$this->equalTo($this->apcAvailable),
 			'Claims APC is not loaded.'
 		);

--- a/tests/suite/joomla/cache/storage/JCacheStorageCacheliteTest.php
+++ b/tests/suite/joomla/cache/storage/JCacheStorageCacheliteTest.php
@@ -97,9 +97,9 @@ class JCacheStorageCacheliteTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @todo Implement testTest().
+     * @todo Implement testIsSupported().
      */
-    public function testTest() {
+    public function testIsSupported() {
         // Remove the following lines when you implement this test.
         $this->markTestIncomplete(
                 'This test has not been implemented yet.'

--- a/tests/suite/joomla/cache/storage/JCacheStorageEacceleratorTest.php
+++ b/tests/suite/joomla/cache/storage/JCacheStorageEacceleratorTest.php
@@ -137,14 +137,14 @@ class JCacheStorageEacceleratorTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Testing test().
+	 * Testing isSupported().
 	 *
 	 * @return void
 	 */
-	public function testTest()
+	public function testIsSupported()
 	{
 		$this->assertThat(
-			$this->object->test(),
+			$this->object->isSupported(),
 			$this->equalTo($this->eacceleratorAvailable),
 			'Claims Eaccelerator is not loaded.'
 		);

--- a/tests/suite/joomla/cache/storage/JCacheStorageFileTest.php
+++ b/tests/suite/joomla/cache/storage/JCacheStorageFileTest.php
@@ -180,12 +180,12 @@ class JCacheStorageFileTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Testing test().
+	 * Testing isSupported().
 	 */
-	public function testTest()
+	public function testIsSupported()
 	{
 		$this->assertThat(
-			$this->object->test(),
+			$this->object->isSupported(),
 			$this->equalTo(is_writable(JPATH_BASE.'/cache')),
 			'Claims File is not loaded.'
 		);

--- a/tests/suite/joomla/cache/storage/JCacheStorageMemcacheTest.php
+++ b/tests/suite/joomla/cache/storage/JCacheStorageMemcacheTest.php
@@ -188,16 +188,16 @@ class JCacheStorageMemcacheTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Testing test().
+	 * Testing isSupported().
 	 *
 	 * @return void
 	 */
-	public function testTest()
+	public function testIsSupported()
 	{
 		if ($this->memcacheAvailable)
 		{
 			$this->assertThat(
-				$this->object->test(),
+				$this->object->isSupported(),
 				$this->isTrue(),
 				'Claims memcache is not loaded.'
 			);

--- a/tests/suite/joomla/cache/storage/JCacheStorageMock.php
+++ b/tests/suite/joomla/cache/storage/JCacheStorageMock.php
@@ -100,7 +100,7 @@ class JCacheStorageMock extends JCacheStorage
 	 *
 	 * @return boolean  True on success, false otherwise.
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		return true;
 	}

--- a/tests/suite/joomla/cache/storage/JCacheStorageWincacheTest.php
+++ b/tests/suite/joomla/cache/storage/JCacheStorageWincacheTest.php
@@ -96,9 +96,9 @@ class JCacheStorageWincacheTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @todo Implement testTest().
+     * @todo Implement testIsSupported().
      */
-    public function testTest() {
+    public function testIsSupported() {
         // Remove the following lines when you implement this test.
         $this->markTestIncomplete(
                 'This test has not been implemented yet.'

--- a/tests/suite/joomla/cache/storage/JCacheStorageXCacheTest.php
+++ b/tests/suite/joomla/cache/storage/JCacheStorageXCacheTest.php
@@ -111,14 +111,14 @@ class JCacheStorageXCacheTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Testing test().
+	 * Testing isSupported().
 	 *
 	 * @return void
 	 */
-	public function testTest()
+	public function testIsSupported()
 	{
 		$this->assertThat(
-			$this->object->test(),
+			$this->object->isSupported(),
 			$this->equalTo($this->xcacheAvailable),
 			'Claims xcache is not loaded.'
 		);

--- a/tests/suite/joomla/database/database/JDatabaseMySQLTest.php
+++ b/tests/suite/joomla/database/database/JDatabaseMySQLTest.php
@@ -591,10 +591,10 @@ class JDatabaseMysqlTest extends JoomlaDatabaseTestCase
 	 * Test Test method - there really isn't a lot to test here, but
 	 * this is present for the sake of completeness
 	 */
-	public function testTest()
+	public function testIsSupported()
 	{
 		$this->assertThat(
-			JDatabaseMysql::test(),
+			JDatabaseMysql::isSupported(),
 			$this->isTrue(),
 			__LINE__
 		);

--- a/tests/suite/joomla/database/database/JDatabaseMySQLiTest.php
+++ b/tests/suite/joomla/database/database/JDatabaseMySQLiTest.php
@@ -582,10 +582,10 @@ class JDatabaseMysqliTest extends JoomlaDatabaseTestCase
 	 * Test Test method - there really isn't a lot to test here, but
 	 * this is present for the sake of completeness
 	 */
-	public function testTest()
+	public function testIsSupported()
 	{
 		$this->assertThat(
-			JDatabaseDriverMysqli::test(),
+			JDatabaseDriverMysqli::isSupported(),
 			$this->isTrue(),
 			__LINE__
 		);

--- a/tests/suite/joomla/database/database/JDatabaseSQLSrvTest.php
+++ b/tests/suite/joomla/database/database/JDatabaseSQLSrvTest.php
@@ -375,10 +375,10 @@ class JDatabaseSQLSrvTest extends JoomlaDatabaseTestCase
 	 * Test Test method - there really isn't a lot to test here, but
 	 * this is present for the sake of completeness
 	 */
-	public function testTest()
+	public function testIsSupported()
 	{
 		$this->assertThat(
-			JDatabaseSqlsrv::test(),
+			JDatabaseSqlsrv::isSupported(),
 			$this->isTrue(),
 			__LINE__
 		);

--- a/tests/suite/joomla/database/stubs/nosqldriver.php
+++ b/tests/suite/joomla/database/stubs/nosqldriver.php
@@ -63,17 +63,29 @@ class JDatabaseDriverNosql extends JDatabaseDriver
 		return true;
 	}
 
+
 	/**
+
 	 * Determines if the connection to the server is active.
+
 	 *
+
 	 * @return  boolean  True if connected to the database engine.
+
 	 *
+
 	 * @since   11.4
+
 	 */
+
 	public function connected()
+
 	{
+
 		return true;
+
 	}
+
 
 	/**
 	 * Drops a table from the database.
@@ -379,7 +391,7 @@ class JDatabaseDriverNosql extends JDatabaseDriver
 	 *
 	 * @since   11.2
 	 */
-	public static function test()
+	public static function isSupported()
 	{
 		return true;
 	}

--- a/tests/suite/joomla/session/JSessionStorageTest.php
+++ b/tests/suite/joomla/session/JSessionStorageTest.php
@@ -116,9 +116,9 @@ class JSessionStorageTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @todo Implement testTest().
+     * @todo Implement testIsSupported().
      */
-    public function testTest() {
+    public function testIsSupported() {
         // Remove the following lines when you implement this test.
         $this->markTestIncomplete(
                 'This test has not been implemented yet.'

--- a/tests/suite/joomla/session/storage/JSessionStorageApcTest.php
+++ b/tests/suite/joomla/session/storage/JSessionStorageApcTest.php
@@ -96,9 +96,9 @@ class JSessionStorageApcTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @todo Implement testTest().
+     * @todo Implement testIsSupported().
      */
-    public function testTest() {
+    public function testIsSupported() {
         // Remove the following lines when you implement this test.
         $this->markTestIncomplete(
                 'This test has not been implemented yet.'
@@ -106,5 +106,3 @@ class JSessionStorageApcTest extends PHPUnit_Framework_TestCase {
     }
 
 }
-
-?>

--- a/tests/suite/joomla/session/storage/JSessionStorageEacceleratorTest.php
+++ b/tests/suite/joomla/session/storage/JSessionStorageEacceleratorTest.php
@@ -96,9 +96,9 @@ class JSessionStorageEacceleratorTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @todo Implement testTest().
+     * @todo Implement testIsSupported().
      */
-    public function testTest() {
+    public function testIsSupported() {
         // Remove the following lines when you implement this test.
         $this->markTestIncomplete(
                 'This test has not been implemented yet.'
@@ -106,5 +106,3 @@ class JSessionStorageEacceleratorTest extends PHPUnit_Framework_TestCase {
     }
 
 }
-
-?>

--- a/tests/suite/joomla/session/storage/JSessionStorageMemcacheTest.php
+++ b/tests/suite/joomla/session/storage/JSessionStorageMemcacheTest.php
@@ -96,9 +96,9 @@ class JSessionStorageMemcacheTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @todo Implement testTest().
+     * @todo Implement testIsSupported().
      */
-    public function testTest() {
+    public function testIsSupported() {
         // Remove the following lines when you implement this test.
         $this->markTestIncomplete(
                 'This test has not been implemented yet.'
@@ -106,5 +106,3 @@ class JSessionStorageMemcacheTest extends PHPUnit_Framework_TestCase {
     }
 
 }
-
-?>

--- a/tests/suite/joomla/session/storage/JSessionStorageNoneTest.php
+++ b/tests/suite/joomla/session/storage/JSessionStorageNoneTest.php
@@ -92,13 +92,11 @@ class JSessionStorageNoneTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * Test JSessionStorageNone::test().
+     * Test JSessionStorageNone::isSupported().
      */
-    public function testTest() {
+    public function testIsSupported() {
     	$this->assertTrue(
-    		JSessionStorageNone::test()
+    		JSessionStorageNone::isSupported()
     	);
     }
 }
-
-?>

--- a/tests/suite/joomla/session/storage/JSessionStorageWincacheTest.php
+++ b/tests/suite/joomla/session/storage/JSessionStorageWincacheTest.php
@@ -96,15 +96,12 @@ class JSessionStorageWincacheTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @todo Implement testTest().
+     * @todo Implement testIsSupported().
      */
-    public function testTest() {
+    public function testIsSupported() {
         // Remove the following lines when you implement this test.
         $this->markTestIncomplete(
                 'This test has not been implemented yet.'
         );
     }
-
 }
-
-?>

--- a/tests/suite/joomla/session/storage/JSessionStorageXcacheTest.php
+++ b/tests/suite/joomla/session/storage/JSessionStorageXcacheTest.php
@@ -96,15 +96,12 @@ class JSessionStorageXcacheTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @todo Implement testTest().
+     * @todo Implement testIsSupported().
      */
-    public function testTest() {
+    public function testIsSupported() {
         // Remove the following lines when you implement this test.
         $this->markTestIncomplete(
                 'This test has not been implemented yet.'
         );
     }
-
 }
-
-?>


### PR DESCRIPTION
This makes this the same across all packaged and isSupported() is just much more descriptive than test(). I also changed all the tests to use dynamic access to static methods instead of call_user_func_array() since we're know in PHP 5.3 land.
