### PR TITLE
Fix JModuleHelper::_load() broken in #934.

### DIFF
--- a/libraries/joomla/application/module/helper.php
+++ b/libraries/joomla/application/module/helper.php
@@ -373,6 +373,9 @@ abstract class JModuleHelper
 
 		unset($dupes);
 
+		// Return to simple indexing that matches the query order.
+		$clean = array_values($clean);
+
 		return $clean;
 	}
 


### PR DESCRIPTION
JModuleHelper::getModules() relies on the index starting at 0.
