### PR TITLE
Fixing up the unit tests.

### DIFF
--- a/libraries/joomla/application/router.php
+++ b/libraries/joomla/application/router.php
@@ -403,7 +403,7 @@ class JRouter extends JObject
 
 		foreach ($this->_rules['parse'] as $rule)
 		{
-			$vars += call_user_func_array($rule, array($this, $uri));
+			$vars += call_user_func_array($rule, array(&$this, &$uri));
 		}
 
 		return $vars;
@@ -422,7 +422,7 @@ class JRouter extends JObject
 	{
 		foreach ($this->_rules['build'] as $rule)
 		{
-			call_user_func_array($rule, array($this, $uri));
+			call_user_func_array($rule, array(&$this, &$uri));
 		}
 	}
 


### PR DESCRIPTION
PHP's `call_user_func_array()` function doesn't respect the standard objects as references paradigm ... have to leave the & symbols.
