### PR TITLE
Modify class generation for JDatabaseDriver::getConnectors()

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -190,7 +190,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 			}
 
 			// Derive the class name from the type.
-			$class = str_ireplace(array('.php', 'sql'), array('', 'SQL'), 'JDatabaseDriver' . ucfirst(trim($type)));
+			$class = str_ireplace('.php', '', 'JDatabaseDriver' . ucfirst(trim($type)));
 
 			// If the class doesn't exist we have nothing left to do but look at the next type.  We did our best.
 			if (!class_exists($class))


### PR DESCRIPTION
The check for 'sql' in file names is no longer needed with the classes having been renamed.  As is, install on Rouven's joomla30 branch fails to list the MySQL(i) adapters due to the class names being incorrectly generated.
