### PR TITLE
Make doc block match what is actually present.

### DIFF
--- a/libraries/joomla/table/user.php
+++ b/libraries/joomla/table/user.php
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die;
 class JTableUser extends JTable
 {
 	/**
-	 * Associative array of user names => group ids
+	 * Associative array of group ids => group ids for the user
 	 *
 	 * @var    array
 	 * @since  11.1


### PR DESCRIPTION
There was a change made to this library that made this doc block description incorrect. Because user group name is not required to be unique it can't be used as a key in an array returned by loadAssocList.  See CMS tracker #28125 (corresponding change already committed). 
