### PR TITLE
fix bug #28039

### DIFF
--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -245,8 +245,7 @@ class JBrowser
 				 * but only if version is > 9.80. See: http://dev.opera.com/articles/view/opera-ua-string-changes/ */
 				if ($this->_majorVersion == 9 && $this->_minorVersion >= 80)
 				{
-					preg_match('|Version[/ ]([0-9.]+)|', $this->_agent, $version);
-					list ($this->_majorVersion, $this->_minorVersion) = explode('.', $version[1]);
+					$this->identifyBrowserVersion();
 				}
 			}
 			elseif (preg_match('|Chrome[/ ]([0-9.]+)|', $this->_agent, $version))
@@ -317,10 +316,7 @@ class JBrowser
 				{
 					// Safari.
 					$this->setBrowser('safari');
-
-					// Set browser version, not engine version
-					preg_match('|Version[/ ]([0-9.]+)|', $this->_agent, $version);
-					list ($this->_majorVersion, $this->_minorVersion) = explode('.', $version[1]);
+					$this->identifyBrowserVersion();
 				}
 			}
 			elseif (preg_match('|Mozilla/([0-9.]+)|', $this->_agent, $version))
@@ -433,6 +429,25 @@ class JBrowser
 		return $this->_platform;
 	}
 
+	/**
+	 * Set browser version, not by engine version
+	 * Fallback to use when no other method identify the engine version
+	 * 
+	 * @return null
+	 */
+	protected function identifyBrowserVersion()
+	{
+		if (preg_match('|Version[/ ]([0-9.]+)|', $this->_agent, $version))
+		{
+			list ($this->_majorVersion, $this->_minorVersion) = explode('.', $version[1]);
+			return;
+		}
+		// Can't identify browser version
+		$this->_majorVersion = 0;
+		$this->_minorVersion = 0;
+		JLog::add("Can't identify browser version. Agent: " . $this->_agent, JLog::NOTICE);
+	}
+	
 	/**
 	 * Sets the current browser.
 	 *

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -432,8 +432,8 @@ class JBrowser
 	/**
 	 * Set browser version, not by engine version
 	 * Fallback to use when no other method identify the engine version
-	 * 
-	 * @return null
+	 *
+	 * @return void
 	 */
 	protected function identifyBrowserVersion()
 	{
@@ -447,7 +447,7 @@ class JBrowser
 		$this->_minorVersion = 0;
 		JLog::add("Can't identify browser version. Agent: " . $this->_agent, JLog::NOTICE);
 	}
-	
+
 	/**
 	 * Sets the current browser.
 	 *


### PR DESCRIPTION
The bug produce cause preg_match not checked for return value. 
The bug report: PHP Notice:  Undefined offset: 1
Cause it tries to find the second item in the matches ($version) array, where is declared from preg_match function before the line error.
See more here:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28039
