### PR TITLE
JModuleHelper calls JRequest::_cleanVar which is protected. 

### DIFF
--- a/libraries/joomla/application/module/helper.php
+++ b/libraries/joomla/application/module/helper.php
@@ -452,7 +452,8 @@ abstract class JModuleHelper
 						// Use int filter for id/catid to clean out spamy slugs
 						if (isset($uri[$key]))
 						{
-							$safeuri->$key = JRequest::_cleanVar($uri[$key], 0, $value);
+							$noHtmlFilter = JFilterInput::getInstance();
+							$safeuri->$key = $noHtmlFilter->clean($uri[$key], $value);
 						}
 					}
 				}


### PR DESCRIPTION
Remove the protected method, instead performing the filtering in place.
