### PR TITLE
Change test method name to testIsMinimumVersion

### DIFF
--- a/tests/suite/joomla/database/JDatabaseTest.php
+++ b/tests/suite/joomla/database/JDatabaseTest.php
@@ -288,18 +288,18 @@ class JDatabaseTest extends JoomlaDatabaseTestCase
 	}
 
 	/**
-	 * Tests the JDatabase::isSupported method.
+	 * Tests the JDatabase::isMinimumVersion method.
 	 *
 	 * @return  void
 	 *
 	 * @since   12.1
 	 */
-	public function testIsSupported()
+	public function testIsMinimumVersion()
 	{
 		$this->assertThat(
-			$this->db->isSupported(),
+			$this->db->isMinimumVersion(),
 			$this->isTrue(),
-			'isSupported should return a boolean true if the database version is supported by the driver'
+			'isMinimumVersion should return a boolean true if the database version is supported by the driver'
 		);
 	}
 


### PR DESCRIPTION
When #919 was formed, the test method for the method renamed from isSupported to isMinimumVersion in JDatabaseTest should have been renamed to testIsMinimumVersion as well.  This syncs the test class with that change.
