### PR TITLE
Fixes to the SQLite driver.

### DIFF
--- a/libraries/joomla/database/driver/sqlite.php
+++ b/libraries/joomla/database/driver/sqlite.php
@@ -26,7 +26,7 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 	 * @since  12.1
 	 */
 	public $name = 'sqlite';
-	
+
 	/**
 	 * The character(s) used to quote SQL statement names such as table names or field names,
 	 * etc. The child classes should define this as necessary.  If a single character string the
@@ -37,7 +37,7 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 	 * @since  12.1
 	 */
 	protected $nameQuote = '`';
-	
+
 	/**
 	 * Constructor.
 	 *
@@ -84,7 +84,7 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 
 		return $this;
 	}
-	
+
 	/**
 	 * Method to escape a string for usage in an SQLite statement.
 	 *
@@ -107,7 +107,7 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 
 		return sqlite_escape_string($text);
 	}
-	
+
 	/**
 	 * Method to get the database collation in use by sampling a text field of a table in the database.
 	 *

--- a/libraries/joomla/database/driver/sqlite.php
+++ b/libraries/joomla/database/driver/sqlite.php
@@ -26,7 +26,18 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 	 * @since  12.1
 	 */
 	public $name = 'sqlite';
-
+	
+	/**
+	 * The character(s) used to quote SQL statement names such as table names or field names,
+	 * etc. The child classes should define this as necessary.  If a single character string the
+	 * same character is used for both sides of the quoted name, else the first character will be
+	 * used for the opening quote and the second for the closing quote.
+	 *
+	 * @var    string
+	 * @since  12.1
+	 */
+	protected $nameQuote = '`';
+	
 	/**
 	 * Constructor.
 	 *
@@ -73,7 +84,30 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 
 		return $this;
 	}
+	
+	/**
+	 * Method to escape a string for usage in an SQLite statement.
+	 *
+	 * Note: Using query objects with bound variables is
+	 * preferable to the below.
+	 *
+	 * @param   string   $text   The string to be escaped.
+	 * @param   boolean  $extra  Unused optional parameter to provide extra escaping.
+	 *
+	 * @return  string  The escaped string.
+	 *
+	 * @since   12.1
+	 */
+	public function escape($text, $extra = false)
+	{
+		if (is_int($text) || is_float($text))
+		{
+			return $text;
+		}
 
+		return sqlite_escape_string($text);
+	}
+	
 	/**
 	 * Method to get the database collation in use by sampling a text field of a table in the database.
 	 *
@@ -223,7 +257,7 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 
 		$this->setQuery($query);
 
-		$tables = $this->loadResultArray();
+		$tables = $this->loadColumn();
 
 		return $tables;
 	}


### PR DESCRIPTION
Setting the SQLite driver to use backticks for name quoting while we figure out a more robust way of handling this cross platform.  Also fixing a few issues with the SQLite driver around escaping and getting a list of table names.
