### PR TITLE
Cleanup in installer adapters

### DIFF
--- a/libraries/joomla/installer/adapters/component.php
+++ b/libraries/joomla/installer/adapters/component.php
@@ -110,13 +110,13 @@ class JInstallerComponent extends JAdapterInstance
 		$this->manifest = $this->parent->getManifest();
 		$name = strtolower(JFilterInput::getInstance()->clean((string) $this->manifest->name, 'cmd'));
 
-		if (substr($name, 0, 4) == "com_")
+		if (substr($name, 0, 4) == 'com_')
 		{
 			$extension = $name;
 		}
 		else
 		{
-			$extension = "com_$name";
+			$extension = 'com_' . $name;
 		}
 
 		$lang = JFactory::getLanguage();
@@ -139,9 +139,9 @@ class JInstallerComponent extends JAdapterInstance
 		{
 			$folder = (string) $element->attributes()->folder;
 
-			if ($folder && file_exists("$path/$folder"))
+			if ($folder && file_exists($path . '/' . $folder))
 			{
-				$source = "$path/$folder";
+				$source = $path . '/' . $folder;
 			}
 		}
 		$lang->load($extension . '.sys', $source, null, false, false) || $lang->load($extension . '.sys', JPATH_ADMINISTRATOR, null, false, false)
@@ -164,17 +164,21 @@ class JInstallerComponent extends JAdapterInstance
 		// Get the extension manifest object
 		$this->manifest = $this->parent->getManifest();
 
-		// Manifest Document Setup Section
+		/*
+		 * ---------------------------------------------------------------------------------------------
+		 * Manifest Document Setup Section
+		 * ---------------------------------------------------------------------------------------------
+		 */
 
 		// Set the extension's name
 		$name = strtolower(JFilterInput::getInstance()->clean((string) $this->manifest->name, 'cmd'));
-		if (substr($name, 0, 4) == "com_")
+		if (substr($name, 0, 4) == 'com_')
 		{
 			$element = $name;
 		}
 		else
 		{
-			$element = "com_$name";
+			$element = 'com_' . $name;
 		}
 
 		$this->set('name', $name);
@@ -187,10 +191,14 @@ class JInstallerComponent extends JAdapterInstance
 		$this->parent->setPath('extension_site', JPath::clean(JPATH_SITE . '/components/' . $this->get('element')));
 		$this->parent->setPath('extension_administrator', JPath::clean(JPATH_ADMINISTRATOR . '/components/' . $this->get('element')));
 
-		// Copy this as its used as a common base
+		// Copy the admin path as it's used as a common base
 		$this->parent->setPath('extension_root', $this->parent->getPath('extension_administrator'));
 
-		// Basic Checks Section
+		/*
+		 * ---------------------------------------------------------------------------------------------
+		 * Basic Checks Section
+		 * ---------------------------------------------------------------------------------------------
+		 */
 
 		// Make sure that we have an admin element
 		if (!$this->manifest->administration)
@@ -199,22 +207,23 @@ class JInstallerComponent extends JAdapterInstance
 			return false;
 		}
 
-		// Filesystem Processing Section
+		/*
+		 * ---------------------------------------------------------------------------------------------
+		 * Filesystem Processing Section
+		 * ---------------------------------------------------------------------------------------------
+		 */
 
-		// If the component site or admin directory already exists, then we will assume that the component is already
-		// installed or another component is using that directory.
+		/*
+		 * If the component site or admin directory already exists, then we will assume that the component is already
+		 * installed or another component is using that directory.
+		 */
 
 		if (file_exists($this->parent->getPath('extension_site')) || file_exists($this->parent->getPath('extension_administrator')))
 		{
 			// Look for an update function or update tag
 			$updateElement = $this->manifest->update;
 
-			/*
-			 * Upgrade manually set or
-			 * Update function available or
-			 * Update tag detected
-			 */
-
+			// Upgrade manually set or update function available or update tag detected
 			if ($this->parent->isUpgrade() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
 				|| $updateElement)
 			{
@@ -242,7 +251,11 @@ class JInstallerComponent extends JAdapterInstance
 			}
 		}
 
-		// Installer Trigger Loading
+		/*
+		 * ---------------------------------------------------------------------------------------------
+		 * Installer Trigger Loading
+		 * ---------------------------------------------------------------------------------------------
+		 */
 
 		// If there is an manifest class file, lets load it; we'll copy it later (don't have dest yet)
 		$manifestScript = (string) $this->manifest->scriptfile;
@@ -267,8 +280,6 @@ class JInstallerComponent extends JAdapterInstance
 
 				// And set this so we can copy it later
 				$this->set('manifest_script', $manifestScript);
-
-				// Note: if we don't find the class, don't bother to copy the file
 			}
 		}
 
@@ -305,9 +316,10 @@ class JInstallerComponent extends JAdapterInstance
 			}
 		}
 
-		// Since we created the component directory and will want to remove it if we have to roll back
-		// the installation, let's add it to the installation step stack
-
+		/*
+		 * Since we created the component directory and we will want to remove it if we have to roll back
+		 * the installation, let's add it to the installation step stack
+		 */
 		if ($created)
 		{
 			$this->parent->pushStep(array('type' => 'folder', 'path' => $this->parent->getPath('extension_site')));
@@ -391,24 +403,18 @@ class JInstallerComponent extends JAdapterInstance
 			}
 		}
 
-		/**
+		/*
 		 * ---------------------------------------------------------------------------------------------
 		 * Database Processing Section
 		 * ---------------------------------------------------------------------------------------------
 		 */
 
-		/*
-		 * Let's run the install queries for the component
-		 * If Joomla 1.5 compatible, with discreet sql files - execute appropriate
-		 * file for utf-8 support or non-utf-8 support
-		 */
-		// Try for Joomla 1.5 type queries
-		// Second argument is the utf compatible version attribute
+		// Run the install queries for the component
 		if (isset($this->manifest->install->sql))
 		{
-			$utfresult = $this->parent->parseSQLFiles($this->manifest->install->sql);
+			$result = $this->parent->parseSQLFiles($this->manifest->install->sql);
 
-			if ($utfresult === false)
+			if ($result === false)
 			{
 				// Install failed, rollback changes
 				$this->parent->abort(JText::sprintf('JLIB_INSTALLER_ABORT_COMP_INSTALL_SQL_ERROR', $db->stderr(true)));
@@ -569,13 +575,13 @@ class JInstallerComponent extends JAdapterInstance
 
 		// Set the extension's name
 		$name = strtolower(JFilterInput::getInstance()->clean((string) $this->manifest->name, 'cmd'));
-		if (substr($name, 0, 4) == "com_")
+		if (substr($name, 0, 4) == 'com_')
 		{
 			$element = $name;
 		}
 		else
 		{
-			$element = "com_$name";
+			$element = 'com_' . $name;
 		}
 
 		$this->set('name', $name);
@@ -597,12 +603,10 @@ class JInstallerComponent extends JAdapterInstance
 		$this->parent->setPath('extension_site', JPath::clean(JPATH_SITE . '/components/' . $this->get('element')));
 		$this->parent->setPath('extension_administrator', JPath::clean(JPATH_ADMINISTRATOR . '/components/' . $this->get('element')));
 
-		// Copy this as its used as a common base
+		// Copy the admin path as it's used as a common base
 		$this->parent->setPath('extension_root', $this->parent->getPath('extension_administrator'));
 
-		/**
-		 * Hunt for the original XML file
-		 */
+		// Hunt for the original XML file
 		$old_manifest = null;
 
 		// Create a new installer because findManifest sets stuff
@@ -654,6 +658,7 @@ class JInstallerComponent extends JAdapterInstance
 		 * Installer Trigger Loading
 		 * ---------------------------------------------------------------------------------------------
 		 */
+
 		// If there is an manifest class file, lets load it; we'll copy it later (don't have dest yet)
 		$manifestScript = (string) $this->manifest->scriptfile;
 
@@ -677,8 +682,6 @@ class JInstallerComponent extends JAdapterInstance
 
 				// And set this so we can copy it later
 				$this->set('manifest_script', $manifestScript);
-
-				// Note: if we don't find the class, don't bother to copy the file
 			}
 		}
 
@@ -815,9 +818,7 @@ class JInstallerComponent extends JAdapterInstance
 		 * ---------------------------------------------------------------------------------------------
 		 */
 
-		/*
-		 * Let's run the update queries for the component
-		 */
+		// Let's run the update queries for the component
 		$row = JTable::getInstance('extension');
 		$eid = $row->find(array('element' => strtolower($this->get('element')), 'type' => 'component'));
 
@@ -852,7 +853,7 @@ class JInstallerComponent extends JAdapterInstance
 
 		/*
 		 * If we have an install script, let's include it, execute the custom
-		 * install method, and append the return value from the custom install
+		 * update method, and append the return value from the custom update
 		 * method to the installation message.
 		 */
 		ob_start();
@@ -935,6 +936,7 @@ class JInstallerComponent extends JAdapterInstance
 		{
 			$this->parent->manifestClass->postflight('update', $this);
 		}
+
 		// Append messages
 		$msg .= ob_get_contents();
 		ob_end_clean();
@@ -984,7 +986,7 @@ class JInstallerComponent extends JAdapterInstance
 		$this->parent->setPath('extension_administrator', JPath::clean(JPATH_ADMINISTRATOR . '/components/' . $row->element));
 		$this->parent->setPath('extension_site', JPath::clean(JPATH_SITE . '/components/' . $row->element));
 
-		// Copy this as its used as a common base
+		// Copy the admin path as it's used as a common base
 		$this->parent->setPath('extension_root', $this->parent->getPath('extension_administrator'));
 
 		/**
@@ -1019,13 +1021,13 @@ class JInstallerComponent extends JAdapterInstance
 
 		// Set the extensions name
 		$name = strtolower(JFilterInput::getInstance()->clean((string) $this->manifest->name, 'cmd'));
-		if (substr($name, 0, 4) == "com_")
+		if (substr($name, 0, 4) == 'com_')
 		{
 			$element = $name;
 		}
 		else
 		{
-			$element = "com_$name";
+			$element = 'com_' . $name;
 		}
 
 		$this->set('name', $name);
@@ -1039,6 +1041,7 @@ class JInstallerComponent extends JAdapterInstance
 		 * Installer Trigger Loading and Uninstall
 		 * ---------------------------------------------------------------------------------------------
 		 */
+
 		// If there is an manifest class file, lets load it; we'll copy it later (don't have dest yet)
 		$scriptFile = (string) $this->manifest->scriptfile;
 
@@ -1062,8 +1065,6 @@ class JInstallerComponent extends JAdapterInstance
 
 				// And set this so we can copy it later
 				$this->set('manifest_script', $scriptFile);
-
-				// Note: if we don't find the class, don't bother to copy the file
 			}
 		}
 
@@ -1090,18 +1091,12 @@ class JInstallerComponent extends JAdapterInstance
 		 * ---------------------------------------------------------------------------------------------
 		 */
 
-		/*
-		 * Let's run the uninstall queries for the component
-		 * If Joomla CMS 1.5 compatible, with discrete sql files - execute appropriate
-		 * file for utf-8 support or non-utf support
-		 */
-		// Try for Joomla 1.5 type queries
-		// Second argument is the utf compatible version attribute
+		// Let's run the uninstall queries for the component
 		if (isset($this->manifest->uninstall->sql))
 		{
-			$utfresult = $this->parent->parseSQLFiles($this->manifest->uninstall->sql);
+			$result = $this->parent->parseSQLFiles($this->manifest->uninstall->sql);
 
-			if ($utfresult === false)
+			if ($result === false)
 			{
 				// Install failed, rollback changes
 				JError::raiseWarning(100, JText::sprintf('JLIB_INSTALLER_ERROR_COMP_UNINSTALL_SQL_ERROR', $db->stderr(true)));
@@ -1217,7 +1212,7 @@ class JInstallerComponent extends JAdapterInstance
 		$query->from('#__menu AS m');
 		$query->leftJoin('#__extensions AS e ON m.component_id = e.extension_id');
 		$query->where('m.parent_id = 1');
-		$query->where("m.client_id = 1");
+		$query->where('m.client_id = 1');
 		$query->where('e.element = ' . $db->quote($option));
 
 		$db->setQuery($query);
@@ -1227,7 +1222,6 @@ class JInstallerComponent extends JAdapterInstance
 		// Check if menu items exist
 		if ($componentrow)
 		{
-
 			// Don't do anything if overwrite has not been enabled
 			if (!$this->parent->isOverwrite())
 			{
@@ -1245,7 +1239,7 @@ class JInstallerComponent extends JAdapterInstance
 		}
 		else
 		{
-			// Lets Find the extension id
+			// Lets find the extension id
 			$query->clear();
 			$query->select('e.extension_id');
 			$query->from('#__extensions AS e');
@@ -1580,13 +1574,13 @@ class JInstallerComponent extends JAdapterInstance
 
 		// Set the extensions name
 		$name = strtolower(JFilterInput::getInstance()->clean((string) $this->manifest->name, 'cmd'));
-		if (substr($name, 0, 4) == "com_")
+		if (substr($name, 0, 4) == 'com_')
 		{
 			$element = $name;
 		}
 		else
 		{
-			$element = "com_$name";
+			$element = 'com_' . $name;
 		}
 
 		$this->set('name', $name);
@@ -1608,7 +1602,7 @@ class JInstallerComponent extends JAdapterInstance
 		$this->parent->setPath('extension_site', JPath::clean(JPATH_SITE . '/components/' . $this->get('element')));
 		$this->parent->setPath('extension_administrator', JPath::clean(JPATH_ADMINISTRATOR . '/components/' . $this->get('element')));
 
-		// Copy this as its used as a common base
+		// Copy the admin path as it's used as a common base
 		$this->parent->setPath('extension_root', $this->parent->getPath('extension_administrator'));
 
 		/**
@@ -1652,8 +1646,6 @@ class JInstallerComponent extends JAdapterInstance
 
 				// And set this so we can copy it later
 				$this->set('manifest_script', $manifestScript);
-
-				// Note: if we don't find the class, don't bother to copy the file
 			}
 		}
 
@@ -1694,13 +1686,7 @@ class JInstallerComponent extends JAdapterInstance
 		 * ---------------------------------------------------------------------------------------------
 		 */
 
-		/*
-		 * Let's run the install queries for the component
-		 *	If Joomla 1.5 compatible, with discreet sql files - execute appropriate
-		 *	file for utf-8 support or non-utf-8 support
-		 */
-		// Try for Joomla 1.5 type queries
-		// second argument is the utf compatible version attribute
+		// Let's run the install queries for the component
 		if (isset($this->manifest->install->sql))
 		{
 			$utfresult = $this->parent->parseSQLFiles($this->manifest->install->sql);
@@ -1732,7 +1718,7 @@ class JInstallerComponent extends JAdapterInstance
 
 		/*
 		 * If we have an install script, lets include it, execute the custom
-		 * install method, and append the return value from the custom install
+		 * discover_install method, and append the return value from the custom discover_install
 		 * method to the installation message.
 		 */
 		ob_start();

--- a/libraries/joomla/installer/adapters/file.php
+++ b/libraries/joomla/installer/adapters/file.php
@@ -56,7 +56,11 @@ class JInstallerFile extends JAdapterInstance
 		// Get the extension manifest object
 		$this->manifest = $this->parent->getManifest();
 
-		// Manifest Document Setup Section
+		/*
+		 * ---------------------------------------------------------------------------------------------
+		 * Manifest Document Setup Section
+		 * ---------------------------------------------------------------------------------------------
+		 */
 
 		// Set the extension's name
 		$name = JFilterInput::getInstance()->clean((string) $this->manifest->name, 'string');
@@ -102,6 +106,7 @@ class JInstallerFile extends JAdapterInstance
 		 * Installer Trigger Loading
 		 * ---------------------------------------------------------------------------------------------
 		 */
+
 		// If there is an manifest class file, lets load it; we'll copy it later (don't have dest yet)
 		$this->scriptElement = $this->manifest->scriptfile;
 		$manifestScript = (string) $this->manifest->scriptfile;
@@ -126,8 +131,6 @@ class JInstallerFile extends JAdapterInstance
 
 				// And set this so we can copy it later
 				$this->set('manifest_script', $manifestScript);
-
-				// Note: if we don't find the class, don't bother to copy the file
 			}
 		}
 
@@ -153,7 +156,11 @@ class JInstallerFile extends JAdapterInstance
 		// Populate File and Folder List to copy
 		$this->populateFilesAndFolderList();
 
-		// Filesystem Processing Section
+		/*
+		 * ---------------------------------------------------------------------------------------------
+		 * Filesystem Processing Section
+		 * ---------------------------------------------------------------------------------------------
+		 */
 
 		// Now that we have folder list, lets start creating them
 		foreach ($this->folderList as $folder)
@@ -187,13 +194,17 @@ class JInstallerFile extends JAdapterInstance
 		// Parse optional tags
 		$this->parent->parseLanguages($this->manifest->languages);
 
-		// Finalization and Cleanup Section
+		/**
+		 * ---------------------------------------------------------------------------------------------
+		 * Finalization and Cleanup Section
+		 * ---------------------------------------------------------------------------------------------
+		 */
 
 		// Get a database connector object
 		$db = $this->parent->getDbo();
 
 		/*
-		 * Check to see if a module by the same name is already installed
+		 * Check to see if a file extension by the same name is already installed
 		 * If it is, then update the table because if the files aren't there
 		 * we can assume that it was (badly) uninstalled
 		 * If it isn't, add an entry to extensions
@@ -270,15 +281,12 @@ class JInstallerFile extends JAdapterInstance
 			$this->parent->pushStep(array('type' => 'extension', 'extension_id' => $row->extension_id));
 		}
 
-		/*
-		 * Let's run the queries for the file
-		 */
-		// second argument is the utf compatible version attribute
+		// Let's run the queries for the file
 		if (strtolower($this->route) == 'install')
 		{
-			$utfresult = $this->parent->parseSQLFiles($this->manifest->install->sql);
+			$result = $this->parent->parseSQLFiles($this->manifest->install->sql);
 
-			if ($utfresult === false)
+			if ($result === false)
 			{
 				// Install failed, rollback changes
 				$this->parent->abort(
@@ -308,7 +316,7 @@ class JInstallerFile extends JAdapterInstance
 			}
 		}
 
-		// Start Joomla! 1.6
+		// Try to run the script file's custom method based on the route
 		ob_start();
 		ob_implicit_flush(false);
 
@@ -419,7 +427,7 @@ class JInstallerFile extends JAdapterInstance
 		// Because files may not have their own folders we cannot use the standard method of finding an installation manifest
 		if (file_exists($manifestFile))
 		{
-			// Set the plugin root path
+			// Set the files root path
 			// @todo remove code: . '/files/' . $manifest->filename);
 			$this->parent->setPath('extension_root', JPATH_ROOT);
 
@@ -432,9 +440,7 @@ class JInstallerFile extends JAdapterInstance
 				return false;
 			}
 
-			/*
-			 * Check for a valid XML root tag.
-			 */
+			// Check for a valid XML root tag.
 			if ($xml->getName() != 'extension')
 			{
 				JError::raiseWarning(100, JText::_('JLIB_INSTALLER_ERROR_FILE_UNINSTALL_INVALID_MANIFEST'));
@@ -467,8 +473,6 @@ class JInstallerFile extends JAdapterInstance
 
 					// And set this so we can copy it later
 					$this->set('manifest_script', $manifestScript);
-
-					// Note: if we don't find the class, don't bother to copy the file
 				}
 			}
 
@@ -484,16 +488,10 @@ class JInstallerFile extends JAdapterInstance
 			$msg = ob_get_contents();
 			ob_end_clean();
 
-			/*
-			 * Let's run the uninstall queries for the component
-			 *	If Joomla 1.5 compatible, with discreet sql files - execute appropriate
-			 *	file for utf-8 support or non-utf support
-			 */
-			// Try for Joomla 1.5 type queries
-			// Second argument is the utf compatible version attribute
-			$utfresult = $this->parent->parseSQLFiles($this->manifest->uninstall->sql);
+			// Let's run the uninstall queries for the extension
+			$result = $this->parent->parseSQLFiles($this->manifest->uninstall->sql);
 
-			if ($utfresult === false)
+			if ($result === false)
 			{
 				// Install failed, rollback changes
 				JError::raiseWarning(100, JText::sprintf('JLIB_INSTALLER_ERROR_FILE_UNINSTALL_SQL_ERROR', $db->stderr(true)));
@@ -631,7 +629,6 @@ class JInstallerFile extends JAdapterInstance
 	 */
 	protected function populateFilesAndFolderList()
 	{
-
 		// Initialise variable
 		$this->folderList = array();
 		$this->fileList = array();
@@ -650,8 +647,7 @@ class JInstallerFile extends JAdapterInstance
 			$folder = (string) $eFiles->attributes()->folder;
 			$target = (string) $eFiles->attributes()->target;
 
-			// Split folder names into array to get folder names. This will
-			// help in creating folders
+			// Split folder names into array to get folder names. This will help in creating folders
 			$arrList = preg_split("#/|\\/#", $target);
 
 			$folderName = $jRootPath;

--- a/libraries/joomla/installer/adapters/language.php
+++ b/libraries/joomla/installer/adapters/language.php
@@ -163,13 +163,8 @@ class JInstallerLanguage extends JAdapterInstance
 			// Look for an update function or update tag
 			$updateElement = $this->manifest->update;
 
-			/*
-			 * Upgrade manually set or
-			 * Update function available or
-			 * Update tag detected
-			 */
-			if ($this->parent->isUpgrade() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
-				|| $updateElement)
+			// Upgrade manually set or update tag detected
+			if ($this->parent->isUpgrade() || $updateElement)
 			{
 				// Transfer control to the update function
 				return $this->update();
@@ -376,7 +371,11 @@ class JInstallerLanguage extends JAdapterInstance
 		// Get the language description and set it as message
 		$this->parent->set('message', (string) $xml->description);
 
-		// Finalization and Cleanup Section
+		/**
+		 * ---------------------------------------------------------------------------------------------
+		 * Finalization and Cleanup Section
+		 * ---------------------------------------------------------------------------------------------
+		 */
 
 		// Clobber any possible pending updates
 		$update = JTable::getInstance('update');
@@ -415,22 +414,6 @@ class JInstallerLanguage extends JAdapterInstance
 			// Install failed, roll back changes
 			$this->parent->abort(JText::sprintf('JLIB_INSTALLER_ABORT', $row->getError()));
 			return false;
-		}
-
-		// And now we run the postflight
-		ob_start();
-		ob_implicit_flush(false);
-		if ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'postflight'))
-		{
-			$this->parent->manifestClass->postflight('update', $this);
-		}
-
-		// Append messages
-		$msg .= ob_get_contents();
-		ob_end_clean();
-		if ($msg != '')
-		{
-			$this->parent->set('extension_message', $msg);
 		}
 
 		return $row->get('extension_id');

--- a/libraries/joomla/installer/adapters/library.php
+++ b/libraries/joomla/installer/adapters/library.php
@@ -60,7 +60,11 @@ class JInstallerLibrary extends JAdapterInstance
 		// Get the extension manifest object
 		$this->manifest = $this->parent->getManifest();
 
-		// Manifest Document Setup Section
+		/*
+		 * ---------------------------------------------------------------------------------------------
+		 * Manifest Document Setup Section
+		 * ---------------------------------------------------------------------------------------------
+		 */
 
 		// Set the extension's name
 		$name = JFilterInput::getInstance()->clean((string) $this->manifest->name, 'string');
@@ -116,7 +120,11 @@ class JInstallerLibrary extends JAdapterInstance
 			$this->parent->setPath('extension_root', JPATH_PLATFORM . '/' . implode(DIRECTORY_SEPARATOR, explode('/', $group)));
 		}
 
-		// Filesystem Processing Section
+		/*
+		 * ---------------------------------------------------------------------------------------------
+		 * Filesystem Processing Section
+		 * ---------------------------------------------------------------------------------------------
+		 */
 
 		// If the library directory does not exist, let's create it
 		$created = false;
@@ -136,7 +144,6 @@ class JInstallerLibrary extends JAdapterInstance
 		 * have to roll back the installation, let's add it to the installation
 		 * step stack
 		 */
-
 		if ($created)
 		{
 			$this->parent->pushStep(array('type' => 'folder', 'path' => $this->parent->getPath('extension_root')));
@@ -160,7 +167,7 @@ class JInstallerLibrary extends JAdapterInstance
 		$row->type = 'library';
 		$row->element = $this->get('element');
 
-		// There is no folder for modules
+		// There is no folder for libraries
 		$row->folder = '';
 		$row->enabled = 1;
 		$row->protected = 0;
@@ -178,7 +185,11 @@ class JInstallerLibrary extends JAdapterInstance
 			return false;
 		}
 
-		// Finalization and Cleanup Section
+		/**
+		 * ---------------------------------------------------------------------------------------------
+		 * Finalization and Cleanup Section
+		 * ---------------------------------------------------------------------------------------------
+		 */
 
 		// Lastly, we will copy the manifest file to its appropriate place.
 		$manifest = array();
@@ -206,7 +217,11 @@ class JInstallerLibrary extends JAdapterInstance
 		// Get the extension manifest object
 		$this->manifest = $this->parent->getManifest();
 
-		// Manifest Document Setup Section
+		/*
+		 * ---------------------------------------------------------------------------------------------
+		 * Manifest Document Setup Section
+		 * ---------------------------------------------------------------------------------------------
+		 */
 
 		// Set the extensions name
 		$name = (string) $this->manifest->name;
@@ -285,7 +300,6 @@ class JInstallerLibrary extends JAdapterInstance
 			}
 
 			// Check for a valid XML root tag.
-
 			if ($xml->getName() != 'extension')
 			{
 				JError::raiseWarning(100, JText::_('JLIB_INSTALLER_ERROR_LIB_UNINSTALL_INVALID_MANIFEST'));

--- a/libraries/joomla/installer/adapters/package.php
+++ b/libraries/joomla/installer/adapters/package.php
@@ -63,7 +63,11 @@ class JInstallerPackage extends JAdapterInstance
 		// Get the extension manifest object
 		$this->manifest = $this->parent->getManifest();
 
-		// Manifest Document Setup Section
+		/*
+		 * ---------------------------------------------------------------------------------------------
+		 * Manifest Document Setup Section
+		 * ---------------------------------------------------------------------------------------------
+		 */
 
 		// Set the extensions name
 		$filter = JFilterInput::getInstance();
@@ -103,6 +107,7 @@ class JInstallerPackage extends JAdapterInstance
 		 * Installer Trigger Loading
 		 * ---------------------------------------------------------------------------------------------
 		 */
+
 		// If there is an manifest class file, lets load it; we'll copy it later (don't have dest yet)
 		$this->scriptElement = $this->manifest->scriptfile;
 		$manifestScript = (string) $this->manifest->scriptfile;
@@ -127,8 +132,6 @@ class JInstallerPackage extends JAdapterInstance
 
 				// And set this so we can copy it later
 				$this->set('manifest_script', $manifestScript);
-
-				// Note: if we don't find the class, don't bother to copy the file
 			}
 		}
 
@@ -151,7 +154,11 @@ class JInstallerPackage extends JAdapterInstance
 		$msg = ob_get_contents();
 		ob_end_clean();
 
-		// Filesystem Processing Section
+		/*
+		 * ---------------------------------------------------------------------------------------------
+		 * Filesystem Processing Section
+		 * ---------------------------------------------------------------------------------------------
+		 */
 
 		if ($folder = $files->attributes()->folder)
 		{
@@ -212,7 +219,11 @@ class JInstallerPackage extends JAdapterInstance
 		// Parse optional tags
 		$this->parent->parseLanguages($this->manifest->languages);
 
-		// Extension Registration
+		/*
+		 * ---------------------------------------------------------------------------------------------
+		 * Extension Registration
+		 * ---------------------------------------------------------------------------------------------
+		 */
 
 		$row = JTable::getInstance('extension');
 		$eid = $row->find(array('element' => strtolower($this->get('element')), 'type' => 'package'));
@@ -247,9 +258,13 @@ class JInstallerPackage extends JAdapterInstance
 			return false;
 		}
 
-		// Finalization and Cleanup Section
+		/*
+		 * ---------------------------------------------------------------------------------------------
+		 * Finalization and Cleanup Section
+		 * ---------------------------------------------------------------------------------------------
+		 */
 
-		// Start Joomla! 1.6
+		// Run the custom method based on the route
 		ob_start();
 		ob_implicit_flush(false);
 
@@ -392,9 +407,7 @@ class JInstallerPackage extends JAdapterInstance
 			return false;
 		}
 
-		/*
-		 * Check for a valid XML root tag.
-		 */
+		// Check for a valid XML root tag.
 		if ($xml->getName() != 'extension')
 		{
 			JError::raiseWarning(100, JText::_('JLIB_INSTALLER_ERROR_PACK_UNINSTALL_INVALID_MANIFEST'));
@@ -425,8 +438,6 @@ class JInstallerPackage extends JAdapterInstance
 
 				// And set this so we can copy it later
 				$this->set('manifest_script', $manifestScript);
-
-				// Note: if we don't find the class, don't bother to copy the file
 			}
 		}
 

--- a/libraries/joomla/installer/adapters/template.php
+++ b/libraries/joomla/installer/adapters/template.php
@@ -138,13 +138,8 @@ class JInstallerTemplate extends JAdapterInstance
 		{
 			$updateElement = $xml->update;
 
-			/*
-			 * Upgrade manually set or
-			 * Update function available or
-			 * Update tag detected
-			 */
-			if ($this->parent->isUpgrade() || ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'update'))
-				|| $updateElement)
+			// Upgrade manually set or update tag detected
+			if ($this->parent->isUpgrade() || $updateElement)
 			{
 				// Force this one
 				$this->parent->setOverwrite(true);
@@ -244,7 +239,11 @@ class JInstallerTemplate extends JAdapterInstance
 			return false;
 		}
 
-		// Extension Registration
+		/**
+		 * ---------------------------------------------------------------------------------------------
+		 * Extension Registration
+		 * ---------------------------------------------------------------------------------------------
+		 */
 
 		$row = JTable::getInstance('extension');
 
@@ -446,9 +445,8 @@ class JInstallerTemplate extends JAdapterInstance
 		{
 			if ($template == 'system')
 			{
-				continue;
-
 				// Ignore special system template
+				continue;
 			}
 			$manifest_details = JInstaller::parseXMLInstallFile(JPATH_SITE . "/templates/$template/templateDetails.xml");
 			$extension = JTable::getInstance('extension');
@@ -465,9 +463,8 @@ class JInstallerTemplate extends JAdapterInstance
 		{
 			if ($template == 'system')
 			{
-				continue;
-
 				// Ignore special system template
+				continue;
 			}
 
 			$manifest_details = JInstaller::parseXMLInstallFile(JPATH_ADMINISTRATOR . "/templates/$template/templateDetails.xml");


### PR DESCRIPTION
- Reviewed and edited many of the inline comments for the adapters for consistent formatting, removing legacy API references, etc.
- Removed instances where an `<images>` tag was processed (noted as deprecated in module adapter, checked for in plugin uninstall)
- Removed preflight from being executed in plugin uninstall
- Removed references to script file methods in adapters that do not have full implementation (for example, language adapter was checking for a custom update method but doesn't support script files at this time)
