### PR TITLE
Added JStringNormalise::fromCamelCase()

### DIFF
--- a/libraries/joomla/string/normalise.php
+++ b/libraries/joomla/string/normalise.php
@@ -19,6 +19,20 @@ defined('JPATH_PLATFORM') or die;
 abstract class JStringNormalise
 {
 	/**
+	 * Method to convert a string from camel case.
+	 *
+	 * @param   string  $input  The string input.
+	 *
+	 * @return  string  The space separated string.
+	 *
+	 * @since   12.1
+	 */
+	public static function fromCamelCase($input)
+	{
+		return JString::trim(preg_replace('#([A-Z])#', ' $1', $input));
+	}
+
+	/**
 	 * Method to convert a string into camel case.
 	 *
 	 * @param   string  $input  The string input.

--- a/tests/suite/joomla/string/JStringNormaliseTest.php
+++ b/tests/suite/joomla/string/JStringNormaliseTest.php
@@ -19,6 +19,22 @@ require_once JPATH_PLATFORM . '/joomla/string/normalise.php';
 class JStringNormaliseTest extends PHPUnit_Framework_TestCase
 {
 	/**
+	 * Method to test JStringNormalise::fromCamelCase().
+	 *
+	 * @param   string  $expected  The expected value from the method.
+	 * @param   string  $input     The input value for the method.
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider  seedFromCamelCase
+	 * @since   11.3
+	 */
+	public function testFromCamelCase($expected, $input)
+	{
+		$this->assertEquals($expected, JStringNormalise::fromCamelcase($input));
+	}
+
+	/**
 	 * Method to test JStringNormalise::toCamelCase().
 	 *
 	 * @param   string  $expected  The expected value from the method.
@@ -112,6 +128,23 @@ class JStringNormaliseTest extends PHPUnit_Framework_TestCase
 	public function testToKey($expected, $input)
 	{
 		$this->assertEquals($expected, JStringNormalise::toKey($input));
+	}
+
+	/**
+	 * Method to seed data to testFromCamelCase.
+	 *
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	public function seedFromCamelCase()
+	{
+		return array(
+			array('Foo Bar', 'FooBar'),
+			array('foo Bar', 'fooBar'),
+			array('Foobar', 'Foobar'),
+			array('foobar', 'foobar')
+		);
 	}
 
 	/**


### PR DESCRIPTION
JStringNormalise::fromCamelCase() will take a string in camel case format and convert it to a space separated string. I've added unit test to verify it works for some basic strings:

The input on the left will produce the output on the right:
FooBar => Foo Bar
fooBar => foo Bar
Foobar => Foobar
foobar => foobar

This currently only works for ASCII characters could be expanded to support a wider range of characters.
