### PR TITLE
Added capability to use differet glue in WHERE clause.

### DIFF
--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -1444,35 +1444,31 @@ abstract class JDatabaseQuery
 	 * Usage:
 	 * $query->where('a = 1')->where('b = 2');
 	 * $query->where(array('a = 1', 'b = 2'));
+	 * $query->where('a = 1')->where('b = 2', 'OR');
 	 *
 	 * @param   mixed   $conditions  A string or array of where conditions.
-	 * @param   string  $glue        The glue by which to join the conditions. Defaults to empty.
-	 *                               Note that the glue isn't set on first use and can be changed
+	 * @param   string  $glue        The glue by which to join the conditions. Defaults to AND glue.
+	 *                               Note that the glue isn't set on first call and can be changed
 	 *                               for each call.
 	 *
 	 * @return  JDatabaseQuery  Returns this object to allow chaining.
 	 *
 	 * @since   11.1
 	 */
-	public function where($conditions, $glue = '')
+	public function where($conditions, $glue = 'AND')
 	{
+		if (is_array($conditions))
+		{
+			$conditions = implode(' ' . strtoupper($glue) . ' ', $conditions);
+		}
+
 		if (is_null($this->where))
 		{
-			$glue = strtoupper($glue);
-			$this->where = new JDatabaseQueryElement('WHERE', $conditions, " $glue ");
+			$this->where = new JDatabaseQueryElement('WHERE', $conditions, ' ');
 		}
 		else
 		{
-			if (is_array($conditions))
-			{
-				$im = strtoupper($glue) . ' ';
-				$im .= implode(' ' . strtoupper($glue) . ' ', $conditions);
-			}
-			else
-			{
-				$im = strtoupper($glue) . ' ' . $conditions;
-			}
-			$this->where->append($im);
+			$this->where->append(strtoupper($glue) . ' ' . $conditions);
 		}
 
 		return $this;

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -1446,14 +1446,15 @@ abstract class JDatabaseQuery
 	 * $query->where(array('a = 1', 'b = 2'));
 	 *
 	 * @param   mixed   $conditions  A string or array of where conditions.
-	 * @param   string  $glue        The glue by which to join the conditions. Defaults to AND.
-	 *                               Note that the glue is set on first use and cannot be changed.
+	 * @param   string  $glue        The glue by which to join the conditions. Defaults to empty.
+	 *                               Note that the glue isn't set on first use and can be changed
+	 *                               for each call.
 	 *
 	 * @return  JDatabaseQuery  Returns this object to allow chaining.
 	 *
 	 * @since   11.1
 	 */
-	public function where($conditions, $glue = 'AND')
+	public function where($conditions, $glue = '')
 	{
 		if (is_null($this->where))
 		{
@@ -1462,7 +1463,16 @@ abstract class JDatabaseQuery
 		}
 		else
 		{
-			$this->where->append($conditions);
+			if (is_array($conditions))
+			{
+				$im = strtoupper($glue) . ' ';
+				$im .= implode(' ' . strtoupper($glue) . ' ', $conditions);
+			}
+			else
+			{
+				$im = strtoupper($glue) . ' ' . $conditions;
+			}
+			$this->where->append($im);
 		}
 
 		return $this;

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -1468,12 +1468,12 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			array(
 				'bar = 2',
 				'goo = 3',
-			)
+			), 'AND'
 		);
 
 		$this->assertThat(
 			trim($q->where),
-			$this->equalTo('WHERE foo = 1 AND bar = 2 AND goo = 3'),
+			$this->equalTo('WHERE foo = 1  AND bar = 2 AND goo = 3'),
 			'Tests rendered value after second use and array input.'
 		);
 
@@ -1493,6 +1493,26 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			'Tests rendered value with glue.'
 		);
 	}
+
+	/**
+	 * Test for WHERE clause using different glues. 
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testWhereDiffGlues()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
+		$q->where("a = 1")->where("b = 1", 'OR')->where("c = 1", 'AND');
+
+		$this->assertThat(
+			trim($q->where),
+			$this->equalTo('WHERE a = 1  OR b = 1  AND c = 1'),
+			'Tests rendered value.'
+		);
+	}
+
 	/**
 	* Tests the JDatabaseQuery::__clone method properly clones an array.
 	*

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -1473,7 +1473,7 @@ class JDatabaseQueryTest extends JoomlaTestCase
 
 		$this->assertThat(
 			trim($q->where),
-			$this->equalTo('WHERE foo = 1  AND bar = 2 AND goo = 3'),
+			$this->equalTo('WHERE foo = 1 AND bar = 2 AND goo = 3'),
 			'Tests rendered value after second use and array input.'
 		);
 
@@ -1504,11 +1504,19 @@ class JDatabaseQueryTest extends JoomlaTestCase
 	public function testWhereDiffGlues()
 	{
 		$q = new JDatabaseQueryInspector($this->dbo);
-		$q->where("a = 1")->where("b = 1", 'OR')->where("c = 1", 'AND');
+		$q->where('a = 1')->where('b = 1', 'OR')->where('c = 1', 'AND');
 
 		$this->assertThat(
 			trim($q->where),
-			$this->equalTo('WHERE a = 1  OR b = 1  AND c = 1'),
+			$this->equalTo('WHERE a = 1 OR b = 1 AND c = 1'),
+			'Tests rendered value.'
+		);
+
+		$q->clear();
+		$q->where('a = 1')->where('(b = 1 OR c = 4)')->where('c = 7', 'OR');
+		$this->assertThat(
+			trim($q->where),
+			$this->equalTo('WHERE a = 1 AND (b = 1 OR c = 4) OR c = 7'),
 			'Tests rendered value.'
 		);
 	}

--- a/tests/suite/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suite/joomla/database/JDatabaseQueryTest.php
@@ -1468,7 +1468,7 @@ class JDatabaseQueryTest extends JoomlaTestCase
 			array(
 				'bar = 2',
 				'goo = 3',
-			), 'AND'
+			)
 		);
 
 		$this->assertThat(


### PR DESCRIPTION
First where() call doesn't need glue, the other calls can have this set and it's referred to actual condition.
This change permit to call a sequence like this:
<code>$q->where('a = 1')->where('b = 1', 'OR')->where('c = 1', 'AND');</code>
that will be translated in
<code>WHERE a = 1 OR b = 1 AND c = 1</code>

It's now possible to have more complex $condition as following
<code>$q->where('a = 1')->where('(b = 1 OR c = 4)')->where('c = 7', 'OR');</code>
that is translated to
<code>WHERE a = 1 AND (b = 1 OR c = 4) OR c = 7</code>
