### PR TITLE
Update libraries/joomla/mail/mail.php

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -281,12 +281,12 @@ class JMail extends PHPMailer
 			{
 				foreach ($attachment as $file)
 				{
-					parent::AddAttachment($file);
+					parent::AddAttachment($file, $name, $encoding, $type);
 				}
 			}
 			else
 			{
-				parent::AddAttachment($attachment);
+				parent::AddAttachment($attachment, $name, $encoding, $type);
 			}
 		}
 


### PR DESCRIPTION
The addAttachment method of the JMail class does not pass on the parameters
$name, $encoding and $type to its PHPMailer parent class.
This makes it impossible to e.g. specify another file name for an attachment.
