### PR TITLE
Add type hinting and correct the method docblock

### DIFF
--- a/libraries/joomla/utilities/date.php
+++ b/libraries/joomla/utilities/date.php
@@ -385,16 +385,15 @@ class JDate extends DateTime
 	}
 
 	/**
-	 * Method to wrap the setTimezone() function and set the internal
-	 * time zone object.
+	 * Method to wrap the setTimezone() function and set the internal time zone object.
 	 *
 	 * @param   DateTimeZone  $tz  The new DateTimeZone object.
 	 *
-	 * @return  DateTimeZone  The old DateTimeZone object.
+	 * @return  JDate
 	 *
 	 * @since   11.1
 	 */
-	public function setTimezone($tz)
+	public function setTimezone(DateTimeZone $tz)
 	{
 		$this->_tz = $tz;
 		return parent::setTimezone($tz);


### PR DESCRIPTION
This adds type hinting to JDate::setTimeZone() and corrects the return value ([ref](http://php.net/datetime.settimezone.php)) specified in the methods docblock.
