### PR TITLE
Uncouple the Filesystem Path Class from JUser. 

### DIFF
--- a/libraries/joomla/filesystem/path.php
+++ b/libraries/joomla/filesystem/path.php
@@ -223,7 +223,7 @@ class JPath
 	{
 		jimport('joomla.filesystem.file');
 
-		$tmp = md5(JUserHelper::genRandomPassword(16));
+		$tmp = md5(mt_rand());
 		$ssp = ini_get('session.save_path');
 		$jtp = JPATH_SITE . '/tmp';
 


### PR DESCRIPTION
A temporary file name is created using a random value in order to test if the script owns the path. Currently, this process invokes a method from JUser to build a random value. The patch changes that process to instead use mt_rand() so as to uncouple the Path Class from JUser.
