### PR TITLE
Corrected phone nubmer cleanup regex

### DIFF
--- a/libraries/joomla/form/rules/tel.php
+++ b/libraries/joomla/form/rules/tel.php
@@ -86,7 +86,7 @@ class JFormRuleTel extends JFormRule
 			 * 7 and 15 digits inclusive and no illegal characters (but common number separators
 			 * are allowed).
 			 */
-			$cleanvalue = preg_replace('/[+. -(\)]/', '', $value);
+			$cleanvalue = preg_replace('/[+. \-(\)]/', '', $value);
 			$regex = '/^[0-9]{7,15}?$/';
 			if (preg_match($regex, $cleanvalue) == true)
 			{


### PR DESCRIPTION
Corrected regex in $cleanvalue = preg_replace('/[+. -()]/', '', $value) to fix problem with phone numbers, containing "-" symbol
