### PR TITLE
Convert thrown exception messages to plain text in HTML and Form packages

### DIFF
--- a/libraries/joomla/form/fields/groupedlist.php
+++ b/libraries/joomla/form/fields/groupedlist.php
@@ -33,7 +33,7 @@ class JFormFieldGroupedList extends JFormField
 	 * @return  array  The field option objects as a nested array in groups.
 	 *
 	 * @since   11.1
-	 * @throws  Exception
+	 * @throws  UnexpectedValueException
 	 */
 	protected function getGroups()
 	{
@@ -117,7 +117,7 @@ class JFormFieldGroupedList extends JFormField
 
 				// Unknown element type.
 				default:
-					throw new Exception(JText::sprintf('JLIB_FORM_ERROR_FIELDS_GROUPEDLIST_ELEMENT_NAME', $element->getName()), 500);
+					throw new UnexpectedValueException(sprintf('Unsupported element %s in JFormFieldGroupedList', $element->getName()), 500);
 			}
 		}
 

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -633,7 +633,7 @@ class JForm
 	 *
 	 * @param   string  $data     The name of an XML string or object.
 	 * @param   string  $replace  Flag to toggle whether form fields should be replaced if a field
-	 * already exists with the same group/name.
+	 *                            already exists with the same group/name.
 	 * @param   string  $xpath    An optional xpath to search for the fields.
 	 *
 	 * @return  boolean  True on success, false otherwise.
@@ -1970,7 +1970,8 @@ class JForm
 	 * @return  object  JForm instance.
 	 *
 	 * @since   11.1
-	 * @throws  Exception if an error occurs.
+	 * @throws  InvalidArgumentException if no data provided.
+	 * @throws  RuntimeException if the form could not be loaded.
 	 */
 	public static function getInstance($name, $data = null, $options = array(), $replace = true, $xpath = false)
 	{
@@ -1980,12 +1981,11 @@ class JForm
 		// Only instantiate the form if it does not already exist.
 		if (!isset($forms[$name]))
 		{
-
 			$data = trim($data);
 
 			if (empty($data))
 			{
-				throw new Exception(JText::_('JLIB_FORM_ERROR_NO_DATA'));
+				throw new InvalidArgumentException('No data passed to JForm::getInstance.');
 			}
 
 			// Instantiate the form.
@@ -1996,18 +1996,14 @@ class JForm
 			{
 				if ($forms[$name]->load($data, $replace, $xpath) == false)
 				{
-					throw new Exception(JText::_('JLIB_FORM_ERROR_XML_FILE_DID_NOT_LOAD'));
-
-					return false;
+					throw new RuntimeException('JForm::getInstance could not load form.');
 				}
 			}
 			else
 			{
 				if ($forms[$name]->loadFile($data, $replace, $xpath) == false)
 				{
-					throw new Exception(JText::_('JLIB_FORM_ERROR_XML_FILE_DID_NOT_LOAD'));
-
-					return false;
+					throw new RuntimeException('JForm::getInstance could not load file.');
 				}
 			}
 		}

--- a/libraries/joomla/form/rule.php
+++ b/libraries/joomla/form/rule.php
@@ -54,14 +54,14 @@ class JFormRule
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
 	 * @since   11.1
-	 * @throws  JException on invalid rule.
+	 * @throws  UnexpectedValueException if rule is invalid.
 	 */
 	public function test($element, $value, $group = null, $input = null, $form = null)
 	{
 		// Check for a valid regex.
 		if (empty($this->regex))
 		{
-			throw new JException(JText::sprintf('JLIB_FORM_INVALID_FORM_RULE', get_class($this)));
+			throw new UnexpectedValueException(sprintf('%s has invalid regex.', get_class($this)));
 		}
 
 		// Add unicode property support if available.

--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -117,12 +117,12 @@ abstract class JHtml
 
 				if (!class_exists($className))
 				{
-					throw new InvalidArgumentException(JText::sprintf('JLIB_HTML_ERROR_NOTFOUNDINFILE', $className, $func), 500);
+					throw new InvalidArgumentException(sprintf('%s not found.', $className), 500);
 				}
 			}
 			else
 			{
-				throw new InvalidArgumentException(JText::sprintf('JLIB_HTML_ERROR_NOTSUPPORTED_NOFILE', $prefix, $file), 500);
+				throw new InvalidArgumentException(sprintf('%s %s not found.', $prefix, $file), 500);
 			}
 		}
 
@@ -138,7 +138,7 @@ abstract class JHtml
 		}
 		else
 		{
-			throw new InvalidArgumentException(JText::sprintf('JLIB_HTML_ERROR_NOTSUPPORTED', $className, $func), 500);
+			throw new InvalidArgumentException(JText::sprintf('%s::%s not found.', $className, $func), 500);
 		}
 	}
 

--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -138,7 +138,7 @@ abstract class JHtml
 		}
 		else
 		{
-			throw new InvalidArgumentException(JText::sprintf('%s::%s not found.', $className, $func), 500);
+			throw new InvalidArgumentException(sprintf('%s::%s not found.', $className, $func), 500);
 		}
 	}
 


### PR DESCRIPTION
Removed the use of JText in hard thrown exception messages that are runtime errors (something the developer needs to fix).
