### PR TITLE
PostgreSQL driver for Joomla! platform [clean version _ v3].

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -972,9 +972,12 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 		static $cursor = null;
 
 		// Execute the query and get the result set cursor.
-		if (!($cursor = $this->execute()))
+		if ( is_null($cursor) )
 		{
-			return $this->errorNum ? null : false;
+			if (!($cursor = $this->execute()))
+			{
+				return $this->errorNum ? null : false;
+			}
 		}
 
 		// Get the next row from the result set as an object of type $class.
@@ -1005,9 +1008,12 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 		static $cursor = null;
 
 		// Execute the query and get the result set cursor.
-		if (!($cursor = $this->execute()))
+		if ( is_null($cursor) )
 		{
-			return $this->errorNum ? null : false;
+			if (!($cursor = $this->execute()))
+			{
+				return $this->errorNum ? null : false;
+			}
 		}
 
 		// Get the next row from the result set as an object of type $class.

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -1,0 +1,1216 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Database
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * PostgreSQL database driver
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Database
+ * @since       12.1
+ */
+class JDatabaseDriverPostgresql extends JDatabaseDriver
+{
+	/**
+	 * The database driver name
+	 *
+	 * @var string
+	 */
+	public $name = 'postgresql';
+
+	/**
+	 * Quote for named objects
+	 *
+	 * @var string
+	 */
+	protected $nameQuote = '"';
+
+	/**
+	 *  The null/zero date string
+	 *
+	 * @var string
+	 */
+	protected $nullDate = '1970-01-01 00:00:00';
+
+	/**
+	 * @var    string  The minimum supported database version.
+	 * @since  12.1
+	 */
+	protected static $dbMinimum = '9.1.2';
+
+	/**
+	 * Operator used for concatenation
+	 *
+	 * @var string
+	 */
+	protected $concat_operator = '||';
+
+	/**
+	 * JDatabaseDriverPostgresqlQuery object returned by getQuery
+	 *
+	 * @var JDatabaseDriverPostgresqlQuery
+	 */
+	protected $queryObject = null;
+
+	/**
+	 * Database object constructor
+	 *
+	 * @param   array  $options  List of options used to configure the connection
+	 *
+	 * @since	12.1
+	 */
+	public function __construct( $options )
+	{
+		$options['host'] = (isset($options['host'])) ? $options['host'] : 'localhost';
+		$options['user'] = (isset($options['user'])) ? $options['user'] : '';
+		$options['password'] = (isset($options['password'])) ? $options['password'] : '';
+		$options['database'] = (isset($options['database'])) ? $options['database'] : '';
+
+		// Finalize initialization
+		parent::__construct($options);
+	}
+
+	/**
+	 * Connects to the database if needed.
+	 *
+	 * @return  void  Returns void if the database connected successfully.
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	public function connect()
+	{
+		if ($this->connection)
+		{
+			return;
+		}
+
+		// Make sure the MySQL extension for PHP is installed and enabled.
+		if (!function_exists('pg_connect'))
+		{
+			throw new RuntimeException(JText::_('JLIB_DATABASE_ERROR_ADAPTER_POSTGRESQL'));
+		}
+
+		// Build the DSN for the connection.
+		$dsn = "host={$this->options['host']} dbname={$this->options['database']} user={$this->options['user']} password={$this->options['password']}";
+
+		// Attempt to connect to the server.
+		if (!($this->connection = @pg_connect($dsn)))
+		{
+			throw new RuntimeException(JText::_('JLIB_DATABASE_ERROR_CONNECT_POSTGRESQL'));
+		}
+
+		pg_set_error_verbosity($this->connection, PGSQL_ERRORS_DEFAULT);
+		pg_query('SET standard_conforming_strings=off');
+	}
+
+	/**
+	 * Database object destructor
+	 *
+	 * @since 12.1
+	 */
+	public function __destruct()
+	{
+		if (is_resource($this->connection))
+		{
+			pg_close($this->connection);
+		}
+	}
+
+	/**
+	 * Method to escape a string for usage in an SQL statement.
+	 *
+	 * @param   string   $text   The string to be escaped.
+	 * @param   boolean  $extra  Optional parameter to provide extra escaping.
+	 *
+	 * @return  string  The escaped string.
+	 *
+	 * @since   12.1
+	 */
+	public function escape($text, $extra = false)
+	{
+		$this->connect();
+
+		$result = pg_escape_string($this->connection, $text);
+
+		if ($extra)
+		{
+			$result = addcslashes($result, '%_');
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Test to see if the PostgreSQL connector is available
+	 *
+	 * @return boolean  True on success, false otherwise.
+	 */
+	public static function test()
+	{
+		return (function_exists('pg_connect'));
+	}
+
+	/**
+	 * Determines if the connection to the server is active.
+	 *
+	 * @return	boolean
+	 *
+	 * @since	12.1
+	 */
+	public function connected()
+	{
+		$this->connect();
+
+		if (is_resource($this->connection))
+		{
+			return pg_ping($this->connection);
+		}
+
+		return false;
+	}
+
+	/**
+	 * Drops a table from the database.
+	 *
+	 * @param   string   $tableName  The name of the database table to drop.
+	 * @param   boolean  $ifExists   Optionally specify that the table must exist before it is dropped.
+	 *
+	 * @return  boolean	true
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	public function dropTable($tableName, $ifExists = true)
+	{
+		$this->connect();
+
+		$this->setQuery('DROP TABLE ' . ($ifExists ? 'IF EXISTS ' : '') . $this->quoteName($tableName));
+		$this->execute();
+
+		return true;
+	}
+
+	/**
+	 * Get the number of affected rows for the previous executed SQL statement.
+	 *
+	 * @return int The number of affected rows in the previous operation
+	 *
+	 * @since 12.1
+	 */
+	public function getAffectedRows()
+	{
+		$this->connect();
+
+		return pg_affected_rows($this->cursor);
+	}
+
+	/**
+	 * Method to get the database collation in use by sampling a text field of a table in the database.
+	 *
+	 * @return  mixed  The collation in use by the database or boolean false if not supported.
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	public function getCollation()
+	{
+		$this->connect();
+
+		$this->setQuery('SHOW LC_COLLATE');
+		$array = $this->loadAssocList();
+		return $array[0]['lc_collate'];
+	}
+
+	/**
+	 * Get the number of returned rows for the previous executed SQL statement.
+	 *
+	 * @param   resource  $cur  An optional database cursor resource to extract the row count from.
+	 *
+	 * @return  integer   The number of returned rows.
+	 *
+	 * @since   12.1
+	 */
+	public function getNumRows( $cur = null )
+	{
+		$this->connect();
+
+		return pg_num_rows($cur ? $cur : $this->cursor);
+	}
+
+	/**
+	 * Get the current or query, or new JDatabaseQuery object.
+	 *
+	 * @param   boolean  $new    False to return the last query set, True to return a new JDatabaseQuery object.
+	 * @param   boolean  $asObj  False to return last query as string, true to get JDatabaseQueryPostgresql object.
+	 *
+	 * @return  JDatabaseQuery  The current query object or a new object extending the JDatabaseQuery class.
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	public function getQuery($new = false, $asObj = false)
+	{
+		if ($new)
+		{
+			// Make sure we have a query class for this driver.
+			if (!class_exists('JDatabaseQueryPostgresql'))
+			{
+				throw new RuntimeException(JText::_('JLIB_DATABASE_ERROR_MISSING_QUERY'));
+			}
+
+			$this->queryObject = new JDatabaseQueryPostgresql($this);
+			return $this->queryObject;
+		}
+		else
+		{
+			if ($asObj)
+			{
+				return $this->queryObject;
+			}
+			else
+			{
+				return $this->sql;
+			}
+		}
+	}
+
+	/**
+	 * Shows the table CREATE statement that creates the given tables.
+	 *
+	 * This is unsuported by PostgreSQL.
+	 *
+	 * @param   mixed  $tables  A table name or a list of table names.
+	 *
+	 * @return  char  An empty char because this function is not supported by PostgreSQL.
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	public function getTableCreate($tables)
+	{
+		return '';
+	}
+
+	/**
+	 * Retrieves field information about a given table.
+	 *
+	 * @param   string   $table     The name of the database table.
+	 * @param   boolean  $typeOnly  True to only return field types.
+	 *
+	 * @return  array  An array of fields for the database table.
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	public function getTableColumns($table, $typeOnly = true)
+	{
+		$this->connect();
+
+		$result = array();
+
+		$tableSub = $this->replacePrefix($table);
+
+		$this->setQuery('
+				SELECT a.attname AS "column_name",
+					pg_catalog.format_type(a.atttypid, a.atttypmod) as "type",
+					CASE WHEN a.attnotnull IS TRUE
+						THEN \'NO\'
+						ELSE \'YES\'
+					END AS "null",
+					CASE WHEN pg_catalog.pg_get_expr(adef.adbin, adef.adrelid, true) IS NOT NULL
+						THEN pg_catalog.pg_get_expr(adef.adbin, adef.adrelid, true)
+					END as "default",
+					CASE WHEN pg_catalog.col_description(a.attrelid, a.attnum) IS NULL
+					THEN \'\'
+					ELSE pg_catalog.col_description(a.attrelid, a.attnum)
+					END  AS "comments"
+				FROM pg_catalog.pg_attribute a
+				LEFT JOIN pg_catalog.pg_attrdef adef ON a.attrelid=adef.adrelid AND a.attnum=adef.adnum
+				LEFT JOIN pg_catalog.pg_type t ON a.atttypid=t.oid
+				WHERE a.attrelid =
+					(SELECT oid FROM pg_catalog.pg_class WHERE relname=' . $this->quote($table) . '
+						AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE
+						nspname = \'public\')
+					)
+				AND a.attnum > 0 AND NOT a.attisdropped
+				ORDER BY a.attnum'
+		);
+
+		$fields = $this->loadObjectList();
+
+		if ($typeOnly)
+		{
+			foreach ($fields as $field)
+			{
+				$result[$field->column_name] = preg_replace("/[(0-9)]/", '', $field->type);
+			}
+		}
+		else
+		{
+			foreach ($fields as $field)
+			{
+				$result[$field->column_name] = $field;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Get the details list of keys for a table.
+	 *
+	 * @param   string  $table  The name of the table.
+	 *
+	 * @return  array  An array of the column specification for the table.
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	public function getTableKeys($table)
+	{
+		$this->connect();
+
+		// To check if table exists and prevent SQL injection
+		$tableList = $this->getTableList();
+
+		if ( in_array($table, $tableList) )
+		{
+			// Get the details columns information.
+			$this->setQuery('
+					SELECT indexname AS "idxName", indisprimary AS "isPrimary", indisunique  AS "isUnique",
+						CASE WHEN indisprimary = true THEN
+							( SELECT \'ALTER TABLE \' || tablename || \' ADD \' || pg_catalog.pg_get_constraintdef(const.oid, true)
+								FROM pg_constraint AS const WHERE const.conname= pgClassFirst.relname )
+						ELSE pg_catalog.pg_get_indexdef(indexrelid, 0, true)
+						END AS "Query"
+					FROM pg_indexes
+					LEFT JOIN pg_class AS pgClassFirst ON indexname=pgClassFirst.relname
+					LEFT JOIN pg_index AS pgIndex ON pgClassFirst.oid=pgIndex.indexrelid
+					WHERE tablename=' . $this->quote($table) . ' ORDER BY indkey'
+			);
+			$keys = $this->loadObjectList();
+
+			return $keys;
+		}
+		return false;
+	}
+
+	/**
+	 * Method to get an array of all tables in the database.
+	 *
+	 * @return  array  An array of all the tables in the database.
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	public function getTableList()
+	{
+		$this->connect();
+
+		$query = $this->getQuery(true);
+		$query->select('table_name')
+				->from('information_schema.tables')
+				->where('table_type=' . $this->quote('BASE TABLE'))
+				->where(
+					'table_schema NOT IN (' . $this->quote('pg_catalog') . ', ' . $this->quote('information_schema') . ')'
+				)
+				->order('table_name ASC');
+
+		$this->setQuery($query);
+		$tables = $this->loadColumn();
+
+		return $tables;
+	}
+
+	/**
+	 * Get the details list of sequences for a table.
+	 *
+	 * @param   string  $table  The name of the table.
+	 *
+	 * @return  array  An array of sequences specification for the table.
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	public function getTableSequences($table)
+	{
+		$this->connect();
+
+		// To check if table exists and prevent SQL injection
+		$tableList = $this->getTableList();
+
+		if ( in_array($table, $tableList) )
+		{
+			$name = array('s.relname', 'n.nspname', 't.relname', 'a.attname', 'info.data_type',
+							'info.minimum_value', 'info.maximum_value', 'info.increment', 'info.cycle_option');
+			$as = array('sequence', 'schema', 'table', 'column', 'data_type',
+							'minimum_value', 'maximum_value', 'increment', 'cycle_option');
+
+			if (version_compare($this->getVersion(), '9.1.0') >= 0)
+			{
+				$name[] .= 'info.start_value';
+				$as[] .= 'start_value';
+			}
+
+			// Get the details columns information.
+			$query = $this->getQuery(true);
+			$query->select($this->quoteName($name, $as))
+					->from('pg_class AS s')
+					->leftJoin("pg_depend d ON d.objid=s.oid AND d.classid='pg_class'::regclass AND d.refclassid='pg_class'::regclass")
+					->leftJoin('pg_class t ON t.oid=d.refobjid')
+					->leftJoin('pg_namespace n ON n.oid=t.relnamespace')
+					->leftJoin('pg_attribute a ON a.attrelid=t.oid AND a.attnum=d.refobjsubid')
+					->leftJoin('information_schema.sequences AS info ON info.sequence_name=s.relname')
+					->where("s.relkind='S' AND d.deptype='a' AND t.relname=" . $this->quote($table));
+			$this->setQuery($query);
+			$seq = $this->loadObjectList();
+
+			return $seq;
+		}
+		return false;
+	}
+
+	/**
+	 * Get the version of the database connector.
+	 *
+	 * @return  string  The database connector version.
+	 *
+	 * @since   12.1
+	 */
+	public function getVersion()
+	{
+		$this->connect();
+		$version = pg_version($this->connection);
+		return $version['server'];
+	}
+
+	/**
+	 * Method to get the auto-incremented value from the last INSERT statement.
+	 * To be called after the INSERT statement, it's MANDATORY to have a sequence on
+	 * every primary key table.
+	 *
+	 * To get the auto incremented value it's possible to call this function after
+	 * INSERT INTO query, or use INSERT INTO with RETURNING clause.
+	 *
+	 * @example with insertid() call:
+	 *		$query = $this->getQuery(true);
+	 *		$query->insert('jos_dbtest')
+	 *				->columns('title,start_date,description')
+	 *				->values("'testTitle2nd','1971-01-01','testDescription2nd'");
+	 *		$this->setQuery($query);
+	 *		$this->execute();
+	 *		$id = $this->insertid();
+	 *
+	 * @example with RETURNING clause:
+	 *		$query = $this->getQuery(true);
+	 *		$query->insert('jos_dbtest')
+	 *				->columns('title,start_date,description')
+	 *				->values("'testTitle2nd','1971-01-01','testDescription2nd'")
+	 *				->returning('id');
+	 *		$this->setQuery($query);
+	 *		$id = $this->loadResult();
+	 *
+	 * @return  integer  The value of the auto-increment field from the last inserted row.
+	 *
+	 * @since   12.1
+	 */
+	public function insertid()
+	{
+		$this->connect();
+		$insertQuery = $this->getQuery(false, true);
+		$table = $insertQuery->__get('insert')->getElements();
+
+		/* find sequence column name */
+		$colNameQuery = $this->getQuery(true);
+		$colNameQuery->select('column_default')
+						->from('information_schema.columns')
+						->where(
+								"table_name=" . $this->quote(
+									$this->replacePrefix(str_replace('"', '', $table[0]))
+								), 'AND'
+						)
+						->where("column_default LIKE '%nextval%'");
+
+		$this->setQuery($colNameQuery);
+		$colName = $this->loadRow();
+		$changedColName = str_replace('nextval', 'currval', $colName);
+
+		$insertidQuery = $this->getQuery(true);
+		$insertidQuery->select($changedColName);
+		$this->setQuery($insertidQuery);
+		$insertVal = $this->loadRow();
+
+		return $insertVal[0];
+	}
+
+	/**
+	 * Locks a table in the database.
+	 *
+	 * @param   string  $tableName  The name of the table to unlock.
+	 *
+	 * @return  JDatabase  Returns this object to support chaining.
+	 *
+	 * @since   11.4
+	 * @throws  RuntimeException
+	 */
+	public function lockTable($tableName)
+	{
+		$this->transactionStart();
+		$this->setQuery('LOCK TABLE ' . $this->quoteName($tableName) . ' IN ACCESS EXCLUSIVE MODE')->execute();
+
+		return $this;
+	}
+
+	/**
+	 * Execute the SQL statement.
+	 *
+	 * @return  mixed  A database cursor resource on success, boolean false on failure.
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	public function execute()
+	{
+		$this->connect();
+
+		if (!is_resource($this->connection))
+		{
+			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database');
+			throw new RuntimeException($this->errorMsg, $this->errorNum);
+		}
+
+		// Take a local copy so that we don't modify the original query and cause issues later
+		$sql = $this->replacePrefix((string) $this->sql);
+		if ($this->limit > 0 || $this->offset > 0)
+		{
+			$sql .= ' LIMIT ' . $this->limit . ' OFFSET ' . $this->offset;
+		}
+
+		// If debugging is enabled then let's log the query.
+		if ($this->debug)
+		{
+			// Increment the query counter and add the query to the object queue.
+			$this->count++;
+			$this->log[] = $sql;
+
+			JLog::add($sql, JLog::DEBUG, 'databasequery');
+		}
+
+		// Reset the error values.
+		$this->errorNum = 0;
+		$this->errorMsg = '';
+
+		try
+		{
+			// Execute the query.
+			$this->cursor = pg_query($this->connection, $sql);
+		}
+		catch (Exception $e)
+		{
+			throw new RuntimeException(JText::_('JLIB_DATABASE_QUERY_FAILED') . "\n" . pg_last_error($this->connection) . "\nSQL=" . $sql);
+		}
+
+		if (!$this->cursor)
+		{
+			$this->errorNum = (int) pg_result_error_field($this->cursor, PGSQL_DIAG_SQLSTATE) . ' ';
+			$this->errorMsg = JText::_('JLIB_DATABASE_QUERY_FAILED') . "\n" . pg_last_error($this->connection) . "\nSQL=$sql";
+
+			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
+			throw new RuntimeException($this->errorMsg);
+		}
+
+		return $this->cursor;
+	}
+
+	/**
+	 * Renames a table in the database.
+	 *
+	 * @param   string  $oldTable  The name of the table to be renamed
+	 * @param   string  $newTable  The new name for the table.
+	 * @param   string  $backup    Not used by PostgreSQL.
+	 * @param   string  $prefix    Not used by PostgreSQL.
+	 *
+	 * @return  JDatabase  Returns this object to support chaining.
+	 *
+	 * @since   11.4
+	 * @throws  RuntimeException
+	 */
+	public function renameTable($oldTable, $newTable, $backup = null, $prefix = null)
+	{
+		$this->connect();
+
+		// To check if table exists and prevent SQL injection
+		$tableList = $this->getTableList();
+
+		// Origin Table does not exist
+		if ( !in_array($oldTable, $tableList) )
+		{
+			// Origin Table not found
+			throw new RuntimeException(JText::_('JLIB_DATABASE_ERROR_POSTGRESQL_TABLE_NOT_FOUND'));
+		}
+		else
+		{
+			/* Rename indexes */
+			$this->setQuery(
+							'SELECT relname
+								FROM pg_class
+								WHERE oid IN (
+									SELECT indexrelid
+									FROM pg_index, pg_class
+									WHERE pg_class.relname=' . $this->quote($oldTable, true) . '
+									AND pg_class.oid=pg_index.indrelid );'
+			);
+
+			$oldIndexes = $this->loadColumn();
+			foreach ($oldIndexes as $oldIndex)
+			{
+				$changedIdxName = str_replace($oldTable, $newTable, $oldIndex);
+				$this->setQuery('ALTER INDEX ' . $this->escape($oldIndex) . ' RENAME TO ' . $this->escape($changedIdxName));
+				$this->execute();
+			}
+
+			/* Rename sequence */
+			$this->setQuery(
+							'SELECT relname
+								FROM pg_class
+								WHERE relkind = \'S\'
+								AND relnamespace IN (
+									SELECT oid
+									FROM pg_namespace
+									WHERE nspname NOT LIKE \'pg_%\'
+									AND nspname != \'information_schema\'
+								)
+								AND relname LIKE \'%' . $oldTable . '%\' ;'
+			);
+
+			$oldSequences = $this->loadColumn();
+			foreach ($oldSequences as $oldSequence)
+			{
+				$changedSequenceName = str_replace($oldTable, $newTable, $oldSequence);
+				$this->setQuery('ALTER SEQUENCE ' . $this->escape($oldSequence) . ' RENAME TO ' . $this->escape($changedSequenceName));
+				$this->execute();
+			}
+
+			/* Rename table */
+			$this->setQuery('ALTER TABLE ' . $this->escape($oldTable) . ' RENAME TO ' . $this->escape($newTable));
+			$this->execute();
+		}
+
+		return true;
+	}
+
+	/**
+	 * Selects the database, but redundant for PostgreSQL
+	 *
+	 * @param   string  $database  Database name to select.
+	 *
+	 * @return  boolean  Always true
+	 */
+	public function select($database)
+	{
+		return true;
+	}
+
+	/**
+	 * Custom settings for UTF support
+	 *
+	 * @return  int  Zero on success, -1 on failure
+	 *
+	 * @since   12.1
+	 */
+	public function setUTF()
+	{
+		$this->connect();
+
+		return pg_set_client_encoding($this->connection, 'UTF8');
+	}
+
+	/**
+	 * Method to commit a transaction.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	public function transactionCommit()
+	{
+		$this->connect();
+
+		$this->setQuery('COMMIT');
+		$this->execute();
+	}
+
+	/**
+	 * Method to roll back a transaction.
+	 *
+	 * @param   string  $toSavepoint  If present rollback transaction to this savepoint
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	public function transactionRollback($toSavepoint = null)
+	{
+		$this->connect();
+
+		$query = 'ROLLBACK';
+		if (!is_null($toSavepoint))
+		{
+			$query .= ' TO SAVEPOINT ' . $this->escape($toSavepoint);
+		}
+
+		$this->setQuery($query);
+		$this->execute();
+	}
+
+	/**
+	 * Method to initialize a transaction.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	public function transactionStart()
+	{
+		$this->connect();
+		$this->setQuery('START TRANSACTION');
+		$this->execute();
+	}
+
+	/**
+	 * Method to fetch a row from the result set cursor as an array.
+	 *
+	 * @param   mixed  $cursor  The optional result set cursor from which to fetch the row.
+	 *
+	 * @return  mixed  Either the next row from the result set or false if there are no more rows.
+	 *
+	 * @since   12.1
+	 */
+	protected function fetchArray($cursor = null)
+	{
+		return pg_fetch_row($cursor ? $cursor : $this->cursor);
+	}
+
+	/**
+	 * Method to fetch a row from the result set cursor as an associative array.
+	 *
+	 * @param   mixed  $cursor  The optional result set cursor from which to fetch the row.
+	 *
+	 * @return  mixed  Either the next row from the result set or false if there are no more rows.
+	 *
+	 * @since   12.1
+	 */
+	protected function fetchAssoc($cursor = null)
+	{
+		return pg_fetch_assoc($cursor ? $cursor : $this->cursor);
+	}
+
+	/**
+	 * Method to fetch a row from the result set cursor as an object.
+	 *
+	 * @param   mixed   $cursor  The optional result set cursor from which to fetch the row.
+	 * @param   string  $class   The class name to use for the returned row object.
+	 *
+	 * @return  mixed   Either the next row from the result set or false if there are no more rows.
+	 *
+	 * @since   12.1
+	 */
+	protected function fetchObject($cursor = null, $class = 'stdClass')
+	{
+		return pg_fetch_object(is_null($cursor) ? $this->cursor : $cursor, null, $class);
+	}
+
+	/**
+	 * Method to free up the memory used for the result set.
+	 *
+	 * @param   mixed  $cursor  The optional result set cursor from which to fetch the row.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	protected function freeResult($cursor = null)
+	{
+		pg_free_result($cursor ? $cursor : $this->cursor);
+	}
+
+	/**
+	 * Inserts a row into a table based on an object's properties.
+	 *
+	 * @param   string  $table    The name of the database table to insert into.
+	 * @param   object  &$object  A reference to an object whose public properties match the table fields.
+	 * @param   string  $key      The name of the primary key. If provided the object property is updated.
+	 *
+	 * @return  boolean    True on success.
+	 *
+	 * @since   11.1
+	 * @throws  RuntimeException
+	 */
+	public function insertObject($table, &$object, $key = null)
+	{
+		$this->connect();
+
+		// Initialise variables.
+		$fields = array();
+		$values = array();
+
+		// Create the base insert statement.
+		$query = $this->getQuery(true);
+		$query->insert($this->quoteName($table));
+
+		// Iterate over the object variables to build the query fields and values.
+		foreach (get_object_vars($object) as $k => $v)
+		{
+			// Only process non-null scalars.
+			if (is_array($v) or is_object($v) or $v === null)
+			{
+				continue;
+			}
+
+			// Ignore any internal fields.
+			if ($k[0] == '_')
+			{
+				continue;
+			}
+
+			// Prepare and sanitize the fields and values for the database query.
+			$fields[] = $this->quoteName($k);
+			$values[] = is_numeric($v) ? $v : $this->quote($v);
+		}
+
+		$query->columns($fields);
+		$query->values(implode(',', $values));
+
+		// Set the query and execute the insert.
+		$this->setQuery($query);
+		if (!$this->execute())
+		{
+			return false;
+		}
+
+		// Update the primary key if it exists.
+		$id = $this->insertid();
+		if ($key && $id)
+		{
+			$object->$key = $id;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Test to see if the PostgreSQL connector is available.
+	 *
+	 * @return  boolean  True on success, false otherwise.
+	 *
+	 * @since   12.1
+	 */
+	public static function isSupported()
+	{
+		return (function_exists('pg_connect'));
+	}
+
+	/**
+	 * Returns an array containing database's table list.
+	 *
+	 * @return	array	The database's table list.
+	 */
+	public function showTables()
+	{
+		$this->connect();
+
+		$query = $this->getQuery(true);
+		$query->select('table_name')
+				->from('information_schema.tables')
+				->where('table_type=' . $this->quote('BASE TABLE'))
+				->where(
+					'table_schema NOT IN (' . $this->quote('pg_catalog') . ', ' . $this->quote('information_schema') . ' )'
+				);
+
+		$this->setQuery($query);
+		$tableList = $this->loadColumn();
+		return $tableList;
+	}
+
+	/**
+	 * Get the substring position inside a string
+	 *
+	 * @param   string  $substring  The string being sought
+	 * @param   string  $string     The string/column being searched
+	 *
+	 * @return int   The position of $substring in $string
+	 */
+	public function getStringPositionSQL( $substring, $string )
+	{
+		$this->connect();
+
+		$query = "SELECT POSITION( $substring IN $string )";
+		$this->setQuery($query);
+		$position = $this->loadRow();
+
+		return $position['position'];
+	}
+
+	/**
+	 * Generate a random value
+	 *
+	 * @return float The random generated number
+	 */
+	public function getRandom()
+	{
+		$this->connect();
+
+		$this->setQuery('SELECT RANDOM()');
+		$random = $this->loadAssoc();
+
+		return $random['random'];
+	}
+
+	/**
+	 * Get the query string to alter the database character set.
+	 *
+	 * @param   string  $dbName  The database name
+	 *
+	 * @return  string  The query that alter the database query string
+	 *
+	 * @since   12.1
+	 */
+	public function getAlterDbCharacterSet( $dbName )
+	{
+		$query = 'ALTER DATABASE ' . $this->quoteName($dbName) . ' SET CLIENT_ENCODING TO ' . $this->quote('UTF8');
+
+		return $query;
+	}
+
+	/**
+	 * Get the query string to create new Database in correct PostgreSQL syntax.
+	 *
+	 * @param   JObject  $options  JObject coming from "initialise" function to pass user
+	 * 									and database name to database driver.
+	 * @param   boolean  $utf      True if the database supports the UTF-8 character set,
+	 * 									not used in PostgreSQL "CREATE DATABASE" query.
+	 *
+	 * @return  string	The query that creates database, owned by $options['user']
+	 *
+	 * @since   12.1
+	 */
+	public function getCreateDbQuery($options, $utf)
+	{
+		$query = 'CREATE DATABASE ' . $this->quoteName($options->db_name) . ' OWNER ' . $this->quoteName($options->db_user);
+
+		if ($utf)
+		{
+			$query .= ' ENCODING ' . $this->quote('UTF-8');
+		}
+
+		return $query;
+	}
+
+	/**
+	 * This function replaces a string identifier <var>$prefix</var> with the string held is the
+	 * <var>tablePrefix</var> class variable.
+	 *
+	 * @param   string  $sql     The SQL statement to prepare.
+	 * @param   string  $prefix  The common table prefix.
+	 *
+	 * @return  string  The processed SQL statement.
+	 *
+	 * @since   12.1
+	 */
+	public function replacePrefix($sql, $prefix = '#__')
+	{
+		$sql = trim($sql);
+		$replacedQuery = '';
+
+		if ( strpos($sql, '\'') )
+		{
+			// Sequence name quoted with ' ' but need to be replaced
+			if ( strpos($sql, 'currval') )
+			{
+				$sql = explode('currval', $sql);
+				for ( $nIndex = 1; $nIndex < count($sql); $nIndex = $nIndex + 2 )
+				{
+					$sql[$nIndex] = str_replace($prefix, $this->tablePrefix, $sql[$nIndex]);
+				}
+				$sql = implode('currval', $sql);
+			}
+
+			// Sequence name quoted with ' ' but need to be replaced
+			if ( strpos($sql, 'nextval') )
+			{
+				$sql = explode('nextval', $sql);
+				for ( $nIndex = 1; $nIndex < count($sql); $nIndex = $nIndex + 2 )
+				{
+					$sql[$nIndex] = str_replace($prefix, $this->tablePrefix, $sql[$nIndex]);
+				}
+				$sql = implode('nextval', $sql);
+			}
+
+			// Sequence name quoted with ' ' but need to be replaced
+			if ( strpos($sql, 'setval') )
+			{
+				$sql = explode('setval', $sql);
+				for ( $nIndex = 1; $nIndex < count($sql); $nIndex = $nIndex + 2 )
+				{
+					$sql[$nIndex] = str_replace($prefix, $this->tablePrefix, $sql[$nIndex]);
+				}
+				$sql = implode('setval', $sql);
+			}
+
+			$explodedQuery = explode('\'', $sql);
+
+			for ( $nIndex = 0; $nIndex < count($explodedQuery); $nIndex = $nIndex + 2 )
+			{
+				if ( strpos($explodedQuery[$nIndex], $prefix) )
+				{
+					$explodedQuery[$nIndex] = str_replace($prefix, $this->tablePrefix, $explodedQuery[$nIndex]);
+				}
+			}
+
+			$replacedQuery = implode('\'', $explodedQuery);
+		}
+		else
+		{
+			$replacedQuery = str_replace($prefix, $this->tablePrefix, $sql);
+		}
+
+		return $replacedQuery;
+	}
+
+	/**
+	 * Method to release a savepoint.
+	 *
+	 * @param   string  $savepointName  Savepoint's name to release
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function releaseTransactionSavepoint( $savepointName )
+	{
+		$this->connect();
+		$this->setQuery('RELEASE SAVEPOINT ' . $this->escape($savepointName));
+		$this->execute();
+	}
+
+	/**
+	 * Method to create a savepoint.
+	 *
+	 * @param   string  $savepointName  Savepoint's name to create
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function transactionSavepoint( $savepointName )
+	{
+		$this->connect();
+		$this->setQuery('SAVEPOINT ' . $this->escape($savepointName));
+		$this->execute();
+	}
+
+	/**
+	 * Unlocks tables in the database, this command does not exist in PostgreSQL,
+	 * it is automatically done on commit or rollback.
+	 *
+	 * @return  JDatabase  Returns this object to support chaining.
+	 *
+	 * @since   11.4
+	 * @throws  RuntimeException
+	 */
+	public function unlockTables()
+	{
+		$this->transactionCommit();
+		return $this;
+	}
+
+	/**
+	 * Updates a row in a table based on an object's properties.
+	 *
+	 * @param   string   $table    The name of the database table to update.
+	 * @param   object   &$object  A reference to an object whose public properties match the table fields.
+	 * @param   string   $key      The name of the primary key.
+	 * @param   boolean  $nulls    True to update null fields or false to ignore them.
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @since   11.1
+	 * @throws  RuntimeException
+	 */
+	public function updateObject($table, &$object, $key, $nulls = false)
+	{
+		$this->connect();
+
+		// Initialise variables.
+		$fields = array();
+		$where = '';
+
+		// Create the base update statement.
+		$query = $this->getQuery(true);
+		$query->update($table);
+		$stmt = '%s WHERE %s';
+
+		// Iterate over the object variables to build the query fields/value pairs.
+		foreach (get_object_vars($object) as $k => $v)
+		{
+			// Only process scalars that are not internal fields.
+			if (is_array($v) or is_object($v) or $k[0] == '_')
+			{
+				continue;
+			}
+
+			// Set the primary key to the WHERE clause instead of a field to update.
+			if ($k == $key)
+			{
+				$where = $this->quoteName($k) . '=' . (is_numeric($v) ? $v : $this->quote($v));
+				continue;
+			}
+
+			// Prepare and sanitize the fields and values for the database query.
+			if ($v === null)
+			{
+				// If the value is null and we want to update nulls then set it.
+				if ($nulls)
+				{
+					$val = 'NULL';
+				}
+				// If the value is null and we do not want to update nulls then ignore this field.
+				else
+				{
+					continue;
+				}
+			}
+			// The field is not null so we prep it for update.
+			else
+			{
+				$val = (is_numeric($v) ? $v : $this->quote($v));
+			}
+
+			// Add the field to be updated.
+			$fields[] = $this->quoteName($k) . '=' . $val;
+		}
+
+		// We don't have any fields to update.
+		if (empty($fields))
+		{
+			return true;
+		}
+
+		// Set the query and execute the update.
+		$query->set(sprintf($stmt, implode(",", $fields), $where));
+		$this->setQuery($query);
+
+		return $this->execute();
+	}
+}

--- a/libraries/joomla/database/exporter/postgresql.php
+++ b/libraries/joomla/database/exporter/postgresql.php
@@ -1,0 +1,313 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Database
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * PostgreSQL export driver.
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Database
+ * @since       12.1
+ */
+class JDatabaseExporterPostgresql extends JDatabaseExporter
+{
+	/**
+	 * An array of cached data.
+	 *
+	 * @var    array
+	 * @since  12.1
+	 */
+	protected $cache = array();
+
+	/**
+	 * The database connector to use for exporting structure and/or data.
+	 *
+	 * @var    JDatabasePostgresql
+	 * @since  12.1
+	 */
+	protected $db = null;
+
+	/**
+	 * An array input sources (table names).
+	 *
+	 * @var    array
+	 * @since  12.1
+	 */
+	protected $from = array();
+
+	/**
+	 * The type of output format (xml).
+	 *
+	 * @var    string
+	 * @since  12.1
+	 */
+	protected $asFormat = 'xml';
+
+	/**
+	 * An array of options for the exporter.
+	 *
+	 * @var    JObject
+	 * @since  12.1
+	 */
+	protected $options = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * Sets up the default options for the exporter.
+	 *
+	 * @since   12.1
+	 */
+	public function __construct()
+	{
+		$this->options = new JObject;
+
+		$this->cache = array('columns' => array(), 'keys' => array());
+
+		// Set up the class defaults:
+
+		// Export with only structure
+		$this->withStructure();
+
+		// Export as xml.
+		$this->asXml();
+
+		// Default destination is a string using $output = (string) $exporter;
+	}
+
+	/**
+	 * Magic function to exports the data to a string.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 * @throws  Exception if an error is encountered.
+	 */
+	public function __toString()
+	{
+		// Check everything is ok to run first.
+		$this->check();
+
+		$buffer = '';
+
+		// Get the format.
+		switch ($this->asFormat)
+		{
+			case 'xml':
+			default:
+				$buffer = $this->buildXml();
+				break;
+		}
+
+		return $buffer;
+	}
+
+	/**
+	 * Set the output option for the exporter to XML format.
+	 *
+	 * @return  JDatabaseExporterPostgresql  Method supports chaining.
+	 *
+	 * @since   12.1
+	 */
+	public function asXml()
+	{
+		$this->asFormat = 'xml';
+
+		return $this;
+	}
+
+	/**
+	 * Builds the XML data for the tables to export.
+	 *
+	 * @return  string  An XML string
+	 *
+	 * @since   12.1
+	 * @throws  Exception if an error occurs.
+	 */
+	protected function buildXml()
+	{
+		$buffer = array();
+
+		$buffer[] = '<?xml version="1.0"?>';
+		$buffer[] = '<postgresqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">';
+		$buffer[] = ' <database name="">';
+
+		$buffer = array_merge($buffer, $this->buildXmlStructure());
+
+		$buffer[] = ' </database>';
+		$buffer[] = '</postgresqldump>';
+
+		return implode("\n", $buffer);
+	}
+
+	/**
+	 * Builds the XML structure to export.
+	 *
+	 * @return  array  An array of XML lines (strings).
+	 *
+	 * @since   12.1
+	 * @throws  Exception if an error occurs.
+	 */
+	protected function buildXmlStructure()
+	{
+		$buffer = array();
+
+		foreach ($this->from as $table)
+		{
+			// Replace the magic prefix if found.
+			$table = $this->getGenericTableName($table);
+
+			// Get the details columns information.
+			$fields = $this->db->getTableColumns($table, false);
+			$keys = $this->db->getTableKeys($table);
+			$sequences = $this->db->getTableSequences($table);
+
+			$buffer[] = '  <table_structure name="' . $table . '">';
+
+			foreach ($sequences as $sequence)
+			{
+				if (version_compare($this->db->getVersion(), '9.1.0') < 0)
+				{
+					$sequence->start_value = null;
+				}
+
+				$buffer[] = '   <sequence Name="' . $sequence->sequence . '"' . ' Schema="' . $sequence->schema . '"' .
+					' Table="' . $sequence->table . '"' . ' Column="' . $sequence->column . '"' . ' Type="' . $sequence->data_type . '"' .
+					' Start_Value="' . $sequence->start_value . '"' . ' Min_Value="' . $sequence->minimum_value . '"' .
+					' Max_Value="' . $sequence->maximum_value . '"' . ' Increment="' . $sequence->increment . '"' .
+					' Cycle_option="' . $sequence->cycle_option . '"' .
+					' />';
+			}
+
+			foreach ($fields as $field)
+			{
+				$buffer[] = '   <field Field="' . $field->column_name . '"' . ' Type="' . $field->type . '"' . ' Null="' . $field->null . '"' .
+							(isset($field->default) ? ' Default="' . $field->default . '"' : '') . ' Comments="' . $field->comments . '"' .
+					' />';
+			}
+
+			foreach ($keys as $key)
+			{
+				$buffer[] = '   <key Index="' . $key->idxName . '"' . ' is_primary="' . $key->isPrimary . '"' . ' is_unique="' . $key->isUnique . '"' .
+					' Query="' . $key->Query . '" />';
+			}
+
+			$buffer[] = '  </table_structure>';
+		}
+
+		return $buffer;
+	}
+
+	/**
+	 * Checks if all data and options are in order prior to exporting.
+	 *
+	 * @return  JDatabaseExporterPostgresql  Method supports chaining.
+	 *
+	 * @since   12.1
+	 *
+	 * @throws  Exception if an error is encountered.
+	 */
+	public function check()
+	{
+		// Check if the db connector has been set.
+		if (!($this->db instanceof JDatabasePostgresql))
+		{
+			throw new Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
+		}
+
+		// Check if the tables have been specified.
+		if (empty($this->from))
+		{
+			throw new Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Get the generic name of the table, converting the database prefix to the wildcard string.
+	 *
+	 * @param   string  $table  The name of the table.
+	 *
+	 * @return  string  The name of the table with the database prefix replaced with #__.
+	 *
+	 * @since   12.1
+	 */
+	protected function getGenericTableName($table)
+	{
+		// TODO Incorporate into parent class and use $this.
+		$prefix = $this->db->getPrefix();
+
+		// Replace the magic prefix if found.
+		$table = preg_replace("|^$prefix|", '#__', $table);
+
+		return $table;
+	}
+
+	/**
+	 * Specifies a list of table names to export.
+	 *
+	 * @param   mixed  $from  The name of a single table, or an array of the table names to export.
+	 *
+	 * @return  JDatabaseExporterPostgresql  Method supports chaining.
+	 *
+	 * @since   12.1
+	 * @throws  Exception if input is not a string or array.
+	 */
+	public function from($from)
+	{
+		if (is_string($from))
+		{
+			$this->from = array($from);
+		}
+		elseif (is_array($from))
+		{
+			$this->from = $from;
+		}
+		else
+		{
+			throw new Exception('JPLATFORM_ERROR_INPUT_REQUIRES_STRING_OR_ARRAY');
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Sets the database connector to use for exporting structure and/or data from PostgreSQL.
+	 *
+	 * @param   JDatabasePostgresql  $db  The database connector.
+	 *
+	 * @return  JDatabaseExporterPostgresql  Method supports chaining.
+	 *
+	 * @since   12.1
+	 */
+	public function setDbo(JDatabasePostgresql $db)
+	{
+		$this->db = $db;
+
+		return $this;
+	}
+
+	/**
+	 * Sets an internal option to export the structure of the input table(s).
+	 *
+	 * @param   boolean  $setting  True to export the structure, false to not.
+	 *
+	 * @return  JDatabaseExporterPostgresql  Method supports chaining.
+	 *
+	 * @since   12.1
+	 */
+	public function withStructure($setting = true)
+	{
+		$this->options->set('with-structure', (boolean) $setting);
+
+		return $this;
+	}
+}

--- a/libraries/joomla/database/importer/postgresql.php
+++ b/libraries/joomla/database/importer/postgresql.php
@@ -1,0 +1,795 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Database
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * PostgreSQL import driver.
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Database
+ * @since       12.1
+ */
+class JDatabaseImporterPostgresql extends JDatabaseImporter
+{
+	/**
+	 * @var    array  An array of cached data.
+	 * @since  12.1
+	 */
+	protected $cache = array();
+
+	/**
+	 * The database connector to use for exporting structure and/or data.
+	 *
+	 * @var    JDatabasePostgresql
+	 * @since  12.1
+	 */
+	protected $db = null;
+
+	/**
+	 * The input source.
+	 *
+	 * @var    mixed
+	 * @since  12.1
+	 */
+	protected $from = array();
+
+	/**
+	 * The type of input format (XML).
+	 *
+	 * @var    string
+	 * @since  12.1
+	 */
+	protected $asFormat = 'xml';
+
+	/**
+	 * An array of options for the exporter.
+	 *
+	 * @var    JObject
+	 * @since  12.1
+	 */
+	protected $options = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * Sets up the default options for the exporter.
+	 *
+	 * @since   12.1
+	 */
+	public function __construct()
+	{
+		$this->options = new JObject;
+
+		$this->cache = array('columns' => array(), 'keys' => array());
+
+		// Set up the class defaults:
+
+		// Import with only structure
+		$this->withStructure();
+
+		// Export as XML.
+		$this->asXml();
+
+		// Default destination is a string using $output = (string) $exporter;
+	}
+
+	/**
+	 * Set the output option for the exporter to XML format.
+	 *
+	 * @return  JDatabaseImporterPostgresql  Method supports chaining.
+	 *
+	 * @since   12.1
+	 */
+	public function asXml()
+	{
+		$this->asFormat = 'xml';
+
+		return $this;
+	}
+
+	/**
+	 * Checks if all data and options are in order prior to exporting.
+	 *
+	 * @return  JDatabaseImporterPostgresql  Method supports chaining.
+	 *
+	 * @since   12.1
+	 * @throws  Exception if an error is encountered.
+	 */
+	public function check()
+	{
+		// Check if the db connector has been set.
+		if (!($this->db instanceof JDatabasePostgresql))
+		{
+			throw new Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
+		}
+
+		// Check if the tables have been specified.
+		if (empty($this->from))
+		{
+			throw new Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Specifies the data source to import.
+	 *
+	 * @param   mixed  $from  The data source to import.
+	 *
+	 * @return  JDatabaseImporterPostgresql  Method supports chaining.
+	 *
+	 * @since   12.1
+	 */
+	public function from($from)
+	{
+		$this->from = $from;
+
+		return $this;
+	}
+
+	/**
+	 * Get the SQL syntax to add a column.
+	 *
+	 * @param   string            $table  The table name.
+	 * @param   SimpleXMLElement  $field  The XML field definition.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	protected function getAddColumnSQL($table, SimpleXMLElement $field)
+	{
+		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' ADD COLUMN ' . $this->getColumnSQL($field);
+
+		return $sql;
+	}
+
+	/**
+	 * Get the SQL syntax to add an index.
+	 *
+	 * @param   SimpleXMLElement  $field  The XML index definition.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	protected function getAddIndexSQL(SimpleXMLElement $field)
+	{
+		return (string) $field['Query'];
+	}
+
+	/**
+	 * Get alters for table if there is a difference.
+	 *
+	 * @param   SimpleXMLElement  $structure  The XML structure of the table.
+	 *
+	 * @return  array
+	 *
+	 * @since   12.1
+	 */
+	protected function getAlterTableSQL(SimpleXMLElement $structure)
+	{
+		// Initialise variables.
+		$table = $this->getRealTableName($structure['name']);
+		$oldFields = $this->db->getTableColumns($table);
+		$oldKeys = $this->db->getTableKeys($table);
+		$oldSequence = $this->db->getTableSequences($table);
+		$alters = array();
+
+		// Get the fields and keys from the XML that we are aiming for.
+		$newFields = $structure->xpath('field');
+		$newKeys = $structure->xpath('key');
+		$newSequence = $structure->xpath('sequence');
+
+		/* Sequence section */
+		$oldSeq = $this->getSeqLookup($oldSequence);
+		$newSequenceLook = $this->getSeqLookup($newSequence);
+
+		foreach ($newSequenceLook as $kSeqName => $vSeq)
+		{
+			if (isset($oldSeq[$kSeqName]))
+			{
+				// The field exists, check it's the same.
+				$column = $oldSeq[$kSeqName][0];
+
+				/* For older database version that doesn't support these fields use default values */
+				if (version_compare($this->db->getVersion(), '9.1.0') < 0)
+				{
+					$column->Min_Value = '1';
+					$column->Max_Value = '9223372036854775807';
+					$column->Increment = '1';
+					$column->Cycle_option = 'NO';
+					$column->Start_Value = '1';
+				}
+
+				// Test whether there is a change.
+				$change = ((string) $vSeq[0]['Type'] != $column->Type) || ((string) $vSeq[0]['Start_Value'] != $column->Start_Value)
+					|| ((string) $vSeq[0]['Min_Value'] != $column->Min_Value) || ((string) $vSeq[0]['Max_Value'] != $column->Max_Value)
+					|| ((string) $vSeq[0]['Increment'] != $column->Increment) || ((string) $vSeq[0]['Cycle_option'] != $column->Cycle_option)
+					|| ((string) $vSeq[0]['Table'] != $column->Table) || ((string) $vSeq[0]['Column'] != $column->Column)
+					|| ((string) $vSeq[0]['Schema'] != $column->Schema) || ((string) $vSeq[0]['Name'] != $column->Name);
+
+				if ($change)
+				{
+					$alters[] = $this->getChangeSequenceSQL($kSeqName, $vSeq);
+				}
+
+				// Unset this field so that what we have left are fields that need to be removed.
+				unset($oldSeq[$kSeqName]);
+			}
+			else
+			{
+				// The sequence is new
+				$alters[] = $this->getAddSequenceSQL($newSequenceLook[$kSeqName][0]);
+			}
+		}
+
+		// Any sequences left are orphans
+		foreach ($oldSeq as $name => $column)
+		{
+			// Delete the sequence.
+			$alters[] = $this->getDropSequenceSQL($name);
+		}
+
+		/* Field section */
+		// Loop through each field in the new structure.
+		foreach ($newFields as $field)
+		{
+			$fName = (string) $field['Field'];
+
+			if (isset($oldFields[$fName]))
+			{
+				// The field exists, check it's the same.
+				$column = $oldFields[$fName];
+
+				// Test whether there is a change.
+				$change = ((string) $field['Type'] != $column->Type) || ((string) $field['Null'] != $column->Null)
+					|| ((string) $field['Default'] != $column->Default);
+
+				if ($change)
+				{
+					$alters[] = $this->getChangeColumnSQL($table, $field);
+				}
+
+				// Unset this field so that what we have left are fields that need to be removed.
+				unset($oldFields[$fName]);
+			}
+			else
+			{
+				// The field is new.
+				$alters[] = $this->getAddColumnSQL($table, $field);
+			}
+		}
+
+		// Any columns left are orphans
+		foreach ($oldFields as $name => $column)
+		{
+			// Delete the column.
+			$alters[] = $this->getDropColumnSQL($table, $name);
+		}
+
+		/* Index section */
+		// Get the lookups for the old and new keys
+		$oldLookup = $this->getIdxLookup($oldKeys);
+		$newLookup = $this->getIdxLookup($newKeys);
+
+		// Loop through each key in the new structure.
+		foreach ($newLookup as $name => $keys)
+		{
+			// Check if there are keys on this field in the existing table.
+			if (isset($oldLookup[$name]))
+			{
+				$same = true;
+				$newCount = count($newLookup[$name]);
+				$oldCount = count($oldLookup[$name]);
+
+				// There is a key on this field in the old and new tables. Are they the same?
+				if ($newCount == $oldCount)
+				{
+					for ($i = 0; $i < $newCount; $i++)
+					{
+						// Check only query field -> different query means different index
+						$same = ((string) $newLookup[$name][$i]['Query'] == $oldLookup[$name][$i]->Query);
+
+						if (!$same)
+						{
+							// Break out of the loop. No need to check further.
+							break;
+						}
+					}
+				}
+				else
+				{
+					// Count is different, just drop and add.
+					$same = false;
+				}
+
+				if (!$same)
+				{
+					$alters[] = $this->getDropIndexSQL($name);
+					$alters[]  = (string) $newLookup[$name][0]['Query'];
+				}
+
+				// Unset this field so that what we have left are fields that need to be removed.
+				unset($oldLookup[$name]);
+			}
+			else
+			{
+				// This is a new key.
+				$alters[] = (string) $newLookup[$name][0]['Query'];
+			}
+		}
+
+		// Any keys left are orphans.
+		foreach ($oldLookup as $name => $keys)
+		{
+			if ($oldLookup[$name][0]->is_primary == 'TRUE')
+			{
+				$alters[] = $this->getDropPrimaryKeySQL($table, $oldLookup[$name][0]->Index);
+			}
+			else
+			{
+				$alters[] = $this->getDropIndexSQL($name);
+			}
+		}
+
+		return $alters;
+	}
+
+	/**
+	 * Get the SQL syntax to drop a sequence.
+	 *
+	 * @param   string  $name  The name of the sequence to drop.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	protected function getDropSequenceSQL($name)
+	{
+		$sql = 'DROP SEQUENCE ' . $this->db->quoteName($name);
+		return $sql;
+	}
+
+	/**
+	 * Get the syntax to add a sequence.
+	 *
+	 * @param   SimpleXMLElement  $field  The XML definition for the sequence.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	protected function getAddSequenceSQL($field)
+	{
+		/* For older database version that doesn't support these fields use default values */
+		if (version_compare($this->db->getVersion(), '9.1.0') < 0)
+		{
+			$field['Min_Value'] = '1';
+			$field['Max_Value'] = '9223372036854775807';
+			$field['Increment'] = '1';
+			$field['Cycle_option'] = 'NO';
+			$field['Start_Value'] = '1';
+		}
+
+		$sql = 'CREATE SEQUENCE ' . (string) $field['Name'] .
+				' INCREMENT BY ' . (string) $field['Increment'] . ' MINVALUE ' . $field['Min_Value'] .
+				' MAXVALUE ' . (string) $field['Max_Value'] . ' START ' . (string) $field['Start_Value'] .
+				(((string) $field['Cycle_option'] == 'NO' ) ? ' NO' : '' ) . ' CYCLE' .
+				' OWNED BY ' . $this->db->quoteName(
+									(string) $field['Schema'] . '.' . (string) $field['Table'] . '.' . (string) $field['Column']
+								);
+		return $sql;
+	}
+
+	/**
+	 * Get the syntax to alter a sequence.
+	 *
+	 * @param   SimpleXMLElement  $field  The XML definition for the sequence.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	protected function getChangeSequenceSQL($field)
+	{
+		/* For older database version that doesn't support these fields use default values */
+		if (version_compare($this->db->getVersion(), '9.1.0') < 0)
+		{
+			$field['Min_Value'] = '1';
+			$field['Max_Value'] = '9223372036854775807';
+			$field['Increment'] = '1';
+			$field['Cycle_option'] = 'NO';
+			$field['Start_Value'] = '1';
+		}
+
+		$sql = 'ALTER SEQUENCE ' . (string) $field['Name'] .
+				' INCREMENT BY ' . (string) $field['Increment'] . ' MINVALUE ' . (string) $field['Min_Value'] .
+				' MAXVALUE ' . (string) $field['Max_Value'] . ' START ' . (string) $field['Start_Value'] .
+				' OWNED BY ' . $this->db->quoteName(
+									(string) $field['Schema'] . '.' . (string) $field['Table'] . '.' . (string) $field['Column']
+								);
+		return $sql;
+	}
+
+	/**
+	 * Get the syntax to alter a column.
+	 *
+	 * @param   string            $table  The name of the database table to alter.
+	 * @param   SimpleXMLElement  $field  The XML definition for the field.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	protected function getChangeColumnSQL($table, SimpleXMLElement $field)
+	{
+		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' ALTER COLUMN ' . $this->db->quoteName((string) $field['Field']) . ' '
+			. $this->getAlterColumnSQL($table, $field);
+
+		return $sql;
+	}
+
+	/**
+	 * Get the SQL syntax for a single column that would be included in a table create statement.
+	 *
+	 * @param   string            $table  The name of the database table to alter.
+	 * @param   SimpleXMLElement  $field  The XML field definition.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	protected function getAlterColumnSQL($table, $field)
+	{
+		// Initialise variables.
+		// TODO Incorporate into parent class and use $this.
+		$blobs = array('text', 'smalltext', 'mediumtext', 'largetext');
+
+		$fName = (string) $field['Field'];
+		$fType = (string) $field['Type'];
+		$fNull = (string) $field['Null'];
+		$fDefault = (isset($field['Default']) && $field['Default'] != 'NULL' ) ?
+						preg_match('/^[0-9]$/', $field['Default']) ? $field['Default'] : $this->db->quote((string) $field['Default'])
+					: null;
+
+		$sql = ' TYPE ' . $fType;
+
+		if ($fNull == 'NO')
+		{
+			if (in_array($fType, $blobs) || $fDefault === null)
+			{
+				$sql .= ",\nALTER COLUMN " . $this->db->quoteName($fName) . ' SET NOT NULL' .
+						",\nALTER COLUMN " . $this->db->quoteName($fName) . ' DROP DEFAULT';
+			}
+			else
+			{
+				$sql .= ",\nALTER COLUMN " . $this->db->quoteName($fName) . ' SET NOT NULL' .
+						",\nALTER COLUMN " . $this->db->quoteName($fName) . ' SET DEFAULT ' . $fDefault;
+			}
+		}
+		else
+		{
+			if ($fDefault !== null)
+			{
+				$sql .= ",\nALTER COLUMN " . $this->db->quoteName($fName) . ' DROP NOT NULL' .
+						",\nALTER COLUMN " . $this->db->quoteName($fName) . ' SET DEFAULT ' . $fDefault;
+			}
+		}
+
+		/* sequence was created in other function, here is associated a default value but not yet owner */
+		if (strpos($fDefault, 'nextval') !== false)
+		{
+			$sql .= ";\nALTER SEQUENCE " . $this->db->quoteName($table . '_' . $fName . '_seq') . ' OWNED BY ' . $this->db->quoteName($table . '.' . $fName);
+		}
+
+		return $sql;
+	}
+
+	/**
+	 * Get the SQL syntax for a single column that would be included in a table create statement.
+	 *
+	 * @param   SimpleXMLElement  $field  The XML field definition.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	protected function getColumnSQL(SimpleXMLElement $field)
+	{
+		// Initialise variables.
+		// TODO Incorporate into parent class and use $this.
+		$blobs = array('text', 'smalltext', 'mediumtext', 'largetext');
+
+		$fName = (string) $field['Field'];
+		$fType = (string) $field['Type'];
+		$fNull = (string) $field['Null'];
+		$fDefault = (isset($field['Default']) && $field['Default'] != 'NULL' ) ?
+						preg_match('/^[0-9]$/', $field['Default']) ? $field['Default'] : $this->db->quote((string) $field['Default'])
+					: null;
+
+		/* nextval() as default value means that type field is serial */
+		if (strpos($fDefault, 'nextval') !== false)
+		{
+			$sql = $this->db->quoteName($fName) . ' SERIAL';
+		}
+		else
+		{
+			$sql = $this->db->quoteName($fName) . ' ' . $fType;
+
+			if ($fNull == 'NO')
+			{
+				if (in_array($fType, $blobs) || $fDefault === null)
+				{
+					$sql .= ' NOT NULL';
+				}
+				else
+				{
+					$sql .= ' NOT NULL DEFAULT ' . $fDefault;
+				}
+			}
+			else
+			{
+				if ($fDefault !== null)
+				{
+					$sql .= ' DEFAULT ' . $fDefault;
+				}
+			}
+		}
+
+		return $sql;
+	}
+
+	/**
+	 * Get the SQL syntax to drop a column.
+	 *
+	 * @param   string  $table  The table name.
+	 * @param   string  $name   The name of the field to drop.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	protected function getDropColumnSQL($table, $name)
+	{
+		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' DROP COLUMN ' . $this->db->quoteName($name);
+
+		return $sql;
+	}
+
+	/**
+	 * Get the SQL syntax to drop an index.
+	 *
+	 * @param   string  $name  The name of the key to drop.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	protected function getDropIndexSQL($name)
+	{
+		$sql = 'DROP INDEX ' . $this->db->quoteName($name);
+
+		return $sql;
+	}
+
+	/**
+	 * Get the SQL syntax to drop a key.
+	 *
+	 * @param   string  $table  The table name.
+	 * @param   string  $name   The constraint name.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	protected function getDropPrimaryKeySQL($table, $name)
+	{
+		$sql = 'ALTER TABLE ONLY ' . $this->db->quoteName($table) . ' DROP CONSTRAINT ' . $this->db->quoteName($name);
+
+		return $sql;
+	}
+
+	/**
+	 * Get the details list of keys for a table.
+	 *
+	 * @param   array  $keys  An array of objects that comprise the keys for the table.
+	 *
+	 * @return  array  The lookup array. array({key name} => array(object, ...))
+	 *
+	 * @since   12.1
+	 * @throws  Exception
+	 */
+	protected function getIdxLookup($keys)
+	{
+		// First pass, create a lookup of the keys.
+		$lookup = array();
+		foreach ($keys as $key)
+		{
+			if ($key instanceof SimpleXMLElement)
+			{
+				$kName = (string) $key['Index'];
+			}
+			else
+			{
+				$kName = $key->Index;
+			}
+			if (empty($lookup[$kName]))
+			{
+				$lookup[$kName] = array();
+			}
+			$lookup[$kName][] = $key;
+		}
+
+		return $lookup;
+	}
+
+	/**
+	 * Get the details list of sequences for a table.
+	 *
+	 * @param   array  $sequences  An array of objects that comprise the sequences for the table.
+	 *
+	 * @return  array  The lookup array. array({key name} => array(object, ...))
+	 *
+	 * @since   12.1
+	 * @throws  Exception
+	 */
+	protected function getSeqLookup($sequences)
+	{
+		// First pass, create a lookup of the keys.
+		$lookup = array();
+		foreach ($sequences as $seq)
+		{
+			if ($seq instanceof SimpleXMLElement)
+			{
+				$sName = (string) $seq['Name'];
+			}
+			else
+			{
+				$sName = $seq->Name;
+			}
+			if (empty($lookup[$sName]))
+			{
+				$lookup[$sName] = array();
+			}
+			$lookup[$sName][] = $seq;
+		}
+
+		return $lookup;
+	}
+
+	/**
+	 * Get the real name of the table, converting the prefix wildcard string if present.
+	 *
+	 * @param   string  $table  The name of the table.
+	 *
+	 * @return  string	The real name of the table.
+	 *
+	 * @since   12.1
+	 */
+	protected function getRealTableName($table)
+	{
+		// TODO Incorporate into parent class and use $this.
+		$prefix = $this->db->getPrefix();
+
+		// Replace the magic prefix if found.
+		$table = preg_replace('|^#__|', $prefix, $table);
+
+		return $table;
+	}
+
+	/**
+	 * Merges the incoming structure definition with the existing structure.
+	 *
+	 * @return  void
+	 *
+	 * @note    Currently only supports XML format.
+	 * @since   12.1
+	 * @throws  Exception on error.
+	 * @todo    If it's not XML convert to XML first.
+	 */
+	protected function mergeStructure()
+	{
+		// Initialise variables.
+		$prefix = $this->db->getPrefix();
+		$tables = $this->db->getTableList();
+
+		if ($this->from instanceof SimpleXMLElement)
+		{
+			$xml = $this->from;
+		}
+		else
+		{
+			$xml = new SimpleXMLElement($this->from);
+		}
+
+		// Get all the table definitions.
+		$xmlTables = $xml->xpath('database/table_structure');
+
+		foreach ($xmlTables as $table)
+		{
+			// Convert the magic prefix into the real table name.
+			$tableName = (string) $table['name'];
+			$tableName = preg_replace('|^#__|', $prefix, $tableName);
+
+			if (in_array($tableName, $tables))
+			{
+				// The table already exists. Now check if there is any difference.
+				if ($queries = $this->getAlterTableSQL($xml->database->table_structure))
+				{
+					// Run the queries to upgrade the data structure.
+					foreach ($queries as $query)
+					{
+						$this->db->setQuery((string) $query);
+						if (!$this->db->query())
+						{
+							$this->addLog('Fail: ' . $this->db->getQuery());
+							throw new Exception($this->db->getErrorMsg());
+						}
+						else
+						{
+							$this->addLog('Pass: ' . $this->db->getQuery());
+						}
+					}
+
+				}
+			}
+			else
+			{
+				// This is a new table.
+				$sql = $this->xmlToCreate($table);
+
+				$this->db->setQuery((string) $sql);
+				if (!$this->db->query())
+				{
+					$this->addLog('Fail: ' . $this->db->getQuery());
+					throw new Exception($this->db->getErrorMsg());
+				}
+				else
+				{
+					$this->addLog('Pass: ' . $this->db->getQuery());
+				}
+			}
+		}
+	}
+
+	/**
+	 * Sets the database connector to use for exporting structure and/or data from PostgreSQL.
+	 *
+	 * @param   JDatabasePostgresql  $db  The database connector.
+	 *
+	 * @return  JDatabaseImporterPostgresql  Method supports chaining.
+	 *
+	 * @since   12.1
+	 */
+	public function setDbo(JDatabasePostgresql $db)
+	{
+		$this->db = $db;
+
+		return $this;
+	}
+
+	/**
+	 * Sets an internal option to merge the structure based on the input data.
+	 *
+	 * @param   boolean  $setting  True to export the structure, false to not.
+	 *
+	 * @return  JDatabaseImporterPostgresql  Method supports chaining.
+	 *
+	 * @since   12.1
+	 */
+	public function withStructure($setting = true)
+	{
+		$this->options->set('with-structure', (boolean) $setting);
+
+		return $this;
+	}
+}

--- a/libraries/joomla/database/query/postgresql.php
+++ b/libraries/joomla/database/query/postgresql.php
@@ -1,0 +1,600 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Database
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Query Building Class.
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Database
+ * @since       11.3
+ */
+class JDatabaseQueryPostgresql extends JDatabaseQuery implements JDatabaseQueryLimitable
+{
+	/**
+	 * @var    object  The FOR UPDATE element used in "FOR UPDATE"  lock
+	 * @since  11.3
+	 */
+	protected $forUpdate = null;
+
+	/**
+	 * @var    object  The FOR SHARE element used in "FOR SHARE"  lock
+	 * @since  11.3
+	 */
+	protected $forShare = null;
+
+	/**
+	 * @var    object  The NOWAIT element used in "FOR SHARE" and "FOR UPDATE" lock
+	 * @since  11.3
+	 */
+	protected $noWait = null;
+
+	/**
+	 * @var    object  The LIMIT element
+	 * @since  11.3
+	 */
+	protected $limit = null;
+
+	/**
+	 * @var    object  The OFFSET element
+	 * @since  11.3
+	 */
+	protected $offset = null;
+
+	/**
+	 * @var    object  The RETURNING element of INSERT INTO
+	 * @since  11.3
+	 */
+	protected $returning = null;
+
+	/**
+	 * Magic function to convert the query to a string, only for postgresql specific query
+	 *
+	 * @return  string	The completed query.
+	 *
+	 * @since   11.3
+	 */
+	public function __toString()
+	{
+		$query = '';
+
+		switch ($this->type)
+		{
+			case 'select':
+				$query .= (string) $this->select;
+				$query .= (string) $this->from;
+				if ($this->join)
+				{
+					// Special case for joins
+					foreach ($this->join as $join)
+					{
+						$query .= (string) $join;
+					}
+				}
+
+				if ($this->where)
+				{
+					$query .= (string) $this->where;
+				}
+
+				if ($this->group)
+				{
+					$query .= (string) $this->group;
+				}
+
+				if ($this->having)
+				{
+					$query .= (string) $this->having;
+				}
+
+				if ($this->order)
+				{
+					$query .= (string) $this->order;
+				}
+
+				if ($this->limit)
+				{
+					$query .= (string) $this->limit;
+				}
+
+				if ($this->offset)
+				{
+					$query .= (string) $this->offset;
+				}
+
+				if ($this->forUpdate)
+				{
+					$query .= (string) $this->forUpdate;
+				}
+				else
+				{
+					if ($this->forShare)
+					{
+						$query .= (string) $this->forShare;
+					}
+				}
+
+				if ($this->noWait)
+				{
+					$query .= (string) $this->noWait;
+				}
+
+				break;
+
+			case 'update':
+				$query .= (string) $this->update;
+				$query .= (string) $this->set;
+
+				if ($this->join)
+				{
+					$onWord = ' ON ';
+
+					// Workaround for special case of JOIN with UPDATE
+					foreach ($this->join as $join)
+					{
+						$joinElem = $join->getElements();
+
+						$joinArray = explode($onWord, $joinElem[0]);
+
+						$this->from($joinArray[0]);
+						$this->where($joinArray[1]);
+					}
+
+					$query .= (string) $this->from;
+				}
+
+				if ($this->where)
+				{
+					$query .= (string) $this->where;
+				}
+
+				break;
+
+			case 'insert':
+				$query .= (string) $this->insert;
+
+				if ($this->values)
+				{
+					if ($this->columns)
+					{
+						$query .= (string) $this->columns;
+					}
+
+					$elements = $this->values->getElements();
+					if (!($elements[0] instanceof $this))
+					{
+						$query .= ' VALUES ';
+					}
+
+					$query .= (string) $this->values;
+
+					if ($this->returning)
+					{
+						$query .= (string) $this->returning;
+					}
+				}
+
+				break;
+
+			default:
+				$query = parent::__toString();
+				break;
+
+		}
+
+		return $query;
+	}
+
+	/**
+	 * Clear data from the query or a specific clause of the query.
+	 *
+	 * @param   string  $clause  Optionally, the name of the clause to clear, or nothing to clear the whole query.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function clear($clause = null)
+	{
+		switch ($clause)
+		{
+			case 'limit':
+				$this->limit = null;
+				break;
+
+			case 'offset':
+				$this->offset = null;
+				break;
+
+			case 'forUpdate':
+				$this->forUpdate = null;
+				break;
+
+			case 'forShare':
+				$this->forShare = null;
+				break;
+
+			case 'noWait':
+				$this->noWait = null;
+				break;
+
+			case 'returning':
+				$this->returning = null;
+				break;
+
+			case 'select':
+			case 'update':
+			case 'delete':
+			case 'insert':
+			case 'from':
+			case 'join':
+			case 'set':
+			case 'where':
+			case 'group':
+			case 'having':
+			case 'order':
+			case 'columns':
+			case 'values':
+				parent::clear($clause);
+				break;
+
+			default:
+				$this->type = null;
+				$this->limit = null;
+				$this->offset = null;
+				$this->forUpdate = null;
+				$this->forShare = null;
+				$this->noWait = null;
+				$this->returning = null;
+				parent::clear($clause);
+				break;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Casts a value to a char.
+	 *
+	 * Ensure that the value is properly quoted before passing to the method.
+	 *
+	 * Usage:
+	 * $query->select($query->castAsChar('a'));
+	 *
+	 * @param   string  $value  The value to cast as a char.
+	 *
+	 * @return  string  Returns the cast value.
+	 *
+	 * @since   11.1
+	 */
+	public function castAsChar($value)
+	{
+		return $value . '::text';
+	}
+
+	/**
+	 * Concatenates an array of column names or values.
+	 *
+	 * Usage:
+	 * $query->select($query->concatenate(array('a', 'b')));
+	 *
+	 * @param   array   $values     An array of values to concatenate.
+	 * @param   string  $separator  As separator to place between each value.
+	 *
+	 * @return  string  The concatenated values.
+	 *
+	 * @since   11.3
+	 */
+	public function concatenate($values, $separator = null)
+	{
+		if ($separator)
+		{
+			return implode(' || ' . $this->quote($separator) . ' || ', $values);
+		}
+		else
+		{
+			return implode(' || ', $values);
+		}
+	}
+
+	/**
+	 * Gets the current date and time.
+	 *
+	 * @return  string  Return string used in query to obtain 
+	 *
+	 * @since   11.3
+	 */
+	public function currentTimestamp()
+	{
+		return 'NOW()';
+	}
+
+	/**
+	 * Sets the FOR UPDATE lock on select's output row
+	 * 
+	 * @param   string   $table_name  The table to lock
+	 * @param   boolean  $glue        The glue by which to join the conditions. Defaults to ',' .
+	 * 
+	 * @return  JDatabaseQuery  FOR UPDATE query element
+	 * 
+	 * @since   11.3
+	 */
+	public function forUpdate ($table_name, $glue = ',')
+	{
+		$this->type = 'forUpdate';
+
+		if ( is_null($this->forUpdate) )
+		{
+			$glue = strtoupper($glue);
+			$this->forUpdate = new JDatabaseQueryElement('FOR UPDATE', 'OF ' . $table_name, "$glue ");
+		}
+		else
+		{
+			$this->forUpdate->append($table_name);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Sets the FOR SHARE lock on select's output row
+	 * 
+	 * @param   string   $table_name  The table to lock
+	 * @param   boolean  $glue        The glue by which to join the conditions. Defaults to ',' .
+	 * 
+	 * @return  JDatabaseQuery  FOR SHARE query element
+	 * 
+	 * @since   11.3
+	 */
+	public function forShare ($table_name, $glue = ',')
+	{
+		$this->type = 'forShare';
+
+		if ( is_null($this->forShare) )
+		{
+			$glue = strtoupper($glue);
+			$this->forShare = new JDatabaseQueryElement('FOR SHARE', 'OF ' . $table_name, "$glue ");
+		}
+		else
+		{
+			$this->forShare->append($table_name);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Used to get a string to extract year from date column.
+	 *
+	 * Usage:
+	 * $query->select($query->year($query->quoteName('dateColumn')));
+	 * 
+	 * @param   string  $date  Date column containing year to be extracted.
+	 *
+	 * @return  string  Returns string to extract year from a date.
+	 *
+	 * @since   12.1
+	 */
+	public function year($date)
+	{
+		return 'EXTRACT (YEAR FROM ' . $date . ')';
+	}
+
+	/**
+	 * Used to get a string to extract month from date column.
+	 *
+	 * Usage:
+	 * $query->select($query->month($query->quoteName('dateColumn')));
+	 * 
+	 * @param   string  $date  Date column containing month to be extracted.
+	 *
+	 * @return  string  Returns string to extract month from a date.
+	 *
+	 * @since   12.1
+	 */
+	public function month($date)
+	{
+		return 'EXTRACT (MONTH FROM ' . $date . ')';
+	}
+
+	/**
+	 * Used to get a string to extract day from date column.
+	 *
+	 * Usage:
+	 * $query->select($query->day($query->quoteName('dateColumn')));
+	 * 
+	 * @param   string  $date  Date column containing day to be extracted.
+	 *
+	 * @return  string  Returns string to extract day from a date.
+	 *
+	 * @since   12.1
+	 */
+	public function day($date)
+	{
+		return 'EXTRACT (DAY FROM ' . $date . ')';
+	}
+
+	/**
+	 * Used to get a string to extract hour from date column.
+	 *
+	 * Usage:
+	 * $query->select($query->hour($query->quoteName('dateColumn')));
+	 * 
+	 * @param   string  $date  Date column containing hour to be extracted.
+	 *
+	 * @return  string  Returns string to extract hour from a date.
+	 *
+	 * @since   12.1
+	 */
+	public function hour($date)
+	{
+		return 'EXTRACT (HOUR FROM ' . $date . ')';
+	}
+
+	/**
+	 * Used to get a string to extract minute from date column.
+	 *
+	 * Usage:
+	 * $query->select($query->minute($query->quoteName('dateColumn')));
+	 * 
+	 * @param   string  $date  Date column containing minute to be extracted.
+	 *
+	 * @return  string  Returns string to extract minute from a date.
+	 *
+	 * @since   12.1
+	 */
+	public function minute($date)
+	{
+		return 'EXTRACT (MINUTE FROM ' . $date . ')';
+	}
+
+	/**
+	 * Used to get a string to extract seconds from date column.
+	 *
+	 * Usage:
+	 * $query->select($query->second($query->quoteName('dateColumn')));
+	 * 
+	 * @param   string  $date  Date column containing second to be extracted.
+	 *
+	 * @return  string  Returns string to extract second from a date.
+	 *
+	 * @since   12.1
+	 */
+	public function second($date)
+	{
+		return 'EXTRACT (SECOND FROM ' . $date . ')';
+	}
+
+	/**
+	 * Sets the NOWAIT lock on select's output row
+	 * 
+	 * @return  JDatabaseQuery  NO WAIT query element
+	 * 
+	 * @since   11.3
+	 */
+	public function noWait ()
+	{
+		$this->type = 'noWait';
+
+		if ( is_null($this->noWait) )
+		{
+			$this->noWait = new JDatabaseQueryElement('NOWAIT', null);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Set the LIMIT clause to the query
+	 * 
+	 * @param   int  $limit  An int of how many row will be returned
+	 *
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 *
+	 * @since   11.3
+	 */
+	public function limit( $limit = 0 )
+	{
+		if (is_null($this->limit))
+		{
+			$this->limit = new JDatabaseQueryElement('LIMIT', (int) $limit);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Set the OFFSET clause to the query
+	 * 
+	 * @param   int  $offset  An int for skipping row
+	 *
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 *
+	 * @since   11.3
+	 */
+	public function offset( $offset = 0 )
+	{
+		if (is_null($this->offset))
+		{
+			$this->offset = new JDatabaseQueryElement('OFFSET', (int) $offset);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Add the RETURNING element to INSERT INTO statement.
+	 *
+	 * @param   mixed  $pkCol  The name of the primary key column.
+	 *
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 *
+	 * @since   11.3
+	 */
+	public function returning( $pkCol )
+	{
+		if (is_null($this->returning))
+		{
+			$this->returning = new JDatabaseQueryElement('RETURNING', $pkCol);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Sets the offset and limit for the result set, if the database driver supports it.
+	 *
+	 * Usage:
+	 * $query->setLimit(100, 0); (retrieve 100 rows, starting at first record)
+	 * $query->setLimit(50, 50); (retrieve 50 rows, starting at 50th record)
+	 *
+	 * @param   integer  $limit   The limit for the result set
+	 * @param   integer  $offset  The offset for the result set
+	 *
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 *
+	 * @since   12.1
+	 */
+	public function setLimit($limit = 0, $offset = 0)
+	{
+		$this->limit  = (int) $limit;
+		$this->offset = (int) $offset;
+
+		return $this;
+	}
+
+	/**
+	 * Method to modify a query already in string format with the needed
+	 * additions to make the query limited to a particular number of
+	 * results, or start at a particular offset.
+	 *
+	 * @param   string   $query   The query in string format
+	 * @param   integer  $limit   The limit for the result set
+	 * @param   integer  $offset  The offset for the result set
+	 *
+	 * @return string
+	 *
+	 * @since 12.1
+	 */
+	public function processLimit($query, $limit, $offset = 0)
+	{
+		if ($limit > 0)
+		{
+			$query .= ' LIMIT ' . $limit;
+		}
+
+		if ($offset > 0)
+		{
+			$query .= ' OFFSET ' . $offset;
+		}
+
+		return $query;
+	}
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
 	<!-- <php>
 		<const name="JTEST_DATABASE_MYSQL_DSN" value="host=localhost;dbname=joomla_ut;user=utuser;pass=ut1234" />
 		<const name="JTEST_DATABASE_MYSQLI_DSN" value="host=localhost;dbname=joomla_ut;user=utuser;pass=ut1234" />
+		<const name="JTEST_DATABASE_POSTGRESQL_DSN" value="host=localhost;port=5432;dbname=joomla_ut;user=utuser;pass=ut1234" />
 	</php> -->
 
 	<testsuite name="AllTests">

--- a/tests/core/mock/database/driver.php
+++ b/tests/core/mock/database/driver.php
@@ -31,7 +31,7 @@ class TestMockDatabaseDriver
 	 *
 	 * @since   11.3
 	 */
-	public static function create($test)
+	public static function create($test, $nullDate = '0000-00-00 00:00:00', $dateFormat = 'Y-m-d H:i:s')
 	{
 		// Collect all the relevant methods in JDatabase.
 		$methods = array(
@@ -106,18 +106,18 @@ class TestMockDatabaseDriver
 		// Mock selected methods.
 		$test->assignMockReturns(
 			$mockObject, array(
-				'getNullDate' => '0000-00-00 00:00:00',
-				'getDateFormat' => 'Y-m-d H:i:s'
+				'getNullDate' => $nullDate,
+				'getDateFormat' => $dateFormat
 			)
 		);
 
 		$test->assignMockCallbacks(
 			$mockObject,
 			array(
-				'getQuery' => array(get_called_class(), 'mockGetQuery'),
-				'quote' => array(get_called_class(), 'mockQuote'),
-				'quoteName' => array(get_called_class(), 'mockQuoteName'),
-				'setQuery' => array(get_called_class(), 'mockSetQuery'),
+				'getQuery' => array((is_callable(array($test, 'mockGetQuery')) ? $test : get_called_class()), 'mockGetQuery'),
+				'quote' => array((is_callable(array($test, 'mockQuote')) ? $test : get_called_class()), 'mockQuote'),
+				'quoteName' => array((is_callable(array($test, 'mockQuoteName')) ? $test : get_called_class()), 'mockQuoteName'),
+				'setQuery' => array((is_callable(array($test, 'mockSetQuery')) ? $test : get_called_class()), 'mockSetQuery'),
 			)
 		);
 

--- a/tests/suites/database/driver/postgresql/JDatabasePostgresqlTest.php
+++ b/tests/suites/database/driver/postgresql/JDatabasePostgresqlTest.php
@@ -1,0 +1,1299 @@
+<?php
+/**
+ * @package    Joomla.Test
+ *
+ * @copyright  Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Test class for JDatabasePostgresql.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Database
+ *
+ * @since       11.3
+ */
+class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
+{
+	/**
+	 * Data for the testEscape test.
+	 *
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	public function dataTestEscape()
+	{
+		return array(
+			/* ' will be escaped and become '' */
+			array("'%_abc123", false, '\'\'%_abc123'),
+			array("'%_abc123", true, '\'\'\%\_abc123'),
+			/* ' and \ will be escaped: the first become '', the latter \\ */
+			array("\'%_abc123", false, '\\\\\'\'%_abc123'),
+			array("\'%_abc123", true, '\\\\\'\'\%\_abc123'));
+	}
+
+	/**
+	 * Data for the testGetEscaped test, proxies of escape, so same data test.
+	 *
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	public function dataTestGetEscaped()
+	{
+		return array(
+			/* ' will be escaped and become '' */
+			array("'%_abc123", false), array("'%_abc123", true),
+			/* ' and \ will be escaped: the first become '', the latter \\ */
+			array("\'%_abc123", false), array("\'%_abc123", true));
+	}
+
+	/**
+	 * Data for the testTransactionRollback test.
+	 *
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	public function dataTestTransactionRollback()
+	{
+		return array(array(null, 0), array('transactionSavepoint', 1));
+	}
+
+	/**
+	 * Data for the getCreateDbQuery test.
+	 *
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	public function dataGetCreateDbQuery()
+	{
+		$obj = new stdClass();
+		$obj->db_user = 'testName';
+		$obj->db_name = 'testDb';
+
+		return array(array($obj, false), array($obj, true));
+	}
+
+	/**
+	 * Data for the TestReplacePrefix test.
+	 *
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	public function dataTestReplacePrefix()
+	{
+		return array(
+			/* no prefix inside, no change */
+			array('SELECT * FROM table', '#__', 'SELECT * FROM table'),
+			/* the prefix inside double quote has to be changed */
+			array('SELECT * FROM "#__table"', '#__', 'SELECT * FROM "jos_table"'),
+			/* the prefix inside single quote hasn't to be changed */
+			array('SELECT * FROM \'#__table\'', '#__', 'SELECT * FROM \'#__table\''),
+			/* mixed quote case */
+			array('SELECT * FROM \'#__table\', "#__tableSecond"', '#__', 'SELECT * FROM \'#__table\', "jos_tableSecond"'),
+			/* the prefix used in sequence name (single quote) has to be changed */
+			array('SELECT * FROM currval(\'#__table_id_seq\'::regclass)', '#__', 'SELECT * FROM currval(\'jos_table_id_seq\'::regclass)'),
+			/* using another prefix */
+			array('SELECT * FROM "#!-_table"', '#!-_', 'SELECT * FROM "jos_table"'));
+	}
+
+	/**
+	 * Data for testQuoteName test.
+	 *
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	public function dataTestQuoteName()
+	{
+		return array(
+			/* no dot inside var */
+			array('jos_dbtest', null, '"jos_dbtest"'),
+			/* a dot inside var */
+			array('public.jos_dbtest', null, '"public"."jos_dbtest"'),
+			/* two dot inside var */
+			array('joomla_ut.public.jos_dbtest', null, '"joomla_ut"."public"."jos_dbtest"'),
+			/* using an array */
+			array(array('joomla_ut', 'dbtest'), null, array('"joomla_ut"', '"dbtest"')),
+			/* using an array with dotted name */
+			array(array('joomla_ut.dbtest', 'public.dbtest'), null, array('"joomla_ut"."dbtest"', '"public"."dbtest"')),
+			/* using an array with two dot in name */
+			array(array('joomla_ut.public.dbtest', 'public.dbtest.col'), null, array('"joomla_ut"."public"."dbtest"', '"public"."dbtest"."col"')),
+
+			/*** same tests with AS part ***/
+			array('jos_dbtest', 'test', '"jos_dbtest" AS "test"'),
+			array('public.jos_dbtest', 'tst', '"public"."jos_dbtest" AS "tst"'),
+			array('joomla_ut.public.jos_dbtest', 'tst', '"joomla_ut"."public"."jos_dbtest" AS "tst"'),
+			array(array('joomla_ut', 'dbtest'), array('j_ut', 'tst'), array('"joomla_ut" AS "j_ut"', '"dbtest" AS "tst"')),
+			array(
+				array('joomla_ut.dbtest', 'public.dbtest'),
+				array('j_ut_db', 'pub_tst'),
+				array('"joomla_ut"."dbtest" AS "j_ut_db"', '"public"."dbtest" AS "pub_tst"')),
+			array(
+				array('joomla_ut.public.dbtest', 'public.dbtest.col'),
+				array('j_ut_p_db', 'pub_tst_col'),
+				array('"joomla_ut"."public"."dbtest" AS "j_ut_p_db"', '"public"."dbtest"."col" AS "pub_tst_col"')),
+			/* last test but with one null inside array */
+			array(
+				array('joomla_ut.public.dbtest', 'public.dbtest.col'),
+				array('j_ut_p_db', null),
+				array('"joomla_ut"."public"."dbtest" AS "j_ut_p_db"', '"public"."dbtest"."col"')));
+	}
+
+	/**
+	 * Data for testLoadNextObject test.
+	 *
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	public function dataTestLoadNextObject()
+	{
+		$objCompOne = new stdClass();
+		$objCompOne->id = 1;
+		$objCompOne->title = 'Testing';
+		$objCompOne->start_date = '1980-04-18 00:00:00';
+		$objCompOne->description = 'one';
+
+		$objCompTwo = new stdClass();
+		$objCompTwo->id = 2;
+		$objCompTwo->title = 'Testing2';
+		$objCompTwo->start_date = '1980-04-18 00:00:00';
+		$objCompTwo->description = 'one';
+
+		$objCompThree = new stdClass();
+		$objCompThree->id = 3;
+		$objCompThree->title = 'Testing3';
+		$objCompThree->start_date = '1980-04-18 00:00:00';
+		$objCompThree->description = 'three';
+
+		$objCompFour = new stdClass();
+		$objCompFour->id = 4;
+		$objCompFour->title = 'Testing4';
+		$objCompFour->start_date = '1980-04-18 00:00:00';
+		$objCompFour->description = 'four';
+
+		return array(array(array($objCompOne, $objCompTwo, $objCompThree, $objCompFour)));
+	}
+
+	/**
+	 * Data for testLoadNextRow test.
+	 *
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	public function dataTestLoadNextRow()
+	{
+		return array(
+			array(
+				array(
+					array(1, 'Testing', '1980-04-18 00:00:00', 'one'),
+					array(2, 'Testing2', '1980-04-18 00:00:00', 'one'),
+					array(3, 'Testing3', '1980-04-18 00:00:00', 'three'),
+					array(4, 'Testing4', '1980-04-18 00:00:00', 'four'))));
+	}
+
+	/**
+	 * Gets the data set to be loaded into the database during setup
+	 *
+	 * @return  xml dataset
+	 *
+	 * @since   11.1
+	 */
+	protected function getDataSet()
+	{
+		return $this->createXMLDataSet(__DIR__ . '/stubs/database.xml');
+	}
+
+	/**
+	 * Test destruct
+	 *
+	 * @todo Implement test__destruct().
+	 *
+	 * @return   void
+	 */
+	public function test__destruct()
+	{
+		// Remove the following lines when you implement this test.
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	/**
+	 * Check if connected() method returns true.
+	 *
+	 * @return   void
+	 */
+	public function testConnected()
+	{
+		$this->assertThat(self::$driver->connected(), $this->equalTo(true), 'Not connected to database');
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql escape method.
+	 *
+	 * @param   string  $text    The string to be escaped.
+	 * @param   bool    $extra   Optional parameter to provide extra escaping.
+	 * @param   string  $result  Correct string escaped
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 * @dataProvider  dataTestEscape
+	 */
+	public function testEscape($text, $extra, $result)
+	{
+		$this->assertThat(self::$driver->escape($text, $extra), $this->equalTo($result), 'The string was not escaped properly');
+	}
+
+	/**
+	 * Test getAffectedRows method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testGetAffectedRows()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->delete();
+		$query->from('jos_dbtest');
+		self::$driver->setQuery($query);
+
+		$result = self::$driver->execute();
+
+		$this->assertThat(self::$driver->getAffectedRows(), $this->equalTo(4), __LINE__);
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql getCollation method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testGetCollation()
+	{
+		$this->assertContains('UTF-8', self::$driver->getCollation(), __LINE__);
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql getNumRows method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testGetNumRows()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('*');
+		$query->from('jos_dbtest');
+		$query->where('description=' . self::$driver->quote('one'));
+		self::$driver->setQuery($query);
+
+		$res = self::$driver->execute();
+
+		$this->assertThat(self::$driver->getNumRows($res), $this->equalTo(2), __LINE__);
+	}
+
+	/**
+	 * Test getTableCreate function
+	 *
+	 * @todo Implement testGetTableCreate().
+	 *
+	 * @return   void
+	 */
+	public function testGetTableCreate()
+	{
+		// Remove the following lines when you implement this test.
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	/**
+	 * Test getTableColumns function.
+	 *
+	 * @return   void
+	 */
+	public function testGetTableColumns()
+	{
+		$tableCol = array('id' => 'integer', 'title' => 'character varying', 'start_date' => 'timestamp without time zone', 'description' => 'text');
+
+		$this->assertThat(self::$driver->getTableColumns('jos_dbtest'), $this->equalTo($tableCol), __LINE__);
+
+		/* not only type field */
+		$id = new stdClass();
+		$id->column_name = 'id';
+		$id->type = 'integer';
+		$id->null = 'NO';
+		$id->default = 'nextval(\'jos_dbtest_id_seq\'::regclass)';
+		$id->comments = '';
+
+		$title = new stdClass();
+		$title->column_name = 'title';
+		$title->type = 'character varying(50)';
+		$title->null = 'NO';
+		$title->default = null;
+		$title->comments = '';
+
+		$start_date = new stdClass();
+		$start_date->column_name = 'start_date';
+		$start_date->type = 'timestamp without time zone';
+		$start_date->null = 'NO';
+		$start_date->default = null;
+		$start_date->comments = '';
+
+		$description = new stdClass();
+		$description->column_name = 'description';
+		$description->type = 'text';
+		$description->null = 'NO';
+		$description->default = null;
+		$description->comments = '';
+
+		$this->assertThat(self::$driver->getTableColumns('jos_dbtest', false),
+			$this->equalTo(array('id' => $id, 'title' => $title, 'start_date' => $start_date, 'description' => $description)), __LINE__);
+	}
+
+	/**
+	 * Test getTableKeys function.
+	 *
+	 * @return   void
+	 */
+	public function testGetTableKeys()
+	{
+		$pkey = new stdClass();
+		$pkey->idxName = 'jos_assets_pkey';
+		$pkey->isPrimary = 't';
+		$pkey->isUnique = 't';
+		$pkey->Query = 'ALTER TABLE jos_assets ADD PRIMARY KEY (id)';
+
+		$asset = new stdClass();
+		$asset->idxName = 'idx_asset_name';
+		$asset->isPrimary = 'f';
+		$asset->isUnique = 't';
+		$asset->Query = 'CREATE UNIQUE INDEX idx_asset_name ON jos_assets USING btree (name)';
+
+		$lftrgt = new stdClass();
+		$lftrgt->idxName = 'jos_assets_idx_lft_rgt';
+		$lftrgt->isPrimary = 'f';
+		$lftrgt->isUnique = 'f';
+		$lftrgt->Query = 'CREATE INDEX jos_assets_idx_lft_rgt ON jos_assets USING btree (lft, rgt)';
+
+		$id = new stdClass();
+		$id->idxName = 'jos_assets_idx_parent_id';
+		$id->isPrimary = 'f';
+		$id->isUnique = 'f';
+		$id->Query = 'CREATE INDEX jos_assets_idx_parent_id ON jos_assets USING btree (parent_id)';
+
+		$this->assertThat(self::$driver->getTableKeys('jos_assets'), $this->equalTo(array($pkey, $id, $lftrgt, $asset)), __LINE__);
+	}
+
+	/**
+	 * Test getTableSequences function.
+	 *
+	 * @return   void
+	 */
+	public function testGetTableSequences()
+	{
+		$seq = new stdClass();
+		$seq->sequence = 'jos_dbtest_id_seq';
+		$seq->schema = 'public';
+		$seq->table = 'jos_dbtest';
+		$seq->column = 'id';
+		$seq->data_type = 'bigint';
+
+		if (version_compare(self::$driver->getVersion(), '9.1.0') >= 0)
+		{
+			$seq->start_value = '1';
+			$seq->minimum_value = '1';
+			$seq->maximum_value = '9223372036854775807';
+			$seq->increment = '1';
+			$seq->cycle_option = 'NO';
+		}
+		else
+		{
+			$seq->minimum_value = null;
+			$seq->maximum_value = null;
+			$seq->increment = null;
+			$seq->cycle_option = null;
+		}
+
+		$this->assertThat(self::$driver->getTableSequences('jos_dbtest'), $this->equalTo(array($seq)), __LINE__);
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql getTableList method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testGetTableList()
+	{
+		$expected = array(
+			"0" => "jos_assets",
+			"1" => "jos_categories",
+			"2" => "jos_content",
+			"3" => "jos_core_log_searches",
+			"4" => "jos_dbtest",
+			"5" => "jos_extensions",
+			"6" => "jos_languages",
+			"7" => "jos_log_entries",
+			"8" => "jos_menu",
+			"9" => "jos_menu_types",
+			"10" => "jos_modules",
+			"11" => "jos_modules_menu",
+			"12" => "jos_schemas",
+			"13" => "jos_session",
+			"14" => "jos_update_categories",
+			"15" => "jos_update_sites",
+			"16" => "jos_update_sites_extensions",
+			"17" => "jos_updates",
+			"18" => "jos_user_profiles",
+			"19" => "jos_user_usergroup_map",
+			"20" => "jos_usergroups",
+			"21" => "jos_users",
+			"22" => "jos_viewlevels");
+
+		$result = self::$driver->getTableList();
+
+		// Assert array size
+		$this->assertThat(count($result), $this->equalTo(count($expected)), __LINE__);
+
+		// Clear found element to check if all elements are present in any order
+		foreach ($result as $k => $v)
+		{
+			if (in_array($v, $expected))
+			{
+				// Ok case, value found so set value to zero
+				$result[$k] = '0';
+			}
+			else
+			{
+				// Error case, value NOT found so set value to one
+				$result[$k] = '1';
+			}
+		}
+
+		// If there's a one it will return true and test fails
+		$this->assertThat(in_array('1', $result), $this->equalTo(false), __LINE__);
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql getVersion method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testGetVersion()
+	{
+		$versionRow = self::$driver->setQuery('SELECT version();')->loadRow();
+		$versionArray = explode(' ', $versionRow[0]);
+
+		$this->assertGreaterThanOrEqual($versionArray[1], self::$driver->getVersion(), __LINE__);
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql insertId method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testInsertid()
+	{
+		self::$driver->setQuery('TRUNCATE TABLE "jos_dbtest"');
+		$result = self::$driver->execute();
+
+		/* increment the sequence automatically with INSERT INTO,
+		 * first insert to have a common starting point */
+		$query = self::$driver->getQuery(true);
+		$query->insert('jos_dbtest')
+			->columns('title,start_date,description')
+			->values("'testTitle','1970-01-01','testDescription'");
+		self::$driver->setQuery($query);
+		self::$driver->execute();
+
+		/* get the current sequence value */
+		$actualVal = self::$driver->getQuery(true);
+		$actualVal->select("currval('jos_dbtest_id_seq'::regclass)");
+		self::$driver->setQuery($actualVal);
+		$idActualVal = self::$driver->loadRow();
+
+		/* insert again, then call insertid() */
+		$secondInsertQuery = self::$driver->getQuery(true);
+		$secondInsertQuery->insert('jos_dbtest')
+			->columns('title,start_date,description')
+			->values("'testTitle2nd', '1971-01-01', 'testDescription2nd'");
+		self::$driver->setQuery($secondInsertQuery);
+		self::$driver->execute();
+
+		/* get insertid of last INSERT INTO */
+		$insertId = self::$driver->insertid();
+
+		/* check if first sequence val +1 is equal to last sequence val */
+		$this->assertThat($insertId, $this->equalTo($idActualVal[0] + 1), __LINE__);
+	}
+
+	/**
+	 * Test insertObject function
+	 *
+	 * @todo Implement testInsertObject().
+	 *
+	 * @return   void
+	 */
+	public function testInsertObject()
+	{
+		// Remove the following lines when you implement this test.
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	/**
+	 * Test isSupported function.
+	 *
+	 * @return   void
+	 */
+	public function testIsSupported()
+	{
+		$this->assertThat(JDatabaseDriverPostgresql::isSupported(), $this->isTrue(), __LINE__);
+	}
+
+	/**
+	 * Test loadAssoc method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testLoadAssoc()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('title');
+		$query->from('jos_dbtest');
+		self::$driver->setQuery($query);
+		$result = self::$driver->loadAssoc();
+
+		$this->assertThat($result, $this->equalTo(array('title' => 'Testing')), __LINE__);
+	}
+
+	/**
+	 * Test loadAssocList method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testLoadAssocList()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('title');
+		$query->from('jos_dbtest');
+		self::$driver->setQuery($query);
+		$result = self::$driver->loadAssocList();
+
+		$this->assertThat($result,
+			$this->equalTo(
+				array(array('title' => 'Testing'), array('title' => 'Testing2'), array('title' => 'Testing3'), array('title' => 'Testing4'))), __LINE__);
+	}
+
+	/**
+	 * Test loadColumn method
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testLoadColumn()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('title');
+		$query->from('jos_dbtest');
+		self::$driver->setQuery($query);
+		$result = self::$driver->loadColumn();
+
+		$this->assertThat($result, $this->equalTo(array('Testing', 'Testing2', 'Testing3', 'Testing4')), __LINE__);
+	}
+
+	/**
+	 * Test loadNextObject function
+	 *
+	 * @param   array  $objArr  Array of expected objects
+	 *
+	 * @return   void
+	 *
+	 * @dataProvider dataTestLoadNextObject
+	 */
+	public function testLoadNextObject($objArr)
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('*');
+		$query->from('jos_dbtest');
+		self::$driver->setQuery($query);
+
+		$this->assertThat(self::$driver->loadNextObject(), $this->equalTo($objArr[0]), __LINE__);
+
+		$this->assertThat(self::$driver->loadNextObject(), $this->equalTo($objArr[1]), __LINE__);
+
+		$this->assertThat(self::$driver->loadNextObject(), $this->equalTo($objArr[2]), __LINE__);
+
+		$this->assertThat(self::$driver->loadNextObject(), $this->equalTo($objArr[3]), __LINE__);
+
+		/* last call to free cursor, asserting that returns false */
+		$this->assertFalse(self::$driver->loadNextObject());
+	}
+
+	/**
+	 * Test loadNextObject function with preceding loadObject call
+	 *
+	 * @param   array  $objArr  Array of expected objects
+	 *
+	 * @return   void
+	 *
+	 * @dataProvider dataTestLoadNextObject
+	 */
+	public function testLoadNextObject_plusLoad($objArr)
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('*');
+		$query->from('jos_dbtest');
+		self::$driver->setQuery($query);
+
+		self::$driver->loadObject();
+
+		$this->assertThat(self::$driver->loadNextObject(), $this->equalTo($objArr[0]), __LINE__);
+
+		$this->assertThat(self::$driver->loadNextObject(), $this->equalTo($objArr[1]), __LINE__);
+
+		$this->assertThat(self::$driver->loadNextObject(), $this->equalTo($objArr[2]), __LINE__);
+
+		$this->assertThat(self::$driver->loadNextObject(), $this->equalTo($objArr[3]), __LINE__);
+
+		/* last call to free cursor, asserting that returns false */
+		$this->assertFalse(self::$driver->loadNextObject());
+	}
+
+	/**
+	 * Test loadNextObject function with preceding query call
+	 *
+	 * @param   array  $objArr  Array of expected objects
+	 *
+	 * @return   void
+	 *
+	 * @dataProvider dataTestLoadNextObject
+	 */
+	public function testLoadNextObject_plusQuery($objArr)
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('*');
+		$query->from('jos_dbtest');
+		self::$driver->setQuery($query);
+
+		self::$driver->execute();
+
+		$this->assertThat(self::$driver->loadNextObject(), $this->equalTo($objArr[0]), __LINE__);
+
+		$this->assertThat(self::$driver->loadNextObject(), $this->equalTo($objArr[1]), __LINE__);
+
+		$this->assertThat(self::$driver->loadNextObject(), $this->equalTo($objArr[2]), __LINE__);
+
+		$this->assertThat(self::$driver->loadNextObject(), $this->equalTo($objArr[3]), __LINE__);
+
+		/* last call to free cursor, asserting that returns false */
+		$this->assertFalse(self::$driver->loadNextObject());
+	}
+
+	/**
+	 * Test loadNextRow function
+	 *
+	 * @param   array  $rowArr  Array of expected arrays
+	 *
+	 * @return   void
+	 *
+	 * @dataProvider dataTestLoadNextRow
+	 */
+	public function testLoadNextRow($rowArr)
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('*');
+		$query->from('jos_dbtest');
+		self::$driver->setQuery($query);
+
+		$this->assertThat(self::$driver->loadNextRow(), $this->equalTo($rowArr[0]), __LINE__);
+
+		$this->assertThat(self::$driver->loadNextRow(), $this->equalTo($rowArr[1]), __LINE__);
+
+		$this->assertThat(self::$driver->loadNextRow(), $this->equalTo($rowArr[2]), __LINE__);
+
+		$this->assertThat(self::$driver->loadNextRow(), $this->equalTo($rowArr[3]), __LINE__);
+
+		/* last call to free cursor, asserting that returns false */
+		$this->assertFalse(self::$driver->loadNextRow());
+	}
+
+	/**
+	 * Test loadNextRow function with preceding query call
+	 *
+	 * @param   array  $rowArr  Array of expected arrays
+	 *
+	 * @return   void
+	 *
+	 * @dataProvider dataTestLoadNextRow
+	 */
+	public function testLoadNextRow_plusQuery($rowArr)
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('*');
+		$query->from('jos_dbtest');
+		self::$driver->setQuery($query);
+
+		self::$driver->execute();
+
+		$this->assertThat(self::$driver->loadNextRow(), $this->equalTo($rowArr[0]), __LINE__);
+
+		$this->assertThat(self::$driver->loadNextRow(), $this->equalTo($rowArr[1]), __LINE__);
+
+		$this->assertThat(self::$driver->loadNextRow(), $this->equalTo($rowArr[2]), __LINE__);
+
+		$this->assertThat(self::$driver->loadNextRow(), $this->equalTo($rowArr[3]), __LINE__);
+
+		/* last call to free cursor, asserting that returns false */
+		$this->assertFalse(self::$driver->loadNextRow());
+	}
+
+	/**
+	 * Test loadNextRow function with preceding loadRow call
+	 *
+	 * @param   array  $rowArr  Array of expected arrays
+	 *
+	 * @return   void
+	 *
+	 * @dataProvider dataTestLoadNextRow
+	 */
+	public function testLoadNextRow_plusLoad($rowArr)
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('*');
+		$query->from('jos_dbtest');
+		self::$driver->setQuery($query);
+
+		self::$driver->loadRow();
+
+		$this->assertThat(self::$driver->loadNextRow(), $this->equalTo($rowArr[0]), __LINE__);
+
+		$this->assertThat(self::$driver->loadNextRow(), $this->equalTo($rowArr[1]), __LINE__);
+
+		$this->assertThat(self::$driver->loadNextRow(), $this->equalTo($rowArr[2]), __LINE__);
+
+		$this->assertThat(self::$driver->loadNextRow(), $this->equalTo($rowArr[3]), __LINE__);
+
+		/* last call to free cursor, asserting that returns false */
+		$this->assertFalse(self::$driver->loadNextRow());
+	}
+
+	/**
+	 * Test loadObject method
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testLoadObject()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('*');
+		$query->from('jos_dbtest');
+		$query->where('description=' . self::$driver->quote('three'));
+		self::$driver->setQuery($query);
+		$result = self::$driver->loadObject();
+
+		$objCompare = new stdClass();
+		$objCompare->id = 3;
+		$objCompare->title = 'Testing3';
+		$objCompare->start_date = '1980-04-18 00:00:00';
+		$objCompare->description = 'three';
+
+		$this->assertThat($result, $this->equalTo($objCompare), __LINE__);
+	}
+
+	/**
+	 * Test loadObjectList method
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testLoadObjectList()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('*');
+		$query->from('jos_dbtest');
+		$query->order('id');
+		self::$driver->setQuery($query);
+		$result = self::$driver->loadObjectList();
+
+		$expected = array();
+
+		$objCompare = new stdClass();
+		$objCompare->id = 1;
+		$objCompare->title = 'Testing';
+		$objCompare->start_date = '1980-04-18 00:00:00';
+		$objCompare->description = 'one';
+
+		$expected[] = clone $objCompare;
+
+		$objCompare = new stdClass();
+		$objCompare->id = 2;
+		$objCompare->title = 'Testing2';
+		$objCompare->start_date = '1980-04-18 00:00:00';
+		$objCompare->description = 'one';
+
+		$expected[] = clone $objCompare;
+
+		$objCompare = new stdClass();
+		$objCompare->id = 3;
+		$objCompare->title = 'Testing3';
+		$objCompare->start_date = '1980-04-18 00:00:00';
+		$objCompare->description = 'three';
+
+		$expected[] = clone $objCompare;
+
+		$objCompare = new stdClass();
+		$objCompare->id = 4;
+		$objCompare->title = 'Testing4';
+		$objCompare->start_date = '1980-04-18 00:00:00';
+		$objCompare->description = 'four';
+
+		$expected[] = clone $objCompare;
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Test loadResult method
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testLoadResult()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('id');
+		$query->from('jos_dbtest');
+		$query->where('title=' . self::$driver->quote('Testing2'));
+
+		self::$driver->setQuery($query);
+		$result = self::$driver->loadResult();
+
+		$this->assertThat($result, $this->equalTo(2), __LINE__);
+	}
+
+	/**
+	 * Test loadRow method
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testLoadRow()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('*');
+		$query->from('jos_dbtest');
+		$query->where('description=' . self::$driver->quote('three'));
+		self::$driver->setQuery($query);
+		$result = self::$driver->loadRow();
+
+		$expected = array(3, 'Testing3', '1980-04-18 00:00:00', 'three');
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Test loadRowList method
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testLoadRowList()
+	{
+		$query = self::$driver->getQuery(true);
+		$query->select('*');
+		$query->from('jos_dbtest');
+		$query->where('description=' . self::$driver->quote('one'));
+		self::$driver->setQuery($query);
+		$result = self::$driver->loadRowList();
+
+		$expected = array(array(1, 'Testing', '1980-04-18 00:00:00', 'one'), array(2, 'Testing2', '1980-04-18 00:00:00', 'one'));
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Test the JDatabasePostgresql::query() method
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testQuery()
+	{
+		/* REPLACE is not present in PostgreSQL */
+		$query = self::$driver->getQuery(true);
+		$query->delete();
+		$query->from('jos_dbtest')->where('id=5');
+		self::$driver->setQuery($query);
+		$result = self::$driver->execute();
+
+		$query = self::$driver->getQuery(true);
+		$query->insert('jos_dbtest')
+			->columns('id,title,start_date, description')
+			->values("5, 'testTitle','1970-01-01','testDescription'")
+			->returning('id');
+
+		self::$driver->setQuery($query);
+		$arr = self::$driver->loadResult();
+
+		$this->assertThat($arr, $this->equalTo(5), __LINE__);
+	}
+
+	/**
+	 * Test quoteName function, with and without dot notation.
+	 *
+	 * @param   string  $quoteMe   String to be quoted
+	 * @param   string  $asPart    String used for AS query part
+	 * @param   string  $expected  Expected string
+	 *
+	 * @return void
+	 *
+	 * @since 11.3
+	 * @dataProvider dataTestQuoteName
+	 */
+	public function testQuoteName($quoteMe, $asPart, $expected)
+	{
+		$this->assertThat(self::$driver->quoteName($quoteMe, $asPart), $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql select method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testSelect()
+	{
+		/* it's not possible to select a database, already done during connection, return true */
+		$this->assertThat(self::$driver->select('database'), $this->isTrue(), __LINE__);
+	}
+
+	/**
+	 * Test setUTF function
+	 *
+	 * @return   void
+	 */
+	public function testSetUTF()
+	{
+		$this->assertThat(self::$driver->setUTF(), $this->equalTo(0), __LINE__);
+	}
+
+	/**
+	 * Test Test method - there really isn't a lot to test here, but
+	 * this is present for the sake of completeness
+	 *
+	 * @return   void
+	 */
+	public function testTest()
+	{
+		$this->assertThat(JDatabaseDriverPostgresql::test(), $this->isTrue(), __LINE__);
+	}
+
+	/**
+	 * Test updateObject function.
+	 *
+	 * @todo Implement testUpdateObject().
+	 *
+	 * @return  void
+	 */
+	public function testUpdateObject()
+	{
+		// Remove the following lines when you implement this test.
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql transactionCommit method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testTransactionCommit()
+	{
+		self::$driver->transactionStart();
+		$queryIns = self::$driver->getQuery(true);
+		$queryIns->insert('jos_dbtest')
+			->columns('id,title,start_date,description')
+			->values("6, 'testTitle','1970-01-01','testDescription'");
+
+		self::$driver->setQuery($queryIns);
+		$arr = self::$driver->execute();
+
+		self::$driver->transactionCommit();
+
+		/* check if value is present */
+		$queryCheck = self::$driver->getQuery(true);
+		$queryCheck->select('*')
+			->from('jos_dbtest')
+			->where('id=6');
+		self::$driver->setQuery($queryCheck);
+		$result = self::$driver->loadRow();
+
+		$expected = array(6, 'testTitle', '1970-01-01 00:00:00', 'testDescription');
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql transactionRollback method,
+	 * with and without savepoint.
+	 *
+	 * @param   string  $toSavepoint  Savepoint name to rollback transaction to
+	 * @param   int     $tupleCount   Number of tuple found after insertion and rollback
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 * @dataProvider dataTestTransactionRollback
+	 */
+	public function testTransactionRollback($toSavepoint, $tupleCount)
+	{
+		self::$driver->transactionStart();
+
+		/* try to insert this tuple, inserted only when savepoint != null */
+		$queryIns = self::$driver->getQuery(true);
+		$queryIns->insert('jos_dbtest')
+			->columns('id,title,start_date,description')
+			->values("7, 'testRollback','1970-01-01','testRollbackSp'");
+		self::$driver->setQuery($queryIns);
+		$arr = self::$driver->execute();
+
+		/* create savepoint only if is passed by data provider */
+		if (!is_null($toSavepoint))
+		{
+			self::$driver->transactionSavepoint($toSavepoint);
+		}
+
+		/* try to insert this tuple, always rolled back */
+		$queryIns = self::$driver->getQuery(true);
+		$queryIns->insert('jos_dbtest')
+			->columns('id,title,start_date,description')
+			->values("8, 'testRollback','1972-01-01','testRollbackSp'");
+		self::$driver->setQuery($queryIns);
+		$arr = self::$driver->execute();
+
+		self::$driver->transactionRollback($toSavepoint);
+
+		/* release savepoint and commit only if a savepoint exists */
+		if (!is_null($toSavepoint))
+		{
+			self::$driver->releaseTransactionSavepoint($toSavepoint);
+			self::$driver->transactionCommit();
+		}
+
+		/* find how many rows have description='testRollbackSp' :
+		 *   - 0 if a savepoint doesn't exist
+		 *   - 1 if a savepoint exists
+		 */
+		$queryCheck = self::$driver->getQuery(true);
+		$queryCheck->select('*')
+			->from('jos_dbtest')
+			->where("description='testRollbackSp'");
+		self::$driver->setQuery($queryCheck);
+		$result = self::$driver->loadRowList();
+
+		$this->assertThat(count($result), $this->equalTo($tupleCount), __LINE__);
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql transactionStart method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testTransactionStart()
+	{
+		self::$driver->transactionRollback();
+		self::$driver->transactionStart();
+		$queryIns = self::$driver->getQuery(true);
+		$queryIns->insert('jos_dbtest')
+			->columns('id,title,start_date,description')
+			->values("6, 'testTitle','1970-01-01','testDescription'");
+
+		self::$driver->setQuery($queryIns);
+		$arr = self::$driver->execute();
+
+		/* check if is present an exclusive lock, it means a transaction is running */
+		$queryCheck = self::$driver->getQuery(true);
+		$queryCheck->select('*')
+			->from('pg_catalog.pg_locks')
+			->where('transactionid NOTNULL');
+		self::$driver->setQuery($queryCheck);
+		$result = self::$driver->loadAssocList();
+
+		$this->assertThat(count($result), $this->equalTo(1), __LINE__);
+	}
+
+	/**
+	 * Test for release of transaction savepoint, correct case is already tested inside
+	 * 		testTransactionRollback, here will be tested a RELEASE SAVEPOINT of an
+	 * 		inexistent savepoint that will throw and exception.
+	 *
+	 * @return  void
+	 *
+	 * @expectedException RuntimeException
+	 */
+	public function testReleaseTransactionSavepoint()
+	{
+		self::$driver->transactionRollback();
+		self::$driver->transactionStart();
+
+		/* release a nonexistent savepoint will throw an exception */
+		try
+		{
+			self::$driver->releaseTransactionSavepoint('pippo');
+		}
+		catch (RuntimeException $e)
+		{
+			self::$driver->transactionRollback();
+			throw $e;
+		}
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql renameTable method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testRenameTable()
+	{
+		$newTableName = 'bak_jos_dbtest';
+
+		self::$driver->renameTable('jos_dbtest', $newTableName);
+
+		/* check name change */
+		$tableList = self::$driver->getTableList();
+		$this->assertThat(in_array($newTableName, $tableList), $this->isTrue(), __LINE__);
+
+		/* check index change */
+		self::$driver->setQuery(
+			'SELECT relname
+							FROM pg_class
+							WHERE oid IN (
+								SELECT indexrelid
+								FROM pg_index, pg_class
+								WHERE pg_class.relname=\'' . $newTableName . '\' AND pg_class.oid=pg_index.indrelid );');
+
+		$oldIndexes = self::$driver->loadColumn();
+		$this->assertThat($oldIndexes[0], $this->equalTo('bak_jos_dbtest_pkey'), __LINE__);
+
+		/* check sequence change */
+		self::$driver->setQuery(
+			'SELECT relname
+							FROM pg_class
+							WHERE relkind = \'S\'
+							AND relnamespace IN (
+								SELECT oid
+								FROM pg_namespace
+								WHERE nspname NOT LIKE \'pg_%\'
+								AND nspname != \'information_schema\'
+							)
+							AND relname LIKE \'%' . $newTableName . '%\' ;');
+
+		$oldSequences = self::$driver->loadColumn();
+		$this->assertThat($oldSequences[0], $this->equalTo('bak_jos_dbtest_id_seq'), __LINE__);
+
+		/* restore initial state */
+		self::$driver->renameTable($newTableName, 'jos_dbtest');
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql replacePrefix method.
+	 *
+	 * @param   text  $stringToReplace  The string in which replace the prefix.
+	 * @param   text  $prefix           The prefix.
+	 * @param   text  $expected         The string expected.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 * @dataProvider  dataTestReplacePrefix
+	 */
+	public function testReplacePrefix($stringToReplace, $prefix, $expected)
+	{
+		$result = self::$driver->replacePrefix($stringToReplace, $prefix);
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Test for creation of transaction savepoint
+	 *
+	 * @todo Implement testTransactionSavepoint().
+	 *
+	 * @return  void
+	 */
+	public function testTransactionSavepoint( /*$savepointName*/ )
+	{
+		$this->markTestSkipped('This command is tested inside testTransactionRollback.');
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql getCreateDbQuery method.
+	 *
+	 * @param   JObject  $options  JObject coming from "initialise" function to pass user
+	 * 									and database name to database driver.
+	 * @param   boolean  $utf      True if the database supports the UTF-8 character set.
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider dataGetCreateDbQuery
+	 */
+	public function testGetCreateDbQuery($options, $utf)
+	{
+		$expected = 'CREATE DATABASE ' . self::$driver->quoteName($options->db_name) . ' OWNER ' . self::$driver->quoteName($options->db_user);
+
+		if ($utf)
+		{
+			$expected .= ' ENCODING ' . self::$driver->quote('UTF-8');
+		}
+
+		$result = self::$driver->getCreateDbQuery($options, $utf);
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql getAlterDbCharacterSet method.
+	 *
+	 * @return  void
+	 */
+	public function testGetAlterDbCharacterSet()
+	{
+		$expected = 'ALTER DATABASE ' . self::$driver->quoteName('test') . ' SET CLIENT_ENCODING TO ' . self::$driver->quote('UTF8');
+
+		$result = self::$driver->getAlterDbCharacterSet('test');
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+}

--- a/tests/suites/database/driver/postgresql/JDatabasePostgresqlTest.php
+++ b/tests/suites/database/driver/postgresql/JDatabasePostgresqlTest.php
@@ -71,7 +71,7 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function dataGetCreateDbQuery()
 	{
-		$obj = new stdClass();
+		$obj = new stdClass;
 		$obj->db_user = 'testName';
 		$obj->db_name = 'testDb';
 
@@ -154,25 +154,25 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function dataTestLoadNextObject()
 	{
-		$objCompOne = new stdClass();
+		$objCompOne = new stdClass;
 		$objCompOne->id = 1;
 		$objCompOne->title = 'Testing';
 		$objCompOne->start_date = '1980-04-18 00:00:00';
 		$objCompOne->description = 'one';
 
-		$objCompTwo = new stdClass();
+		$objCompTwo = new stdClass;
 		$objCompTwo->id = 2;
 		$objCompTwo->title = 'Testing2';
 		$objCompTwo->start_date = '1980-04-18 00:00:00';
 		$objCompTwo->description = 'one';
 
-		$objCompThree = new stdClass();
+		$objCompThree = new stdClass;
 		$objCompThree->id = 3;
 		$objCompThree->title = 'Testing3';
 		$objCompThree->start_date = '1980-04-18 00:00:00';
 		$objCompThree->description = 'three';
 
-		$objCompFour = new stdClass();
+		$objCompFour = new stdClass;
 		$objCompFour->id = 4;
 		$objCompFour->title = 'Testing4';
 		$objCompFour->start_date = '1980-04-18 00:00:00';
@@ -327,36 +327,39 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 		$this->assertThat(self::$driver->getTableColumns('jos_dbtest'), $this->equalTo($tableCol), __LINE__);
 
 		/* not only type field */
-		$id = new stdClass();
+		$id = new stdClass;
 		$id->column_name = 'id';
 		$id->type = 'integer';
 		$id->null = 'NO';
 		$id->default = 'nextval(\'jos_dbtest_id_seq\'::regclass)';
 		$id->comments = '';
 
-		$title = new stdClass();
+		$title = new stdClass;
 		$title->column_name = 'title';
 		$title->type = 'character varying(50)';
 		$title->null = 'NO';
 		$title->default = null;
 		$title->comments = '';
 
-		$start_date = new stdClass();
+		$start_date = new stdClass;
 		$start_date->column_name = 'start_date';
 		$start_date->type = 'timestamp without time zone';
 		$start_date->null = 'NO';
 		$start_date->default = null;
 		$start_date->comments = '';
 
-		$description = new stdClass();
+		$description = new stdClass;
 		$description->column_name = 'description';
 		$description->type = 'text';
 		$description->null = 'NO';
 		$description->default = null;
 		$description->comments = '';
 
-		$this->assertThat(self::$driver->getTableColumns('jos_dbtest', false),
-			$this->equalTo(array('id' => $id, 'title' => $title, 'start_date' => $start_date, 'description' => $description)), __LINE__);
+		$this->assertThat(
+			self::$driver->getTableColumns('jos_dbtest', false),
+			$this->equalTo(array('id' => $id, 'title' => $title, 'start_date' => $start_date, 'description' => $description)),
+			__LINE__
+		);
 	}
 
 	/**
@@ -366,25 +369,25 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function testGetTableKeys()
 	{
-		$pkey = new stdClass();
+		$pkey = new stdClass;
 		$pkey->idxName = 'jos_assets_pkey';
 		$pkey->isPrimary = 't';
 		$pkey->isUnique = 't';
 		$pkey->Query = 'ALTER TABLE jos_assets ADD PRIMARY KEY (id)';
 
-		$asset = new stdClass();
+		$asset = new stdClass;
 		$asset->idxName = 'idx_asset_name';
 		$asset->isPrimary = 'f';
 		$asset->isUnique = 't';
 		$asset->Query = 'CREATE UNIQUE INDEX idx_asset_name ON jos_assets USING btree (name)';
 
-		$lftrgt = new stdClass();
+		$lftrgt = new stdClass;
 		$lftrgt->idxName = 'jos_assets_idx_lft_rgt';
 		$lftrgt->isPrimary = 'f';
 		$lftrgt->isUnique = 'f';
 		$lftrgt->Query = 'CREATE INDEX jos_assets_idx_lft_rgt ON jos_assets USING btree (lft, rgt)';
 
-		$id = new stdClass();
+		$id = new stdClass;
 		$id->idxName = 'jos_assets_idx_parent_id';
 		$id->isPrimary = 'f';
 		$id->isUnique = 'f';
@@ -400,7 +403,7 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function testGetTableSequences()
 	{
-		$seq = new stdClass();
+		$seq = new stdClass;
 		$seq->sequence = 'jos_dbtest_id_seq';
 		$seq->schema = 'public';
 		$seq->table = 'jos_dbtest';
@@ -597,9 +600,13 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadAssocList();
 
-		$this->assertThat($result,
+		$this->assertThat(
+			$result,
 			$this->equalTo(
-				array(array('title' => 'Testing'), array('title' => 'Testing2'), array('title' => 'Testing3'), array('title' => 'Testing4'))), __LINE__);
+				array(array('title' => 'Testing'), array('title' => 'Testing2'), array('title' => 'Testing3'), array('title' => 'Testing4'))
+			),
+			__LINE__
+		);
 	}
 
 	/**
@@ -812,7 +819,7 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadObject();
 
-		$objCompare = new stdClass();
+		$objCompare = new stdClass;
 		$objCompare->id = 3;
 		$objCompare->title = 'Testing3';
 		$objCompare->start_date = '1980-04-18 00:00:00';
@@ -839,7 +846,7 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 
 		$expected = array();
 
-		$objCompare = new stdClass();
+		$objCompare = new stdClass;
 		$objCompare->id = 1;
 		$objCompare->title = 'Testing';
 		$objCompare->start_date = '1980-04-18 00:00:00';
@@ -847,7 +854,7 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 
 		$expected[] = clone $objCompare;
 
-		$objCompare = new stdClass();
+		$objCompare = new stdClass;
 		$objCompare->id = 2;
 		$objCompare->title = 'Testing2';
 		$objCompare->start_date = '1980-04-18 00:00:00';
@@ -855,7 +862,7 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 
 		$expected[] = clone $objCompare;
 
-		$objCompare = new stdClass();
+		$objCompare = new stdClass;
 		$objCompare->id = 3;
 		$objCompare->title = 'Testing3';
 		$objCompare->start_date = '1980-04-18 00:00:00';
@@ -863,7 +870,7 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 
 		$expected[] = clone $objCompare;
 
-		$objCompare = new stdClass();
+		$objCompare = new stdClass;
 		$objCompare->id = 4;
 		$objCompare->title = 'Testing4';
 		$objCompare->start_date = '1980-04-18 00:00:00';

--- a/tests/suites/database/driver/postgresql/stubs/database.xml
+++ b/tests/suites/database/driver/postgresql/stubs/database.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dataset>
+  <table name="jos_dbtest">
+    <column>id</column>
+    <column>title</column>
+    <column>start_date</column>
+    <column>description</column>
+    <row>
+      <value>1</value>
+      <value>Testing</value>
+      <value>1980-04-18 00:00:00</value>
+      <value>one</value>
+    </row>
+    <row>
+      <value>2</value>
+      <value>Testing2</value>
+      <value>1980-04-18 00:00:00</value>
+      <value>one</value>
+    </row>
+    <row>
+      <value>3</value>
+      <value>Testing3</value>
+      <value>1980-04-18 00:00:00</value>
+      <value>three</value>
+    </row>
+    <row>
+      <value>4</value>
+      <value>Testing4</value>
+      <value>1980-04-18 00:00:00</value>
+      <value>four</value>
+    </row>
+  </table>
+</dataset>

--- a/tests/suites/database/stubs/postgresql.sql
+++ b/tests/suites/database/stubs/postgresql.sql
@@ -1,0 +1,564 @@
+--
+-- Table: jos_assets
+--
+DROP TABLE IF EXISTS "jos_assets" CASCADE;
+CREATE TABLE "jos_assets" (
+  -- Primary Key
+  "id" serial NOT NULL,
+  -- Nested set parent.
+  "parent_id" bigint DEFAULT 0 NOT NULL,
+  -- Nested set lft.
+  "lft" bigint DEFAULT 0 NOT NULL,
+  -- Nested set rgt.
+  "rgt" bigint DEFAULT 0 NOT NULL,
+  -- The cached level in the nested tree.
+  "level" integer NOT NULL,
+  -- The unique name for the asset.\n
+  "name" character varying(50) NOT NULL,
+  -- The descriptive title for the asset.
+  "title" character varying(100) NOT NULL,
+  -- JSON encoded access control.
+  "rules" character varying(5120) NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "idx_asset_name" UNIQUE ("name")
+);
+CREATE INDEX "jos_assets_idx_lft_rgt" on "jos_assets" ("lft", "rgt");
+CREATE INDEX "jos_assets_idx_parent_id" on "jos_assets" ("parent_id");
+
+COMMENT ON COLUMN "jos_assets"."id" IS 'Primary Key';
+COMMENT ON COLUMN "jos_assets"."parent_id" IS 'Nested set parent.';
+COMMENT ON COLUMN "jos_assets"."lft" IS 'Nested set lft.';
+COMMENT ON COLUMN "jos_assets"."rgt" IS 'Nested set rgt.';
+COMMENT ON COLUMN "jos_assets"."level" IS 'The cached level in the nested tree.';
+COMMENT ON COLUMN "jos_assets"."name" IS 'The unique name for the asset.\n';
+COMMENT ON COLUMN "jos_assets"."title" IS 'The descriptive title for the asset.';
+COMMENT ON COLUMN "jos_assets"."rules" IS 'JSON encoded access control.';
+
+--
+-- Table: jos_categories
+--
+DROP TABLE IF EXISTS "jos_categories" CASCADE;
+CREATE TABLE "jos_categories" (
+  "id" serial NOT NULL,
+  -- FK to the #__assets table.
+  "asset_id" integer DEFAULT 0 NOT NULL,
+  "parent_id" integer DEFAULT 0 NOT NULL,
+  "lft" bigint DEFAULT 0 NOT NULL,
+  "rgt" bigint DEFAULT 0 NOT NULL,
+  "level" integer DEFAULT 0 NOT NULL,
+  "path" character varying(255) DEFAULT '' NOT NULL,
+  "extension" character varying(50) DEFAULT '' NOT NULL,
+  "title" character varying(255) NOT NULL,
+  "alias" character varying(255) DEFAULT '' NOT NULL,
+  "note" character varying(255) DEFAULT '' NOT NULL,
+  "description" character varying(5120) DEFAULT '' NOT NULL,
+  "published" smallint DEFAULT 0 NOT NULL,
+  "checked_out" bigint DEFAULT 0 NOT NULL,
+  "checked_out_time" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
+  "access" smallint DEFAULT 0 NOT NULL,
+  "params" text NOT NULL,
+  -- The meta description for the page.
+  "metadesc" character varying(1024) NOT NULL,
+  -- The meta keywords for the page.
+  "metakey" character varying(1024) NOT NULL,
+  -- JSON encoded metadata properties.
+  "metadata" character varying(2048) NOT NULL,
+  "created_user_id" integer DEFAULT 0 NOT NULL,
+  "created_time" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
+  "modified_user_id" integer DEFAULT 0 NOT NULL,
+  "modified_time" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
+  "hits" integer DEFAULT 0 NOT NULL,
+  "language" character(7) NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "jos_categories_cat_idx" on "jos_categories" ("extension", "published", "access");
+CREATE INDEX "jos_categories_idx_access" on "jos_categories" ("access");
+CREATE INDEX "jos_categories_idx_checkout" on "jos_categories" ("checked_out");
+CREATE INDEX "jos_categories_idx_path" on "jos_categories" ("path");
+CREATE INDEX "jos_categories_idx_left_right" on "jos_categories" ("lft", "rgt");
+CREATE INDEX "jos_categories_idx_alias" on "jos_categories" ("alias");
+CREATE INDEX "jos_categories_idx_language" on "jos_categories" ("language");
+
+COMMENT ON COLUMN "jos_categories"."asset_id" IS 'FK to the #__assets table.';
+COMMENT ON COLUMN "jos_categories"."metadesc" IS 'The meta description for the page.';
+COMMENT ON COLUMN "jos_categories"."metakey" IS 'The meta keywords for the page.';
+COMMENT ON COLUMN "jos_categories"."metadata" IS 'JSON encoded metadata properties.';
+
+--
+-- Table: jos_content
+--
+DROP TABLE IF EXISTS "jos_content" CASCADE;
+CREATE TABLE "jos_content" (
+  "id" serial NOT NULL,
+  -- FK to the #__assets table.
+  "asset_id" integer DEFAULT 0 NOT NULL,
+  "title" character varying(255) DEFAULT '' NOT NULL,
+  "alias" character varying(255) DEFAULT '' NOT NULL,
+  "title_alias" character varying(255) DEFAULT '' NOT NULL,
+  "introtext" text NOT NULL,
+  "fulltext" text NOT NULL,
+  "state" smallint DEFAULT 0 NOT NULL,
+  "sectionid" integer DEFAULT 0 NOT NULL,
+  "mask" integer DEFAULT 0 NOT NULL,
+  "catid" integer DEFAULT 0 NOT NULL,
+  "created" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
+  "created_by" integer DEFAULT 0 NOT NULL,
+  "created_by_alias" character varying(255) DEFAULT '' NOT NULL,
+  "modified" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
+  "modified_by" integer DEFAULT 0 NOT NULL,
+  "checked_out" integer DEFAULT 0 NOT NULL,
+  "checked_out_time" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
+  "publish_up" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
+  "publish_down" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
+  "images" text NOT NULL,
+  "urls" text NOT NULL,
+  "attribs" character varying(5120) NOT NULL,
+  "version" integer DEFAULT 1 NOT NULL,
+  "parentid" integer DEFAULT 0 NOT NULL,
+  "ordering" bigint DEFAULT 0 NOT NULL,
+  "metakey" text NOT NULL,
+  "metadesc" text NOT NULL,
+  "access" integer DEFAULT 0 NOT NULL,
+  "hits" integer DEFAULT 0 NOT NULL,
+  "metadata" text NOT NULL,
+  -- Set if article is featured.
+  "featured" smallint DEFAULT 0 NOT NULL,
+  -- The language code for the article.
+  "language" character(7) NOT NULL,
+  -- A reference to enable linkages to external data sets.
+  "xreference" character varying(50) NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "jos_content_idx_access" on "jos_content" ("access");
+CREATE INDEX "jos_content_idx_checkout" on "jos_content" ("checked_out");
+CREATE INDEX "jos_content_idx_state" on "jos_content" ("state");
+CREATE INDEX "jos_content_idx_catid" on "jos_content" ("catid");
+CREATE INDEX "jos_content_idx_createdby" on "jos_content" ("created_by");
+CREATE INDEX "jos_content_idx_featured_catid" on "jos_content" ("featured", "catid");
+CREATE INDEX "jos_content_idx_language" on "jos_content" ("language");
+CREATE INDEX "jos_content_idx_xreference" on "jos_content" ("xreference");
+
+COMMENT ON COLUMN "jos_content"."asset_id" IS 'FK to the #__assets table.';
+COMMENT ON COLUMN "jos_content"."featured" IS 'Set if article is featured.';
+COMMENT ON COLUMN "jos_content"."language" IS 'The language code for the article.';
+COMMENT ON COLUMN "jos_content"."xreference" IS 'A reference to enable linkages to external data sets.';
+
+--
+-- Table: jos_core_log_searches
+--
+DROP TABLE IF EXISTS "jos_core_log_searches" CASCADE;
+CREATE TABLE "jos_core_log_searches" (
+  "search_term" character varying(128) DEFAULT '' NOT NULL,
+  "hits" integer DEFAULT 0 NOT NULL
+);
+
+--
+-- Table: jos_extensions
+--
+DROP TABLE IF EXISTS "jos_extensions" CASCADE;
+CREATE TABLE "jos_extensions" (
+  "extension_id" serial NOT NULL,
+  "name" character varying(100) NOT NULL,
+  "type" character varying(20) NOT NULL,
+  "element" character varying(100) NOT NULL,
+  "folder" character varying(100) NOT NULL,
+  "client_id" smallint NOT NULL,
+  "enabled" smallint DEFAULT 1 NOT NULL,
+  "access" smallint DEFAULT 1 NOT NULL,
+  "protected" smallint DEFAULT 0 NOT NULL,
+  "manifest_cache" text NOT NULL,
+  "params" text NOT NULL,
+  "custom_data" text NOT NULL,
+  "system_data" text NOT NULL,
+  "checked_out" integer DEFAULT 0 NOT NULL,
+  "checked_out_time" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
+  "ordering" bigint DEFAULT 0,
+  "state" bigint DEFAULT 0,
+  PRIMARY KEY ("extension_id")
+);
+CREATE INDEX "jos_extensions_element_clientid" on "jos_extensions" ("element", "client_id");
+CREATE INDEX "jos_extensions_element_folder_clientid" on "jos_extensions" ("element", "folder", "client_id");
+CREATE INDEX "jos_extensions_extension" on "jos_extensions" ("type", "element", "folder", "client_id");
+
+--
+-- Table: jos_languages
+--
+DROP TABLE IF EXISTS "jos_languages" CASCADE;
+CREATE TABLE "jos_languages" (
+  "lang_id" serial NOT NULL,
+  "lang_code" character(7) NOT NULL,
+  "title" character varying(50) NOT NULL,
+  "title_native" character varying(50) NOT NULL,
+  "sef" character varying(50) NOT NULL,
+  "image" character varying(50) NOT NULL,
+  "description" character varying(512) NOT NULL,
+  "metakey" text NOT NULL,
+  "metadesc" text NOT NULL,
+  "published" bigint DEFAULT 0 NOT NULL,
+  PRIMARY KEY ("lang_id"),
+  CONSTRAINT "idx_sef" UNIQUE ("sef")
+);
+
+--
+-- Table: jos_log_entries
+--
+DROP TABLE IF EXISTS "jos_log_entries" CASCADE;
+CREATE TABLE "jos_log_entries" (
+  "priority" bigint DEFAULT NULL,
+  "message" character varying(512) DEFAULT NULL,
+  "date" timestamp without time zone DEFAULT NULL,
+  "category" character varying(255) DEFAULT NULL
+);
+
+--
+-- Table: jos_menu
+--
+DROP TABLE IF EXISTS "jos_menu" CASCADE;
+CREATE TABLE "jos_menu" (
+  "id" serial NOT NULL,
+  -- The type of menu this item belongs to. FK to #__menu_types.menutype
+  "menutype" character varying(24) NOT NULL,
+  -- The display title of the menu item.
+  "title" character varying(255) NOT NULL,
+  -- The SEF alias of the menu item.
+  "alias" character varying(255) NOT NULL,
+  "note" character varying(255) DEFAULT '' NOT NULL,
+  -- The computed path of the menu item based on the alias field.
+  "path" character varying(1024) NOT NULL,
+  -- The actually link the menu item refers to.
+  "link" character varying(1024) NOT NULL,
+  -- The type of link: Component, URL, Alias, Separator
+  "type" character varying(16) NOT NULL,
+  -- The published state of the menu link.
+  "published" smallint DEFAULT 0 NOT NULL,
+  -- The parent menu item in the menu tree.
+  "parent_id" integer DEFAULT 1 NOT NULL,
+  -- The relative level in the tree.
+  "level" integer DEFAULT 0 NOT NULL,
+  -- FK to #__extensions.id
+  "component_id" integer DEFAULT 0 NOT NULL,
+  -- The relative ordering of the menu item in the tree.
+  "ordering" bigint DEFAULT 0 NOT NULL,
+  -- FK to #__users.id
+  "checked_out" integer DEFAULT 0 NOT NULL,
+  -- The time the menu item was checked out.
+  "checked_out_time" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
+  -- The click behaviour of the link.
+  "browserNav" smallint DEFAULT 0 NOT NULL,
+  -- The access level required to view the menu item.
+  "access" smallint DEFAULT 0 NOT NULL,
+  -- The image of the menu item.
+  "img" character varying(255) NOT NULL,
+  "template_style_id" integer DEFAULT 0 NOT NULL,
+  -- JSON encoded data for the menu item.
+  "params" text NOT NULL,
+  -- Nested set lft.
+  "lft" bigint DEFAULT 0 NOT NULL,
+  -- Nested set rgt.
+  "rgt" bigint DEFAULT 0 NOT NULL,
+  -- Indicates if this menu item is the home or default page.
+  "home" smallint DEFAULT 0 NOT NULL,
+  "language" character(7) DEFAULT '' NOT NULL,
+  "client_id" smallint DEFAULT 0 NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "idx_client_id_parent_id_alias" UNIQUE ("client_id", "parent_id", "alias")
+);
+CREATE INDEX "jos_menu_idx_componentid" on "jos_menu" ("component_id", "menutype", "published", "access");
+CREATE INDEX "jos_menu_idx_menutype" on "jos_menu" ("menutype");
+CREATE INDEX "jos_menu_idx_left_right" on "jos_menu" ("lft", "rgt");
+CREATE INDEX "jos_menu_idx_alias" on "jos_menu" ("alias");
+CREATE INDEX "jos_menu_idx_path" on "jos_menu" ("path");
+-- path(333));
+CREATE INDEX "jos_menu_idx_language" on "jos_menu" ("language");
+
+COMMENT ON COLUMN "jos_menu"."menutype" IS 'The type of menu this item belongs to. FK to #__menu_types.menutype';
+COMMENT ON COLUMN "jos_menu"."title" IS 'The display title of the menu item.';
+COMMENT ON COLUMN "jos_menu"."alias" IS 'The SEF alias of the menu item.';
+COMMENT ON COLUMN "jos_menu"."path" IS 'The computed path of the menu item based on the alias field.';
+COMMENT ON COLUMN "jos_menu"."link" IS 'The actually link the menu item refers to.';
+COMMENT ON COLUMN "jos_menu"."type" IS 'The type of link: Component, URL, Alias, Separator';
+COMMENT ON COLUMN "jos_menu"."published" IS 'The published state of the menu link.';
+COMMENT ON COLUMN "jos_menu"."parent_id" IS 'The parent menu item in the menu tree.';
+COMMENT ON COLUMN "jos_menu"."level" IS 'The relative level in the tree.';
+COMMENT ON COLUMN "jos_menu"."component_id" IS 'FK to #__extensions.id';
+COMMENT ON COLUMN "jos_menu"."ordering" IS 'The relative ordering of the menu item in the tree.';
+COMMENT ON COLUMN "jos_menu"."checked_out" IS 'FK to #__users.id';
+COMMENT ON COLUMN "jos_menu"."checked_out_time" IS 'The time the menu item was checked out.';
+COMMENT ON COLUMN "jos_menu"."browserNav" IS 'The click behaviour of the link.';
+COMMENT ON COLUMN "jos_menu"."access" IS 'The access level required to view the menu item.';
+COMMENT ON COLUMN "jos_menu"."img" IS 'The image of the menu item.';
+COMMENT ON COLUMN "jos_menu"."params" IS 'JSON encoded data for the menu item.';
+COMMENT ON COLUMN "jos_menu"."lft" IS 'Nested set lft.';
+COMMENT ON COLUMN "jos_menu"."rgt" IS 'Nested set rgt.';
+COMMENT ON COLUMN "jos_menu"."home" IS 'Indicates if this menu item is the home or default page.';
+
+--
+-- Table: jos_menu_types
+--
+DROP TABLE IF EXISTS "jos_menu_types" CASCADE;
+CREATE TABLE "jos_menu_types" (
+  "id" serial NOT NULL,
+  "menutype" character varying(24) NOT NULL,
+  "title" character varying(48) NOT NULL,
+  "description" character varying(255) DEFAULT '' NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "idx_menutype" UNIQUE ("menutype")
+);
+
+--
+-- Table: jos_modules
+--
+DROP TABLE IF EXISTS "jos_modules" CASCADE;
+CREATE TABLE "jos_modules" (
+  "id" serial NOT NULL,
+  "title" character varying(100) DEFAULT '' NOT NULL,
+  "note" character varying(255) DEFAULT '' NOT NULL,
+  "content" text NOT NULL,
+  "ordering" bigint DEFAULT 0 NOT NULL,
+  "position" character varying(50) DEFAULT NULL,
+  "checked_out" integer DEFAULT 0 NOT NULL,
+  "checked_out_time" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
+  "publish_up" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
+  "publish_down" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
+  "published" smallint DEFAULT 0 NOT NULL,
+  "module" character varying(50) DEFAULT NULL,
+  "access" smallint DEFAULT 0 NOT NULL,
+  "showtitle" smallint DEFAULT 1 NOT NULL,
+  "params" text NOT NULL,
+  "client_id" smallint DEFAULT 0 NOT NULL,
+  "language" character(7) NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "jos_modules_published" on "jos_modules" ("published", "access");
+CREATE INDEX "jos_modules_newsfeeds" on "jos_modules" ("module", "published");
+CREATE INDEX "jos_modules_idx_language" on "jos_modules" ("language");
+
+--
+-- Table: jos_modules_menu
+--
+DROP TABLE IF EXISTS "jos_modules_menu" CASCADE;
+CREATE TABLE "jos_modules_menu" (
+  "moduleid" bigint DEFAULT 0 NOT NULL,
+  "menuid" bigint DEFAULT 0 NOT NULL,
+  PRIMARY KEY ("moduleid", "menuid")
+);
+
+--
+-- Table: jos_schemas
+--
+DROP TABLE IF EXISTS "jos_schemas" CASCADE;
+CREATE TABLE "jos_schemas" (
+  "extension_id" bigint NOT NULL,
+  "version_id" character varying(20) NOT NULL,
+  PRIMARY KEY ("extension_id", "version_id")
+);
+
+--
+-- Table: jos_session
+--
+DROP TABLE IF EXISTS "jos_session" CASCADE;
+CREATE TABLE "jos_session" (
+  "session_id" character varying(32) DEFAULT '' NOT NULL,
+  "client_id" smallint DEFAULT 0 NOT NULL,
+  "guest" smallint DEFAULT 1,
+  "time" character varying(14) DEFAULT '',
+  "data" character varying(20480) DEFAULT NULL,
+  "userid" bigint DEFAULT 0,
+  "username" character varying(150) DEFAULT '',
+  "usertype" character varying(50) DEFAULT '',
+  PRIMARY KEY ("session_id")
+);
+CREATE INDEX "jos_session_whosonline" on "jos_session" ("guest", "usertype");
+CREATE INDEX "jos_session_userid" on "jos_session" ("userid");
+CREATE INDEX "jos_session_time" on "jos_session" ("time");
+
+--
+-- Table: jos_updates
+--
+
+-- Comments: 
+-- Available Updates
+--
+DROP TABLE IF EXISTS "jos_updates" CASCADE;
+CREATE TABLE "jos_updates" (
+  "update_id" serial NOT NULL,
+  "update_site_id" bigint DEFAULT 0,
+  "extension_id" bigint DEFAULT 0,
+  "categoryid" bigint DEFAULT 0,
+  "name" character varying(100) DEFAULT '',
+  "description" text NOT NULL,
+  "element" character varying(100) DEFAULT '',
+  "type" character varying(20) DEFAULT '',
+  "folder" character varying(20) DEFAULT '',
+  "client_id" smallint DEFAULT 0,
+  "version" character varying(10) DEFAULT '',
+  "data" text NOT NULL,
+  "detailsurl" text NOT NULL,
+  PRIMARY KEY ("update_id")
+);
+COMMENT ON TABLE "jos_updates" IS 'Available Updates';
+
+--
+-- Table: jos_update_categories
+--
+
+-- Comments: 
+-- Update Categories
+--
+DROP TABLE IF EXISTS "jos_update_categories" CASCADE;
+CREATE TABLE "jos_update_categories" (
+  "categoryid" serial NOT NULL,
+  "name" character varying(20) DEFAULT '',
+  "description" text NOT NULL,
+  "parent" bigint DEFAULT 0,
+  "updatesite" bigint DEFAULT 0,
+  PRIMARY KEY ("categoryid")
+);
+COMMENT ON TABLE "jos_update_categories" IS 'Update Categories';
+
+--
+-- Table: jos_update_sites
+--
+
+-- Comments: 
+-- Update Sites
+--
+DROP TABLE IF EXISTS "jos_update_sites" CASCADE;
+CREATE TABLE "jos_update_sites" (
+  "update_site_id" serial NOT NULL,
+  "name" character varying(100) DEFAULT '',
+  "type" character varying(20) DEFAULT '',
+  "location" text NOT NULL,
+  "enabled" bigint DEFAULT 0,
+  PRIMARY KEY ("update_site_id")
+);
+COMMENT ON TABLE "jos_update_sites" IS 'Update Sites';
+
+--
+-- Table: jos_update_sites_extensions
+--
+
+-- Comments: 
+-- Links extensions to update sites
+--
+DROP TABLE IF EXISTS "jos_update_sites_extensions" CASCADE;
+CREATE TABLE "jos_update_sites_extensions" (
+  "update_site_id" bigint DEFAULT 0 NOT NULL,
+  "extension_id" bigint DEFAULT 0 NOT NULL,
+  PRIMARY KEY ("update_site_id", "extension_id")
+);
+COMMENT ON TABLE "jos_update_sites_extensions" IS 'Links extensions to update sites';
+
+--
+-- Table: jos_usergroups
+--
+DROP TABLE IF EXISTS "jos_usergroups" CASCADE;
+CREATE TABLE "jos_usergroups" (
+  -- Primary Key
+  "id" serial NOT NULL,
+  -- Adjacency List Reference Id
+  "parent_id" integer DEFAULT 0 NOT NULL,
+  -- Nested set lft.
+  "lft" bigint DEFAULT 0 NOT NULL,
+  -- Nested set rgt.
+  "rgt" bigint DEFAULT 0 NOT NULL,
+  "title" character varying(100) DEFAULT '' NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "idx_usergroup_parent_title_lookup" UNIQUE ("parent_id", "title")
+);
+CREATE INDEX "jos_usergroups_idx_usergroup_title_lookup" on "jos_usergroups" ("title");
+CREATE INDEX "jos_usergroups_idx_usergroup_adjacency_lookup" on "jos_usergroups" ("parent_id");
+CREATE INDEX "jos_usergroups_idx_usergroup_nested_set_lookup" on "jos_usergroups" ("lft", "rgt");
+
+COMMENT ON COLUMN "jos_usergroups"."id" IS 'Primary Key';
+COMMENT ON COLUMN "jos_usergroups"."parent_id" IS 'Adjacency List Reference Id';
+COMMENT ON COLUMN "jos_usergroups"."lft" IS 'Nested set lft.';
+COMMENT ON COLUMN "jos_usergroups"."rgt" IS 'Nested set rgt.';
+
+--
+-- Table: jos_users
+--
+DROP TABLE IF EXISTS "jos_users" CASCADE;
+CREATE TABLE "jos_users" (
+  "id" serial NOT NULL,
+  "name" character varying(255) DEFAULT '' NOT NULL,
+  "username" character varying(150) DEFAULT '' NOT NULL,
+  "email" character varying(100) DEFAULT '' NOT NULL,
+  "password" character varying(100) DEFAULT '' NOT NULL,
+  "usertype" character varying(25) DEFAULT '' NOT NULL,
+  "block" smallint DEFAULT 0 NOT NULL,
+  "sendEmail" smallint DEFAULT 0,
+  "registerDate" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
+  "lastvisitDate" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
+  "activation" character varying(100) DEFAULT '' NOT NULL,
+  "params" text NOT NULL,
+  PRIMARY KEY ("id")
+);
+CREATE INDEX "jos_users_usertype" on "jos_users" ("usertype");
+CREATE INDEX "jos_users_idx_name" on "jos_users" ("name");
+CREATE INDEX "jos_users_idx_block" on "jos_users" ("block");
+CREATE INDEX "jos_users_username" on "jos_users" ("username");
+CREATE INDEX "jos_users_email" on "jos_users" ("email");
+
+--
+-- Table: jos_user_profiles
+--
+
+-- Comments: 
+-- Simple user profile storage table
+--
+DROP TABLE IF EXISTS "jos_user_profiles" CASCADE;
+CREATE TABLE "jos_user_profiles" (
+  "user_id" bigint NOT NULL,
+  "profile_key" character varying(100) NOT NULL,
+  "profile_value" character varying(255) NOT NULL,
+  "ordering" bigint DEFAULT 0 NOT NULL,
+  CONSTRAINT "idx_user_id_profile_key" UNIQUE ("user_id", "profile_key")
+);
+COMMENT ON TABLE "jos_user_profiles" IS 'Simple user profile storage table';
+
+--
+-- Table: jos_user_usergroup_map
+--
+DROP TABLE IF EXISTS "jos_user_usergroup_map" CASCADE;
+CREATE TABLE "jos_user_usergroup_map" (
+  -- Foreign Key to #__users.id
+  "user_id" integer DEFAULT 0 NOT NULL,
+  -- Foreign Key to #__usergroups.id
+  "group_id" integer DEFAULT 0 NOT NULL,
+  PRIMARY KEY ("user_id", "group_id")
+);
+
+COMMENT ON COLUMN "jos_user_usergroup_map"."user_id" IS 'Foreign Key to #__users.id';
+COMMENT ON COLUMN "jos_user_usergroup_map"."group_id" IS 'Foreign Key to #__usergroups.id';
+
+--
+-- Table: jos_viewlevels
+--
+DROP TABLE IF EXISTS "jos_viewlevels" CASCADE;
+CREATE TABLE "jos_viewlevels" (
+  -- Primary Key
+  "id" serial NOT NULL,
+  "title" character varying(100) DEFAULT '' NOT NULL,
+  "ordering" bigint DEFAULT 0 NOT NULL,
+  -- JSON encoded access control.
+  "rules" character varying(5120) NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "idx_assetgroup_title_lookup" UNIQUE ("title")
+);
+
+COMMENT ON COLUMN "jos_viewlevels"."id" IS 'Primary Key';
+COMMENT ON COLUMN "jos_viewlevels"."rules" IS 'JSON encoded access control.';
+
+--
+-- Table: jos_dbtest
+--
+DROP TABLE IF EXISTS "jos_dbtest" CASCADE;
+CREATE TABLE "jos_dbtest" (
+  "id" serial NOT NULL,
+  "title" character varying(50) NOT NULL,
+  "start_date" timestamp without time zone NOT NULL,
+  "description" text NOT NULL,
+  PRIMARY KEY ("id")
+);
+

--- a/tests/suites/unit/joomla/database/database/JDatabaseExporterPostgresqlInspector.php
+++ b/tests/suites/unit/joomla/database/database/JDatabaseExporterPostgresqlInspector.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * @version    $Id: JDatabaseExporterPostgresqlInspector.php gpongelli $
+ * @package    Joomla.UnitTest
+ *
+ * @copyright  Copyright (C) 2005 - 2012 Open Source Matters. All rights reserved.
+ * @license    GNU General Public License
+ */
+
+require_once JPATH_PLATFORM . '/joomla/database/exporter/postgresql.php';
+
+/**
+ * Class to expose protected properties and methods in JDatabasePostgresqlExporter for testing purposes
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Database
+ *
+ * @since       12.1
+ */
+class JDatabaseExporterPostgresqlInspector extends JDatabaseExporterPostgresql
+{
+	/**
+	 * Gets any property from the class.
+	 *
+	 * @param   string  $property  The name of the class property.
+	 *
+	 * @return  mixed   The value of the class property.
+	 *
+	 * @since   12.1
+	 */
+	public function __get($property)
+	{
+		return $this->$property;
+	}
+
+	/**
+	 * Exposes the protected buildXml method.
+	 *
+	 * @return  string	An XML string
+	 *
+	 * @throws  Exception if an error occurs.
+	 * @since   12.1
+	 */
+	public function buildXml()
+	{
+		return parent::buildXml();
+	}
+
+	/**
+	 * Exposes the protected buildXmlStructure method.
+	 *
+	 * @return  array  An array of XML lines (strings).
+	 *
+	 * @throws  Exception if an error occurs.
+	 * @since   12.1
+	 */
+	public function buildXmlStructure()
+	{
+		return parent::buildXmlStructure();
+	}
+
+	/**
+	 * Exposes the protected check method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function check()
+	{
+		return parent::check();
+	}
+
+	/**
+	 * Exposes the protected getColumns method.
+	 *
+	 * @param   mixed  $table  The name of a table or an array of table names.
+	 *
+	 * @return  array  An array of column definitions.
+	 *
+	 * @since   12.1
+	 */
+	public function getColumns($table)
+	{
+		return parent::getColumns($table);
+	}
+
+	/**
+	 * Exposes the protected getGenericTableName method.
+	 *
+	 * @param   string  $table  The name of a table.
+	 *
+	 * @return  string  The name of the table with the database prefix replaced with #__.
+	 *
+	 * @since   12.1
+	 */
+	public function getGenericTableName($table)
+	{
+		return parent::getGenericTableName($table);
+	}
+
+	/**
+	 * Exposes the protected getKeys method.
+	 *
+	 * @param   mixed  $table  The name of a table or an array of table names.
+	 *
+	 * @return  array  An array of key definitions.
+	 *
+	 * @since   12.1
+	 */
+	public function getKeys($table)
+	{
+		return parent::getKeys($table);
+	}
+
+	/**
+	 * Exposes the protected withStructure method.
+	 *
+	 * @param   boolean  $setting  True to export the structure, false to not.
+	 *
+	 * @return  void
+	 *
+	 * @since	12.1
+	 */
+	public function withStructure($setting = true)
+	{
+		return parent::withStructure($setting);
+	}
+
+}

--- a/tests/suites/unit/joomla/database/database/JDatabaseExporterPostgresqlTest.php
+++ b/tests/suites/unit/joomla/database/database/JDatabaseExporterPostgresqlTest.php
@@ -1,0 +1,671 @@
+<?php
+/**
+ * @version    $Id: JDatabaseExporterPostgresqlTest.php gpongelli $
+ * @package    Joomla.UnitTest
+ *
+ * @copyright  Copyright (C) 2005 - 2012 Open Source Matters. All rights reserved.
+ * @license    GNU General Public License
+ */
+
+require_once __DIR__ . '/JDatabaseExporterPostgresqlInspector.php';
+
+/**
+ * Test the JDatabaseExporterPostgresql class.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Database
+ *
+ * @since       12.1
+ */
+class JDatabaseExporterPostgresqlTest extends PHPUnit_Framework_TestCase
+{
+	/**
+	 * @var    object  The mocked database object for use by test methods.
+	 * @since  12.1
+	 */
+	protected $dbo = null;
+
+	/**
+	 * @var    string  The last query sent to the dbo setQuery method.
+	 * @since  12.1
+	 */
+	protected $lastQuery = '';
+
+	/**
+	 * @var    bool  Boolean value to know if current database version is newer than 9.1.0
+	 * @since  12.1
+	 */
+	private $_ver9dot1 = true;
+
+	/**
+	 * Sets up the testing conditions
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function setup()
+	{
+		// Set up the database object mock.
+
+		$this->dbo = $this->getMock(
+			'JDatabasePostgresql',
+			array(
+				'getErrorNum',
+				'getPrefix',
+				'getTableColumns',
+				'getTableKeys',
+				'getTableSequences',
+				'getVersion',
+				'quoteName',
+				'loadObjectList',
+				'setQuery',
+			),
+			array(),
+			'',
+			false
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getPrefix')
+		->will(
+			$this->returnValue(
+				'jos_'
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getTableColumns')
+		->will(
+			$this->returnValue(
+				array(
+					(object) array(
+						'column_name' => 'id',
+						'type' => 'integer',
+						'null' => 'NO',
+						'default' => 'nextval(\'jos_dbtest_id_seq\'::regclass)',
+						'comments' => '',
+					),
+					(object) array(
+						'column_name' => 'title',
+						'type' => 'character varying(50)',
+						'null' => 'NO',
+						'default' => 'NULL',
+						'comments' => '',
+					),
+					(object) array(
+						'column_name' => 'start_date',
+						'type' => 'timestamp without time zone',
+						'null' => 'NO',
+						'default' => 'NULL',
+						'comments' => '',
+					),
+					(object) array(
+						'column_name' => 'description',
+						'type' => 'text',
+						'null' => 'NO',
+						'default' => 'NULL',
+						'comments' => '',
+					)
+				)
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getTableKeys')
+		->will(
+			$this->returnValue(
+				array(
+					(object) array(
+						'idxName' => 'jos_dbtest_pkey',
+						'isPrimary' => 'TRUE',
+						'isUnique' => 'TRUE',
+						'Query' => 'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)',
+					)
+				)
+			)
+		);
+
+		/* Check if database is at least 9.1.0 */
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getVersion')
+		->will(
+			$this->returnValue(
+				'9.1.2'
+			)
+		);
+
+		if (version_compare($this->dbo->getVersion(), '9.1.0') >= 0)
+		{
+			$this->_ver9dot1 = true;
+			$start_val = '1';
+		}
+		else
+		{
+			/* Older version */
+			$this->_ver9dot1 = false;
+			$start_val = null;
+		}
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getTableSequences')
+		->will(
+			$this->returnValue(
+				array(
+					(object) array(
+						'sequence' => 'jos_dbtest_id_seq',
+						'schema' => 'public',
+						'table' => 'jos_dbtest',
+						'column' => 'id',
+						'data_type' => 'bigint',
+						'start_value' => $start_val,
+						'minimum_value' => '1',
+						'maximum_value' => '9223372036854775807',
+						'increment' => '1',
+						'cycle_option' => 'NO',
+					)
+				)
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('quoteName')
+		->will(
+			$this->returnCallback(
+				array($this, 'callbackQuoteName')
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('setQuery')
+		->will(
+			$this->returnCallback(
+				array($this, 'callbackSetQuery')
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('loadObjectList')
+		->will(
+			$this->returnCallback(
+				array($this, 'callbackLoadObjectList')
+			)
+		);
+	}
+
+	/**
+	 * Callback for the dbo loadObjectList method.
+	 *
+	 * @return array  An array of results based on the setting of the last query.
+	 *
+	 * @since  12.1
+	 */
+	public function callbackLoadObjectList()
+	{
+		return array();
+	}
+
+	/**
+	 * Callback for the dbo quoteName method.
+	 *
+	 * @param   string  $value  The value to be quoted.
+	 *
+	 * @return string  The value passed wrapped in PostgreSQL quotes.
+	 *
+	 * @since  12.1
+	 */
+	public function callbackQuoteName($value)
+	{
+		return '"$value"';
+	}
+
+	/**
+	 * Callback for the dbo setQuery method.
+	 *
+	 * @param   string  $query  The query.
+	 *
+	 * @return void
+	 *
+	 * @since  12.1
+	 */
+	public function callbackSetQuery($query)
+	{
+		$this->lastQuery = $query;
+	}
+
+	/**
+	 * Test the magic __toString method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function test__toString()
+	{
+		$instance = new JDatabaseExporterPostgresqlInspector;
+
+		// Set up the export settings.
+		$instance
+			->setDbo($this->dbo)
+			->from('jos_test')
+			->withStructure(true);
+
+		/* Depending on which version is running, 9.1.0 or older */
+		$start_val = null;
+		if ($this->_ver9dot1)
+		{
+			$start_val = '1';
+		}
+
+		$this->assertThat(
+			(string) $instance,
+			$this->equalTo(
+'<?xml version="1.0"?>
+<postgresqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+ <database name="">
+  <table_structure name="#__test">
+   <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' . $start_val . '" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />
+   <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />
+   <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />
+   <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />
+   <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />
+   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)" />
+  </table_structure>
+ </database>
+</postgresqldump>'
+			),
+			'__toString has not returned the expected result.'
+		);
+
+	}
+
+	/**
+	 * Tests the asXml method.
+	 *
+	 * @return void
+	 *
+	 * @since  12.1
+	 */
+	public function testAsXml()
+	{
+		$instance = new JDatabaseExporterPostgresqlInspector;
+
+		$result = $instance->asXml();
+
+		$this->assertThat(
+			$result,
+			$this->identicalTo($instance),
+			'asXml must return an object to support chaining.'
+		);
+
+		$this->assertThat(
+			$instance->asFormat,
+			$this->equalTo('xml'),
+			'The asXml method should set the protected asFormat property to "xml".'
+		);
+	}
+
+	/**
+	 * Test the buildXML method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testBuildXml()
+	{
+		$instance = new JDatabaseExporterPostgresqlInspector;
+
+		// Set up the export settings.
+		$instance
+			->setDbo($this->dbo)
+			->from('jos_test')
+			->withStructure(true);
+
+		/* Depending on which version is running, 9.1.0 or older */
+		$start_val = null;
+		if ($this->_ver9dot1)
+		{
+			$start_val = '1';
+		}
+
+		$this->assertThat(
+			$instance->buildXml(),
+			$this->equalTo(
+'<?xml version="1.0"?>
+<postgresqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+ <database name="">
+  <table_structure name="#__test">
+   <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' . $start_val . '" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />
+   <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />
+   <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />
+   <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />
+   <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />
+   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)" />
+  </table_structure>
+ </database>
+</postgresqldump>'
+			),
+			'buildXml has not returned the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the buildXmlStructure method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testBuildXmlStructure()
+	{
+		$instance = new JDatabaseExporterPostgresqlInspector;
+
+		// Set up the export settings.
+		$instance
+			->setDbo($this->dbo)
+			->from('jos_test')
+			->withStructure(true);
+
+		/* Depending on which version is running, 9.1.0 or older */
+		$start_val = null;
+		if ($this->_ver9dot1)
+		{
+			$start_val = '1';
+		}
+
+		$this->assertThat(
+			$instance->buildXmlStructure(),
+			$this->equalTo(
+				array(
+					'  <table_structure name="#__test">',
+					'   <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' . $start_val . '" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />',
+					'   <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />',
+					'   <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />',
+					'   <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />',
+					'   <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />',
+					'   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)" />',
+					'  </table_structure>'
+				)
+			),
+			'buildXmlStructure has not returned the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the check method.
+	 *
+	 * @return void
+	 *
+	 * @since  12.1
+	 */
+	public function testCheckWithNoDbo()
+	{
+		$instance = new JDatabaseExporterPostgresqlInspector;
+
+		try
+		{
+			$instance->check();
+		}
+		catch (Exception $e)
+		{
+			// Exception expected.
+			return;
+		}
+
+		$this->fail(
+			'Check method should throw exception if DBO not set'
+		);
+	}
+
+	/**
+	 * Tests the check method.
+	 *
+	 * @return void
+	 *
+	 * @since  12.1
+	 */
+	public function testCheckWithNoTables()
+	{
+		$instance	= new JDatabaseExporterPostgresqlInspector;
+		$instance->setDbo($this->dbo);
+
+		try
+		{
+			$instance->check();
+		}
+		catch (Exception $e)
+		{
+			// Exception expected.
+			return;
+		}
+
+		$this->fail(
+			'Check method should throw exception if DBO not set'
+		);
+	}
+
+	/**
+	 * Tests the check method.
+	 *
+	 * @return void
+	 *
+	 * @since  12.1
+	 */
+	public function testCheckWithGoodInput()
+	{
+		$instance	= new JDatabaseExporterPostgresqlInspector;
+		$instance->setDbo($this->dbo);
+		$instance->from('foobar');
+
+		try
+		{
+			$result = $instance->check();
+
+			$this->assertThat(
+				$result,
+				$this->identicalTo($instance),
+				'check must return an object to support chaining.'
+			);
+		}
+		catch (Exception $e)
+		{
+			$this->fail(
+				'Check method should not throw exception with good setup: ' . $e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Tests the from method with bad input.
+	 *
+	 * @return void
+	 *
+	 * @since  12.1
+	 */
+	public function testFromWithBadInput()
+	{
+		$instance = new JDatabaseExporterPostgresqlInspector;
+
+		try
+		{
+			$instance->from(new stdClass);
+		}
+		catch (Exception $e)
+		{
+			// Exception expected.
+			return;
+		}
+
+		$this->fail(
+			'From method should thrown an exception if argument is not a string or array.'
+		);
+	}
+
+	/**
+	 * Tests the from method with expected good inputs.
+	 *
+	 * @return void
+	 *
+	 * @since  12.1
+	 */
+	public function testFromWithGoodInput()
+	{
+		$instance = new JDatabaseExporterPostgresqlInspector;
+
+		try
+		{
+			$result = $instance->from('jos_foobar');
+
+			$this->assertThat(
+				$result,
+				$this->identicalTo($instance),
+				'from must return an object to support chaining.'
+			);
+
+			$this->assertThat(
+				$instance->from,
+				$this->equalTo(array('jos_foobar')),
+				'The from method should convert a string input to an array.'
+			);
+		}
+		catch (Exception $e)
+		{
+			$this->fail(
+				'From method should not throw exception with good input: ' . $e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Tests the method getGenericTableName method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testGetGenericTableName()
+	{
+		$instance = new JDatabaseExporterPostgresqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getGenericTableName('jos_test'),
+			$this->equalTo('#__test'),
+			'The testGetGenericTableName should replace the database prefix with #__.'
+		);
+	}
+
+	/**
+	 * Tests the setDbo method with the wrong type of class.
+	 *
+	 * @return void
+	 *
+	 * @since  12.1
+	 */
+	public function testSetDboWithBadInput()
+	{
+		$instance	= new JDatabaseExporterPostgresqlInspector;
+
+		try
+		{
+			$instance->setDbo(new stdClass);
+		}
+		catch (PHPUnit_Framework_Error $e)
+		{
+			// Expecting the error, so just ignore it.
+			return;
+		}
+
+		$this->fail(
+			'setDbo requires a JDatabasePostgresql object and should throw an exception.'
+		);
+	}
+
+	/**
+	 * Tests the setDbo method with the wrong type of class.
+	 *
+	 * @return void
+	 *
+	 * @since  12.1
+	 */
+	public function testSetDboWithGoodInput()
+	{
+		$instance = new JDatabaseExporterPostgresqlInspector;
+
+		try
+		{
+			$result = $instance->setDbo($this->dbo);
+
+			$this->assertThat(
+				$result,
+				$this->identicalTo($instance),
+				'setDbo must return an object to support chaining.'
+			);
+
+		}
+		catch (PHPUnit_Framework_Error $e)
+		{
+			// Unknown error has occurred.
+			$this->fail(
+				$e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Tests the withStructure method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testWithStructure()
+	{
+		$instance = new JDatabaseExporterPostgresqlInspector;
+
+		$result = $instance->withStructure();
+
+		$this->assertThat(
+			$result,
+			$this->identicalTo($instance),
+			'withStructure must return an object to support chaining.'
+		);
+
+		$this->assertThat(
+			$instance->options->get('with-structure'),
+			$this->isTrue(),
+			'The default use of withStructure should result in true.'
+		);
+
+		$instance->withStructure(true);
+		$this->assertThat(
+			$instance->options->get('with-structure'),
+			$this->isTrue(),
+			'The explicit use of withStructure with true should result in true.'
+		);
+
+		$instance->withStructure(false);
+		$this->assertThat(
+			$instance->options->get('with-structure'),
+			$this->isFalse(),
+			'The explicit use of withStructure with false should result in false.'
+		);
+	}
+}

--- a/tests/suites/unit/joomla/database/database/JDatabaseImporterPostgresqlInspector.php
+++ b/tests/suites/unit/joomla/database/database/JDatabaseImporterPostgresqlInspector.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * @version    $Id: JDatabaseImporterPostgresqlInspector.php gpongelli $
+ * @package    Joomla.UnitTest
+ *
+ * @copyright  Copyright (C) 2005 - 2012 Open Source Matters. All rights reserved.
+ * @license    GNU General Public License
+ */
+
+require_once JPATH_PLATFORM . '/joomla/database/importer/postgresql.php';
+require_once JPATH_PLATFORM . '/joomla/database/exception.php';
+
+/**
+ * Class to expose protected properties and methods in JDatabasePostgresqlImporter for testing purposes
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Database
+ *
+ * @since       12.1
+ */
+class JDatabaseImporterPostgresqlInspector extends JDatabaseImporterPostgresql
+{
+	/**
+	 * Gets any property from the class.
+	 *
+	 * @param   string  $property  The name of the class property.
+	 *
+	 * @return  mixed   The value of the class property.
+	 *
+	 * @since   12.1
+	 */
+	public function __get($property)
+	{
+		return $this->$property;
+	}
+
+	/**
+	 * Exposes the protected check method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function check()
+	{
+		return parent::check();
+	}
+
+	/**
+	 * Exposes the protected getAddColumnSQL method.
+	 *
+	 * @param   string            $table  The table name.
+	 * @param   SimpleXMLElement  $field  The XML field definition.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	public function getAddColumnSQL($table, SimpleXMLElement $field)
+	{
+		return parent::getAddColumnSQL($table, $field);
+	}
+
+	/**
+	 * Exposes the protected getAddKeySQL method.
+	 *
+	 * @param   SimpleXMLElement  $field  The XML index definition.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	public function getAddIndexSQL(SimpleXMLElement $field)
+	{
+		return parent::getAddIndexSQL($field);
+	}
+
+	/**
+	 * Exposes the protected getAddSequenceSQL method.
+	 *
+	 * @param   SimpleXMLElement  $structure  The XML sequence definition.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	public function getAddSequenceSQL(SimpleXMLElement $structure)
+	{
+		return parent::getAddSequenceSQL($structure);
+	}
+
+	/**
+	 * Exposes the protected getAlterTableSQL method.
+	 *
+	 * @param   SimpleXMLElement  $structure  The XML structure of the table.
+	 *
+	 * @return  array
+	 *
+	 * @since   12.1
+	 */
+	public function getAlterTableSQL(SimpleXMLElement $structure)
+	{
+		return parent::getAlterTableSQL($structure);
+	}
+
+	/**
+	 * Exposes the protected getChangeColumnSQL method.
+	 *
+	 * @param   string            $table  The table name.
+	 * @param   SimpleXMLElement  $field  The XML field definition.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	public function getChangeColumnSQL($table, SimpleXMLElement $field)
+	{
+		return parent::getChangeColumnSQL($table, $field);
+	}
+
+	/**
+	 * Exposes the protected getColumnSQL method.
+	 *
+	 * @param   SimpleXMLElement  $field  The XML field definition.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	public function getColumnSQL(SimpleXMLElement $field)
+	{
+		return parent::getColumnSQL($field);
+	}
+
+	/**
+	 * Exposes the protected getChangeSequenceSQL method.
+	 *
+	 * @param   SimpleXMLElement  $structure  The XML sequence definition.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	public function getChangeSequenceSQL(SimpleXMLElement $structure)
+	{
+		return parent::getChangeSequenceSQL($structure);
+	}
+
+	/**
+	 * Exposes the protected getDropColumnSQL method.
+	 *
+	 * @param   string  $table  The table name.
+	 * @param   string  $name   The name of the field to drop.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	public function getDropColumnSQL($table, $name)
+	{
+		return parent::getDropColumnSQL($table, $name);
+	}
+
+	/**
+	 * Exposes the protected getDropKeySQL method.
+	 *
+	 * @param   string  $table  The table name.
+	 * @param   string  $name   The name of the key to drop.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	public function getDropKeySQL($table, $name)
+	{
+		return parent::getDropKeySQL($table, $name);
+	}
+
+	/**
+	 * Exposes the protected getDropPrimaryKeySQL method.
+	 *
+	 * @param   string  $table  The table name.
+	 * @param   string  $name   The constraint name.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	public function getDropPrimaryKeySQL($table, $name)
+	{
+		return parent::getDropPrimaryKeySQL($table, $name);
+	}
+
+	/**
+	 * Exposes the protected getDropIndexSQL method.
+	 *
+	 * @param   string  $name  The index name.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	public function getDropIndexSQL($name)
+	{
+		return parent::getDropIndexSQL($name);
+	}
+
+	/**
+	 * Exposes the protected getDropSequenceSQL method.
+	 *
+	 * @param   string  $name  The index name.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.1
+	 */
+	public function getDropSequenceSQL($name)
+	{
+		return parent::getDropSequenceSQL($name);
+	}
+
+	/**
+	 * Exposes the protected getIdxLookup method.
+	 *
+	 * @param   array  $keys  An array of objects that comprise the indexes for the table.
+	 *
+	 * @return  array	The lookup array. array({key name} => array(object, ...))
+	 *
+	 * @since   12.1
+	 * @throws	Exception
+	 */
+	public function getIdxLookup($keys)
+	{
+		return parent::getIdxLookup($keys);
+	}
+
+	/**
+	 * Exposes the protected getSeqLookup method.
+	 *
+	 * @param   array  $sequences  An array of objects that comprise the sequences for the table.
+	 *
+	 * @return  array	The lookup array. array({key name} => array(object, ...))
+	 *
+	 * @since   12.1
+	 * @throws	Exception
+	 */
+	public function getSeqLookup($sequences)
+	{
+		return parent::getSeqLookup($sequences);
+	}
+
+	/**
+	 * Exposes the protected getRealTableName method.
+	 *
+	 * @param   string  $table  The name of the table.
+	 *
+	 * @return  string	The real name of the table.
+	 *
+	 * @since   12.1
+	 */
+	public function getRealTableName($table)
+	{
+		return parent::getRealTableName($table);
+	}
+
+	/**
+	 * Exposes the protected mergeStructure method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 * @throws  Exception on error.
+	 */
+	public function mergeStructure()
+	{
+		return parent::mergeStructure();
+	}
+
+	/**
+	 * Exposes the protected withStructure method.
+	 *
+	 * @param   boolean  $setting  True to export the structure, false to not.
+	 *
+	 * @return  void
+	 *
+	 * @since	12.1
+	 */
+	public function withStructure($setting = true)
+	{
+		return parent::withStructure($setting);
+	}
+
+}

--- a/tests/suites/unit/joomla/database/database/JDatabaseImporterPostgresqlTest.php
+++ b/tests/suites/unit/joomla/database/database/JDatabaseImporterPostgresqlTest.php
@@ -1,0 +1,1058 @@
+<?php
+/**
+ * @version    $Id: JDatabaseImporterPostgresqlTest.php gpongelli $
+ * @package    Joomla.UnitTest
+ * 
+ * @copyright  Copyright (C) 2005 - 2012 Open Source Matters. All rights reserved.
+ * @license    GNU General Public License
+ */
+
+require_once __DIR__ . '/JDatabaseImporterPostgresqlInspector.php';
+
+/**
+ * Test the JDatabaseImporterPostgresql class.
+ * 
+ * @package     Joomla.UnitTest
+ * @subpackage  Database
+ * 
+ * @since       12.1
+ */
+class JDatabaseImporterPostgresqlTest extends PHPUnit_Framework_TestCase
+{
+	/**
+	 * @var    object  The mocked database object for use by test methods.
+	 * @since  12.1
+	 */
+	protected $dbo = null;
+
+	/**
+	 * @var    string  The last query sent to the dbo setQuery method.
+	 * @since  12.1
+	 */
+	protected $lastQuery = '';
+
+	/**
+	 * @var    array  Selected sample data for tests.
+	 * @since  12.1
+	 */
+	protected $sample = array(
+		'xml-id-field' => '<field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />',
+		'xml-id-seq' => '<sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="1" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />',
+		'xml-title-field' => '<field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />',
+		'xml-title-def' => '<field Field="title" Type="character varying(50)" Null="NO" Default="this is a test" Comments="" />',
+		'xml-int-defnum' => '<field Field="title" Type="integer" Null="NO" Default="0" Comments="" />',
+		'xml-body-field' => '<field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />',
+		'xml-primary-key' => '<key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)" />',
+		'xml-index' => '<key Index="jos_dbtest_idx_name" is_primary="FALSE" is_unique="FALSE" Query="CREATE INDEX jos_dbtest_idx_name ON jos_dbtest USING btree (name)" />',
+	);
+
+	/**
+	 * Sets up the testing conditions
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function setup()
+	{
+		// Set up the database object mock.
+
+		$this->dbo = $this->getMock(
+			'JDatabasePostgresql',
+			array(
+				'getErrorNum',
+				'getPrefix',
+				'getTableColumns',
+				'getTableKeys',
+				'getTableSequences',
+				'getAddSequenceSQL',
+				'getChangeSequenceSQL',
+				'getDropSequenceSQL',
+				'getAddIndexSQL',
+				'getVersion',
+				'quoteName',
+				'loadObjectList',
+				'quote',
+				'setQuery',
+			),
+			array(),
+			'',
+			false
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getPrefix')
+		->will(
+			$this->returnValue(
+				'jos_'
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getTableColumns')
+		->will(
+			$this->returnValue(
+				array(
+					'id' => (object) array(
+						'Field' => 'id',
+						'Type' => 'integer',
+						'Null' => 'NO',
+						'Default' => 'nextval(\'jos_dbtest_id_seq\'::regclass)',
+						'Comments' => '',
+					),
+					'title' => (object) array(
+						'Field' => 'title',
+						'Type' => 'character varying(50)',
+						'Null' => 'NO',
+						'Default' => 'NULL',
+						'Comments' => '',
+					),
+				)
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getTableKeys')
+		->will(
+			$this->returnValue(
+				array(
+					(object) array(
+						'Index' => 'jos_dbtest_pkey',
+						'is_primary' => 'TRUE',
+						'is_unique' => 'TRUE',
+						'Query' => 'ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)',
+					),
+					(object) array(
+						'Index' => 'jos_dbtest_idx_name',
+						'is_primary' => 'FALSE',
+						'is_unique' => 'FALSE',
+						'Query' => 'CREATE INDEX jos_dbtest_idx_name ON jos_dbtest USING btree (name)',
+					)
+				)
+			)
+		);
+
+		/* Check if database is at least 9.1.0 */
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getVersion')
+		->will(
+			$this->returnValue(
+				'7.1.2'
+			)
+		);
+
+		if (version_compare($this->dbo->getVersion(), '9.1.0') >= 0)
+		{
+			$start_val = '1';
+		}
+		else
+		{
+			/* Older version */
+			$start_val = null;
+		}
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('getTableSequences')
+		->will(
+			$this->returnValue(
+			array(
+					(object) array(
+						'Name' => 'jos_dbtest_id_seq',
+						'Schema' => 'public',
+						'Table' => 'jos_dbtest',
+						'Column' => 'id',
+						'Type' => 'bigint',
+						'Start_Value' => $start_val,
+						'Min_Value' => '1',
+						'Max_Value' => '9223372036854775807',
+						'Increment' => '1',
+						'Cycle_option' => 'NO',
+					)
+				)
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('quoteName')
+		->will(
+			$this->returnCallback(
+				array($this, 'callbackQuoteName')
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('quote')
+		->will(
+			$this->returnCallback(
+				array($this, 'callbackQuote')
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('setQuery')
+		->will(
+			$this->returnCallback(
+				array($this, 'callbackSetQuery')
+			)
+		);
+
+		$this->dbo->expects(
+			$this->any()
+		)
+		->method('loadObjectList')
+		->will(
+			$this->returnCallback(
+				array($this, 'callbackLoadObjectList')
+			)
+		);
+	}
+
+	/**
+	 * Callback for the dbo loadObjectList method.
+	 *
+	 * @return array  An array of results based on the setting of the last query.
+	 *
+	 * @since  12.1
+	 */
+	public function callbackLoadObjectList()
+	{
+		return array('');
+	}
+
+	/**
+	 * Callback for the dbo quote method.
+	 *
+	 * @param   string  $value  The value to be quoted.
+	 *
+	 * @return  string  The value passed wrapped in MySQL quotes.
+	 *
+	 * @since  12.1
+	 */
+	public function callbackQuote($value)
+	{
+		return "'$value'";
+	}
+
+	/**
+	 * Callback for the dbo quoteName method.
+	 *
+	 * @param   string  $value  The value to be quoted.
+	 *
+	 * @return  string  The value passed wrapped in MySQL quotes.
+	 *
+	 * @since  12.1
+	 */
+	public function callbackQuoteName($value)
+	{
+		return "\"$value\"";
+	}
+
+	/**
+	 * Callback for the dbo setQuery method.
+	 *
+	 * @param   string  $query  The query.
+	 *
+	 * @return  void
+	 *
+	 * @since  12.1
+	 */
+	public function callbackSetQuery($query)
+	{
+		$this->lastQuery = $query;
+	}
+
+	/**
+	 * Data for the testGetAlterTableSQL test.
+	 *
+	 * @return  array  Each array element must be an array with 3 elements: SimpleXMLElement field, expected result, error message.
+	 *
+	 * @since   12.1
+	 */
+	public function dataGetAlterTableSQL()
+	{
+		$f1 = '<field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />';
+		$f2 = '<field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />';
+		$f3 = '<field Field="alias" Type="character varying(255)" Null="NO" Default="test" Comments="" />';
+		$f2_def = '<field Field="title" Type="character varying(50)" Null="NO" Default="add default" Comments="" />';
+
+		$k1 = '<key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)" />';
+		$k2 = '<key Index="jos_dbtest_idx_name" is_primary="FALSE" is_unique="FALSE" Query="CREATE INDEX jos_dbtest_idx_name ON jos_dbtest USING btree (name)" />';
+		$k3 = '<key Index="jos_dbtest_idx_title" is_primary="FALSE" is_unique="FALSE" Query="CREATE INDEX jos_dbtest_idx_title ON jos_dbtest USING btree (title)" />';
+		$k4 = '<key Index="jos_dbtest_uidx_name" is_primary="FALSE" is_unique="TRUE" Query="CREATE UNIQUE INDEX jos_dbtest_uidx_name ON jos_dbtest USING btree (name)" />';
+		$pk = '<key Index="jos_dbtest_title_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE jos_dbtest ADD PRIMARY KEY (title)" />';
+
+		$s1 = '<sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="1" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />';
+		$s2 = '<sequence Name="jos_dbtest_title_seq" Schema="public" Table="jos_dbtest" Column="title" Type="bigint" Start_Value="1" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />';
+
+		return array(
+			array(
+				new SimpleXmlElement('<table_structure name="#__dbtest">' . $s1 . $f1 . $f2 . $k1 . $k2 . '</table_structure>'),
+				array(
+				),
+				'getAlterTableSQL should not change anything.'
+			),
+			array( /* add col */
+				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $f3 . $k1 . $k2 . '</table_structure>'),
+				array(
+					'ALTER TABLE "jos_test" ADD COLUMN "alias" character varying(255) NOT NULL DEFAULT \'test\'',
+				),
+				'getAlterTableSQL should add the new alias column.'
+			),
+			array( /* add idx */
+				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $k1 . $k2 . $k3 . '</table_structure>'),
+				array(
+					'CREATE INDEX jos_dbtest_idx_title ON jos_dbtest USING btree (title)',
+				),
+				'getAlterTableSQL should add the new key.'
+			),
+			array( /* add unique idx */
+				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $k1 . $k2 . $k4 . '</table_structure>'),
+				array(
+					'CREATE UNIQUE INDEX jos_dbtest_uidx_name ON jos_dbtest USING btree (name)',
+				),
+				'getAlterTableSQL should add the new unique key.'
+			),
+			array( /* add sequence */
+				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $s2 . $f1 . $f2 . $k1 . $k2 . '</table_structure>'),
+				array(
+					'CREATE SEQUENCE jos_dbtest_title_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START 1 NO CYCLE OWNED BY "public.jos_dbtest.title"',
+				),
+				'getAlterTableSQL should add the new sequence.'
+			),
+			array( /* add pkey */
+				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $k1 . $k2 . $pk . '</table_structure>'),
+				array(
+					'ALTER TABLE jos_dbtest ADD PRIMARY KEY (title)',
+				),
+				'getAlterTableSQL should add the new sequence.'
+			),
+			array( /* drop col */
+				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $k1 . $k2 . '</table_structure>'),
+				array(
+					'ALTER TABLE "jos_test" DROP COLUMN "title"',
+				),
+				'getAlterTableSQL should remove the title column.'
+			),
+			array( /* drop idx */
+				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $k1 . '</table_structure>'),
+				array(
+					"DROP INDEX \"jos_dbtest_idx_name\""
+				),
+				'getAlterTableSQL should change sequence.'
+			),
+			array( /* drop seq */
+				new SimpleXmlElement('<table_structure name="#__test">' . $f1 . $f2 . $k1 . $k2 . '</table_structure>'),
+				array(
+					'DROP SEQUENCE "jos_dbtest_id_seq"',
+				),
+				'getAlterTableSQL should drop the sequence.'
+			),
+			array( /* drop pkey */
+				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $k2 . '</table_structure>'),
+				array(
+					'ALTER TABLE ONLY "jos_test" DROP CONSTRAINT "jos_dbtest_pkey"',
+				),
+				'getAlterTableSQL should drop the old primary key.'
+			),
+			array( /* change col */
+				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2_def . $k1 . $k2 . '</table_structure>'),
+				array(
+					"ALTER TABLE \"jos_test\" ALTER COLUMN \"title\"  TYPE character varying(50),\nALTER COLUMN \"title\" SET NOT NULL,\nALTER COLUMN \"title\" SET DEFAULT 'add default'",
+				),
+				'getAlterTableSQL should change title field.'
+			),
+			array( /* change seq */
+				new SimpleXmlElement('<table_structure name="#__test">' . $s2 . $f1 . $f2 . $k1 . $k2 . '</table_structure>'),
+				array(
+					"CREATE SEQUENCE jos_dbtest_title_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START 1 NO CYCLE OWNED BY \"public.jos_dbtest.title\"",
+					"DROP SEQUENCE \"jos_dbtest_id_seq\"",
+				),
+				'getAlterTableSQL should change sequence.'
+			),
+			array( /* change idx */
+				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $k1 . $k3 . '</table_structure>'),
+				array(
+					"CREATE INDEX jos_dbtest_idx_title ON jos_dbtest USING btree (title)",
+					'DROP INDEX "jos_dbtest_idx_name"'
+				),
+				'getAlterTableSQL should change index.'
+			),
+			array( /* change pkey */
+				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $pk . $k2 . '</table_structure>'),
+				array(
+					'ALTER TABLE jos_dbtest ADD PRIMARY KEY (title)',
+					'ALTER TABLE ONLY "jos_test" DROP CONSTRAINT "jos_dbtest_pkey"'
+				),
+				'getAlterTableSQL should change primary key.'
+			),
+			);
+	}
+
+	/**
+	 * Data for the testGetColumnSQL test.
+	 *
+	 * @return  array  Each array element must be an array with 3 elements: SimpleXMLElement field, expected result, error message.
+	 *
+	 * @since   12.1
+	 */
+	public function dataGetColumnSQL()
+	{
+		return array(
+			array(
+				new SimpleXmlElement(
+					$this->sample['xml-id-field']
+				),
+				'"id" serial',
+				'Typical primary key field',
+			),
+			array(
+				new SimpleXmlElement(
+					$this->sample['xml-title-field']
+				),
+				'"title" character varying(50) NOT NULL',
+				'Typical text field',
+			),
+			array(
+				new SimpleXmlElement(
+					$this->sample['xml-body-field']
+				),
+				'"description" text NOT NULL',
+				'Typical blob field',
+			),
+			array(
+				new SimpleXmlElement(
+					$this->sample['xml-title-def']
+				),
+				'"title" character varying(50) NOT NULL DEFAULT \'this is a test\'',
+				'Typical text field with default value',
+			),
+		);
+	}
+
+	/**
+	 * Tests the asXml method.
+	 *
+	 * @return void
+	 *
+	 * @since  12.1
+	 */
+	public function testAsXml()
+	{
+		$instance = new JDatabaseImporterPostgresqlInspector;
+
+		$result = $instance->asXml();
+
+		$this->assertThat(
+			$result,
+			$this->identicalTo($instance),
+			'asXml must return an object to support chaining.'
+		);
+
+		$this->assertThat(
+			$instance->asFormat,
+			$this->equalTo('xml'),
+			'The asXml method should set the protected asFormat property to "xml".'
+		);
+	}
+
+	/**
+	 * Tests the check method.
+	 *
+	 * @return void
+	 *
+	 * @since  12.1
+	 */
+	public function testCheckWithNoDbo()
+	{
+		$instance = new JDatabaseImporterPostgresqlInspector;
+
+		try
+		{
+			$instance->check();
+		}
+		catch (Exception $e)
+		{
+			// Exception expected.
+			return;
+		}
+
+		$this->fail(
+			'Check method should throw exception if DBO not set'
+		);
+	}
+
+	/**
+	 * Tests the check method.
+	 *
+	 * @return void
+	 *
+	 * @since  12.1
+	 */
+	public function testCheckWithNoFrom()
+	{
+		$instance	= new JDatabaseImporterPostgresqlInspector;
+		$instance->setDbo($this->dbo);
+
+		try
+		{
+			$instance->check();
+		}
+		catch (Exception $e)
+		{
+			// Exception expected.
+			return;
+		}
+
+		$this->fail(
+			'Check method should throw exception if DBO not set'
+		);
+	}
+
+	/**
+	 * Tests the check method.
+	 *
+	 * @return void
+	 *
+	 * @since  12.1
+	 */
+	public function testCheckWithGoodInput()
+	{
+		$instance	= new JDatabaseImporterPostgresqlInspector;
+		$instance->setDbo($this->dbo);
+		$instance->from('foobar');
+
+		try
+		{
+			$result = $instance->check();
+
+			$this->assertThat(
+				$result,
+				$this->identicalTo($instance),
+				'check must return an object to support chaining.'
+			);
+		}
+		catch (Exception $e)
+		{
+			$this->fail(
+				'Check method should not throw exception with good setup: ' . $e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Tests the from method with expected good inputs.
+	 *
+	 * @return void
+	 *
+	 * @since  12.1
+	 */
+	public function testFromWithGoodInput()
+	{
+		$instance = new JDatabaseImporterPostgresqlInspector;
+
+		try
+		{
+			$result = $instance->from('foobar');
+
+			$this->assertThat(
+				$result,
+				$this->identicalTo($instance),
+				'from must return an object to support chaining.'
+			);
+
+			$this->assertThat(
+				$instance->from,
+				$this->equalTo('foobar'),
+				'The from method did not store the value as expected.'
+			);
+		}
+		catch (Exception $e)
+		{
+			$this->fail(
+				'From method should not throw exception with good input: ' . $e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Tests the getAddColumnSQL method.
+	 *
+	 * Note that combinations of fields is tested in testGetColumnSQL.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testGetAddColumnSQL()
+	{
+		$instance = new JDatabaseImporterPostgresqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getAddColumnSQL(
+				'jos_test',
+				new SimpleXmlElement($this->sample['xml-title-field'])
+			),
+			$this->equalTo(
+				'ALTER TABLE "jos_test" ADD COLUMN "title" character varying(50) NOT NULL'
+			),
+			'testGetAddColumnSQL did not yield the expected result.'
+		);
+
+		/* test a field with a default value */
+		$this->assertThat(
+			$instance->getAddColumnSQL(
+				'jos_test',
+				new SimpleXmlElement($this->sample['xml-title-def'])
+			),
+			$this->equalTo(
+				'ALTER TABLE "jos_test" ADD COLUMN "title" character varying(50) NOT NULL DEFAULT \'this is a test\''
+			),
+			'testGetAddColumnSQL did not yield the expected result.'
+		);
+
+		/* test a field with a numeric default value */
+		$this->assertThat(
+			$instance->getAddColumnSQL(
+				'jos_test',
+				new SimpleXmlElement($this->sample['xml-int-defnum'])
+			),
+			$this->equalTo(
+				'ALTER TABLE "jos_test" ADD COLUMN "title" integer NOT NULL DEFAULT 0'
+			),
+			'testGetAddColumnSQL did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getAddSequenceSQL method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testGetAddSequenceSQL()
+	{
+		$instance = new JDatabaseImporterPostgresqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getAddSequenceSQL(
+				new SimpleXmlElement($this->sample['xml-id-seq'])
+			),
+			$this->equalTo(
+				'CREATE SEQUENCE jos_dbtest_id_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START 1 NO CYCLE OWNED BY "public.jos_dbtest.id"'
+			),
+			'getAddSequenceSQL did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getAddIndexSQL method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testGetAddIndexSQL()
+	{
+		$instance = new JDatabaseImporterPostgresqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getAddIndexSQL(
+					new SimpleXmlElement($this->sample['xml-index'])
+			),
+			$this->equalTo(
+				"CREATE INDEX jos_dbtest_idx_name ON jos_dbtest USING btree (name)"
+			),
+			'testGetAddIndexSQL did not yield the expected result.'
+		);
+
+		$this->assertThat(
+			$instance->getAddIndexSQL(
+					new SimpleXmlElement($this->sample['xml-primary-key'])
+			),
+			$this->equalTo(
+				"ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)"
+			),
+			'testGetAddIndexSQL did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getAlterTableSQL method.
+	 *
+	 * @param   SimpleXMLElement  $structure  XML structure of field
+	 * @param   string            $expected   Expected string
+	 * @param   string            $message    Error message
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 *
+	 * @dataProvider dataGetAlterTableSQL
+	 */
+	public function testGetAlterTableSQL($structure, $expected, $message)
+	{
+		$instance = new JDatabaseImporterPostgresqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getAlterTableSQL(
+				$structure
+			),
+			$this->equalTo(
+				$expected
+			),
+			$message
+		);
+	}
+
+	/**
+	 * Tests the getChangeColumnSQL method.
+	 *
+	 * Note that combinations of fields is tested in testGetColumnSQL.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testGetChangeColumnSQL()
+	{
+		$instance = new JDatabaseImporterPostgresqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getChangeColumnSQL(
+				'jos_test',
+				new SimpleXmlElement($this->sample['xml-title-field'])
+			),
+			$this->equalTo(
+				'ALTER TABLE "jos_test" ALTER COLUMN "title"  TYPE character varying(50),' . "\n" .
+				'ALTER COLUMN "title" SET NOT NULL,' . "\n" .
+				'ALTER COLUMN "title" DROP DEFAULT'
+			),
+			'getChangeColumnSQL did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getChangeSequenceSQL method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testGetChangeSequenceSQL()
+	{
+		$instance = new JDatabaseImporterPostgresqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getChangeSequenceSQL(
+				new SimpleXmlElement($this->sample['xml-id-seq'])
+			),
+			$this->equalTo(
+				'ALTER SEQUENCE jos_dbtest_id_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START 1 OWNED BY "public.jos_dbtest.id"'
+			),
+			'getChangeSequenceSQL did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getColumnSQL method.
+	 *
+	 * @param   SimpleXmlElement  $field     The database field as an object.
+	 * @param   string            $expected  The expected result from the getColumnSQL method.
+	 * @param   string            $message   The error message to display if the result does not match the expected value.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 *
+	 * @dataProvider dataGetColumnSQL
+	 */
+	public function testGetColumnSQL($field, $expected, $message)
+	{
+		$instance	= new JDatabaseImporterPostgresqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			strtolower($instance->getColumnSQL($field)),
+			$this->equalTo(strtolower($expected)),
+			$message
+		);
+	}
+
+	/**
+	 * Tests the getDropColumnSQL method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testGetDropColumnSQL()
+	{
+		$instance = new JDatabaseImporterPostgresqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getDropColumnSQL(
+				'jos_test',
+				'title'
+			),
+			$this->equalTo(
+				'ALTER TABLE "jos_test" DROP COLUMN "title"'
+			),
+			'getDropColumnSQL did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getDropKeySQL method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testGetDropIndexSQL()
+	{
+		$instance = new JDatabaseImporterPostgresqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getDropIndexSQL(
+				'idx_title'
+			),
+			$this->equalTo(
+				'DROP INDEX "idx_title"'
+			),
+			'getDropKeySQL did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getDropPrimaryKeySQL method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testGetDropPrimaryKeySQL()
+	{
+		$instance = new JDatabaseImporterPostgresqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getDropPrimaryKeySQL(
+				'jos_test', 'idx_jos_test_pkey'
+			),
+			$this->equalTo(
+				'ALTER TABLE ONLY "jos_test" DROP CONSTRAINT "idx_jos_test_pkey"'
+			),
+			'getDropPrimaryKeySQL did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getDropSequenceSQL method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testGetDropSequenceSQL()
+	{
+		$instance = new JDatabaseImporterPostgresqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getDropSequenceSQL(
+				'idx_jos_test_seq'
+			),
+			$this->equalTo(
+				'DROP SEQUENCE "idx_jos_test_seq"'
+			),
+			'getDropSequenceSQL did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getIdxLookup method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testGetIdxLookup()
+	{
+		$instance = new JDatabaseImporterPostgresqlInspector;
+
+		$o1 = (object) array('Index' => 'id', 'foo' => 'bar1');
+		$o2 = (object) array('Index' => 'id', 'foo' => 'bar2');
+		$o3 = (object) array('Index' => 'title', 'foo' => 'bar3');
+
+		$this->assertThat(
+			$instance->getIdxLookup(
+				array($o1, $o2, $o3)
+			),
+			$this->equalTo(
+				array(
+					'id' => array($o1, $o2),
+					'title' => array($o3)
+				)
+			),
+			'getIdxLookup, using array input, did not yield the expected result.'
+		);
+
+		$o1 = new SimpleXmlElement('<key Index="id" foo="bar1" />');
+		$o2 = new SimpleXmlElement('<key Index="id" foo="bar2" />');
+		$o3 = new SimpleXmlElement('<key Index="title" foo="bar3" />');
+
+		$this->assertThat(
+			$instance->getIdxLookup(
+				array($o1, $o2, $o3)
+			),
+			$this->equalTo(
+				array(
+					'id' => array($o1, $o2),
+					'title' => array($o3)
+				)
+			),
+			'getIdxLookup, using SimpleXmlElement input, did not yield the expected result.'
+		);
+	}
+
+	/**
+	 * Tests the getRealTableName method with the wrong type of class.
+	 *
+	 * @return void
+	 *
+	 * @since  12.1
+	 */
+	public function testGetRealTableName()
+	{
+		$instance	= new JDatabaseImporterPostgresqlInspector;
+		$instance->setDbo($this->dbo);
+
+		$this->assertThat(
+			$instance->getRealTableName('#__test'),
+			$this->equalTo('jos_test'),
+			'getRealTableName should return the name of the table with #__ converted to the database prefix.'
+		);
+	}
+
+	/**
+	 * Tests the setDbo method with the wrong type of class.
+	 *
+	 * @return void
+	 *
+	 * @since  12.1
+	 */
+	public function testSetDboWithBadInput()
+	{
+		$instance	= new JDatabaseImporterPostgresqlInspector;
+
+		try
+		{
+			$instance->setDbo(new stdClass);
+		}
+		catch (PHPUnit_Framework_Error $e)
+		{
+			// Expecting the error, so just ignore it.
+			return;
+		}
+
+		$this->fail(
+			'setDbo requires a JDatabasePostgresql object and should throw an exception.'
+		);
+	}
+
+	/**
+	 * Tests the setDbo method with the wrong type of class.
+	 *
+	 * @return void
+	 *
+	 * @since  12.1
+	 */
+	public function testSetDboWithGoodInput()
+	{
+		$instance = new JDatabaseImporterPostgresqlInspector;
+
+		try
+		{
+			$result = $instance->setDbo($this->dbo);
+
+			$this->assertThat(
+				$result,
+				$this->identicalTo($instance),
+				'setDbo must return an object to support chaining.'
+			);
+
+		}
+		catch (PHPUnit_Framework_Error $e)
+		{
+			// Unknown error has occurred.
+			$this->fail(
+				$e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Tests the withStructure method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function testWithStructure()
+	{
+		$instance = new JDatabaseImporterPostgresqlInspector;
+
+		$result = $instance->withStructure();
+
+		$this->assertThat(
+			$result,
+			$this->identicalTo($instance),
+			'withStructure must return an object to support chaining.'
+		);
+
+		$this->assertThat(
+			$instance->options->get('with-structure'),
+			$this->isTrue(),
+			'The default use of withStructure should result in true.'
+		);
+
+		$instance->withStructure(true);
+		$this->assertThat(
+			$instance->options->get('with-structure'),
+			$this->isTrue(),
+			'The explicit use of withStructure with true should result in true.'
+		);
+
+		$instance->withStructure(false);
+		$this->assertThat(
+			$instance->options->get('with-structure'),
+			$this->isFalse(),
+			'The explicit use of withStructure with false should result in false.'
+		);
+	}
+}

--- a/tests/suites/unit/joomla/database/database/JDatabasePostgresqlQueryTest.php
+++ b/tests/suites/unit/joomla/database/database/JDatabasePostgresqlQueryTest.php
@@ -1,0 +1,1247 @@
+<?php
+/**
+ * @version    $Id: JDatabasePostgresqlQueryTest.php gpongelli $
+ * @package    Joomla.UnitTest
+ *
+ * @copyright  Copyright (C) 2005 - 2011 Open Source Matters. All rights reserved.
+ * @license    GNU General Public License
+ */
+
+/**
+ * Test class for JDatabasePostgresqlQuery.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Database
+ *
+ * @since       11.3
+ */
+class JDatabasePostgresqlQueryTest extends TestCase
+{
+	/**
+	 * @var  JDatabase  A mock of the JDatabase object for testing purposes.
+	 */
+	protected $dbo;
+
+	/**
+	 * Data for the testNullDate test.
+	 *
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	public function dataTestNullDate()
+	{
+		return array(
+			// Quoted, expected
+			array(true, "'1970-01-01 00:00:00'"),
+			array(false, "1970-01-01 00:00:00"),
+		);
+	}
+
+	/**
+	 * Data for the testNullDate test.
+	 *
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	public function dataTestQuote()
+	{
+		return array(
+			// Text, escaped, expected
+			array('text', false, '\'text\''),
+		);
+	}
+
+	/**
+	 * Data for the testJoin test.
+	 *
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	public function dataTestJoin()
+	{
+		return array(
+			// $type, $conditions
+			array('', 		'b ON b.id = a.id'),
+			array('INNER',	'b ON b.id = a.id'),
+			array('OUTER',	'b ON b.id = a.id'),
+			array('LEFT',	'b ON b.id = a.id'),
+			array('RIGHT',	'b ON b.id = a.id'),
+		);
+	}
+
+	/**
+	 * A mock callback for the database escape method.
+	 *
+	 * We use this method to ensure that JDatabaseQuery's escape method uses the
+	 * the database object's escape method.
+	 *
+	 * @param   string  $text  The input text.
+	 *
+	 * @return  string
+	 *
+	 * @since   11.3
+	 */
+	public function mockEscape($text)
+	{
+		return "_{$text}_";
+	}
+
+	/**
+	 * A mock callback for the database quoteName method.
+	 *
+	 * We use this method to ensure that JDatabaseQuery's quoteName method uses the
+	 * the database object's quoteName method.
+	 *
+	 * @param   string  $text  The input text.
+	 *
+	 * @return  string
+	 *
+	 * @since   11.3
+	 */
+	public function mockQuoteName($text)
+	{
+		return '"' . $text . '"';
+	}
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 *
+	 * @return  void
+	 */
+	protected function setUp()
+	{
+		$this->dbo = TestMockDatabaseDriver::create($this, '1970-01-01 00:00:00', 'Y-m-d H:i:s');
+
+		// Mock the escape method to ensure the API is calling the DBO's escape method.
+		$this->assignMockCallbacks(
+			$this->dbo,
+			array('escape' => array($this, 'mockEscape'))
+		);
+	}
+
+	/**
+	 * Test for the JDatabaseQueryPostgresql::__string method for a 'select' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function test__toStringSelect()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$q->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.id = 1')
+			->group('a.id')
+				->having('COUNT(a.id) > 3')
+			->order('a.id');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(
+				"\nSELECT a.id" .
+				"\nFROM a" .
+				"\nINNER JOIN b ON b.id = a.id" .
+				"\nWHERE b.id = 1" .
+				"\nGROUP BY a.id" .
+				"\nHAVING COUNT(a.id) > 3" .
+				"\nORDER BY a.id"
+			),
+			'Tests for correct rendering.'
+		);
+	}
+
+	/**
+	 * Test for the JDatabaseQuery::__string method for a 'update' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function test__toStringUpdate()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$q->update('#__foo AS a')
+			->join('INNER', 'b ON b.id = a.id')
+			->set('a.id = 2')
+			->where('b.id = 1');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(
+				"\nUPDATE #__foo AS a" .
+				"\nSET a.id = 2" .
+				"\nFROM b" .
+				"\nWHERE b.id = 1 AND b.id = a.id"
+			),
+			'Tests for correct rendering.'
+		);
+	}
+
+	/**
+	 * Test for year extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function test__toStringYear()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$q->select($q->year($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+					(string) $q,
+					$this->equalTo("\nSELECT EXTRACT (YEAR FROM \"col\")\nFROM table")
+		);
+	}
+
+	/**
+	 * Test for month extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function test__toStringMonth()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$q->select($q->month($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+					(string) $q,
+					$this->equalTo("\nSELECT EXTRACT (MONTH FROM \"col\")\nFROM table")
+		);
+	}
+
+	/**
+	 * Test for day extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function test__toStringDay()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$q->select($q->day($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+					(string) $q,
+					$this->equalTo("\nSELECT EXTRACT (DAY FROM \"col\")\nFROM table")
+		);
+	}
+
+	/**
+	 * Test for hour extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function test__toStringHour()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$q->select($q->hour($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+					(string) $q,
+					$this->equalTo("\nSELECT EXTRACT (HOUR FROM \"col\")\nFROM table")
+		);
+	}
+
+	/**
+	 * Test for minute extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function test__toStringMinute()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$q->select($q->minute($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+					(string) $q,
+					$this->equalTo("\nSELECT EXTRACT (MINUTE FROM \"col\")\nFROM table")
+		);
+	}
+
+	/**
+	 * Test for seconds extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function test__toStringSecond()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$q->select($q->second($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+					(string) $q,
+					$this->equalTo("\nSELECT EXTRACT (SECOND FROM \"col\")\nFROM table")
+		);
+	}
+
+	/**
+	 * Test for INSERT INTO clause with subquery.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function test__toStringInsert_subquery()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+		$subq = new JDatabaseQueryPostgresql($this->dbo);
+		$subq->select('col2')->where('a=1');
+
+		$q->insert('table')->columns('col')->values($subq);
+
+		$this->assertThat(
+					(string) $q,
+					$this->equalTo("\nINSERT INTO table\n(col)\n(\nSELECT col2\nWHERE a=1)")
+		);
+
+		$q->clear();
+		$q->insert('table')->columns('col')->values('3');
+		$this->assertThat(
+					(string) $q,
+					$this->equalTo("\nINSERT INTO table\n(col) VALUES \n(3)")
+		);
+	}
+
+	/**
+	 * Test for the castAsChar method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testCastAsChar()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->castAsChar('123'),
+			$this->equalTo('123::text'),
+			'The default castAsChar behaviour is quote the input.'
+		);
+
+	}
+
+	/**
+	 * Test for the charLength method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testCharLength()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->charLength('a.title'),
+			$this->equalTo('CHAR_LENGTH(a.title)')
+		);
+	}
+
+	/**
+	 * Test chaining.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testChaining()
+	{
+		$q = $this->dbo->getQuery(true)->select('foo');
+
+		$this->assertThat(
+			$q,
+			$this->isInstanceOf('JDatabaseQuery')
+		);
+	}
+
+	/**
+	 * Test for the clear method (clearing all types and clauses).
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testClear_all()
+	{
+		$properties = array(
+			'select',
+			'delete',
+			'update',
+			'insert',
+			'from',
+			'join',
+			'set',
+			'where',
+			'group',
+			'having',
+			'order',
+			'columns',
+			'values',
+			'forShare',
+			'forUpdate',
+			'limit',
+			'noWait',
+			'offset',
+			'returning',
+		);
+
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		// First pass - set the values.
+		foreach ($properties as $property)
+		{
+			TestReflection::setValue($q, $property, $property);
+		}
+
+		// Clear the whole query.
+		$q->clear();
+
+		// Check that all properties have been cleared
+		foreach ($properties as $property)
+		{
+			$this->assertThat(
+				$q->$property,
+				$this->equalTo(null)
+			);
+		}
+
+		// And check that the type has been cleared.
+		$this->assertThat(
+			$q->type,
+			$this->equalTo(null)
+		);
+	}
+
+	/**
+	 * Test for the clear method (clearing each clause).
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testClear_clause()
+	{
+		$clauses = array(
+			'from',
+			'join',
+			'set',
+			'where',
+			'group',
+			'having',
+			'order',
+			'columns',
+			'values',
+			'forShare',
+			'forUpdate',
+			'limit',
+			'noWait',
+			'offset',
+			'returning',
+		);
+
+		// Test each clause.
+		foreach ($clauses as $clause)
+		{
+			$q = new JDatabaseQueryPostgresql($this->dbo);
+
+			// Set the clauses
+			foreach ($clauses as $clause2)
+			{
+				TestReflection::setValue($q, $clause2, $clause2);
+			}
+
+			// Clear the clause.
+			$q->clear($clause);
+
+			// Check that clause was cleared.
+			$this->assertThat(
+				$q->$clause,
+				$this->equalTo(null)
+			);
+
+			// Check the state of the other clauses.
+			foreach ($clauses as $clause2)
+			{
+				if ($clause != $clause2)
+				{
+					$this->assertThat(
+						$q->$clause2,
+						$this->equalTo($clause2),
+						"Clearing '$clause' resulted in '$clause2' having a value of " . $q->$clause2 . '.'
+					);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Test for the clear method (clearing each query type).
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testClear_type()
+	{
+		$types = array(
+			'select',
+			'delete',
+			'update',
+			'insert',
+			'forShare',
+			'forUpdate',
+			'limit',
+			'noWait',
+			'offset',
+			'returning',
+		);
+
+		$clauses = array(
+			'from',
+			'join',
+			'set',
+			'where',
+			'group',
+			'having',
+			'order',
+			'columns',
+			'values',
+		);
+
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		// Set the clauses.
+		foreach ($clauses as $clause)
+		{
+			TestReflection::setValue($q, $clause, $clause);
+		}
+
+		// Check that all properties have been cleared
+		foreach ($types as $type)
+		{
+			// Set the type.
+			TestReflection::setValue($q, $type, $type);
+
+			// Clear the type.
+			$q->clear($type);
+
+			// Check the type has been cleared.
+			$this->assertThat(
+				$q->type,
+				$this->equalTo(null)
+			);
+
+			$this->assertThat(
+				$q->$type,
+				$this->equalTo(null)
+			);
+
+			// Now check the claues have not been affected.
+			foreach ($clauses as $clause)
+			{
+				$this->assertThat(
+					$q->$clause,
+					$this->equalTo($clause)
+				);
+			}
+		}
+	}
+
+	/**
+	 * Test for "concatenate" words.
+	 *
+	 * @return  void
+	 */
+	public function testConcatenate()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->concatenate(array('foo', 'bar')),
+			$this->equalTo('foo || bar'),
+			'Tests without separator.'
+		);
+
+		$this->assertThat(
+			$q->concatenate(array('foo', 'bar'), ' and '),
+			$this->equalTo("foo || '_ and _' || bar"),
+			'Tests without separator.'
+		);
+	}
+
+	/**
+	 * Test for FROM clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testFrom()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->from('#__foo'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->from),
+			$this->equalTo('FROM #__foo'),
+			'Tests rendered value.'
+		);
+
+		// Add another column.
+		$q->from('#__bar');
+
+		$this->assertThat(
+			trim($q->from),
+			$this->equalTo('FROM #__foo,#__bar'),
+			'Tests rendered value after second use.'
+		);
+	}
+
+	/**
+	 * Test for GROUP clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testGroup()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->group('foo'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->group),
+			$this->equalTo('GROUP BY foo'),
+			'Tests rendered value.'
+		);
+
+		// Add another column.
+		$q->group('bar');
+
+		$this->assertThat(
+			trim($q->group),
+			$this->equalTo('GROUP BY foo,bar'),
+			'Tests rendered value after second use.'
+		);
+	}
+
+	/**
+	 * Test for HAVING clause using a simple condition and with glue for second one.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testHaving()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->having('COUNT(foo) > 1'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->having),
+			$this->equalTo('HAVING COUNT(foo) > 1'),
+			'Tests rendered value.'
+		);
+
+		// Add another column.
+		$q->having('COUNT(bar) > 2');
+
+		$this->assertThat(
+			trim($q->having),
+			$this->equalTo('HAVING COUNT(foo) > 1 AND COUNT(bar) > 2'),
+			'Tests rendered value after second use.'
+		);
+
+		// Reset the field to test the glue.
+		TestReflection::setValue($q, 'having', null);
+		$q->having('COUNT(foo) > 1', 'OR');
+		$q->having('COUNT(bar) > 2');
+
+		$this->assertThat(
+			trim($q->having),
+			$this->equalTo('HAVING COUNT(foo) > 1 OR COUNT(bar) > 2'),
+			'Tests rendered value with OR glue.'
+		);
+	}
+
+	/**
+	 * Test for INNER JOIN clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testInnerJoin()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+		$q2 = new JDatabaseQueryPostgresql($this->dbo);
+		$condition = 'foo ON foo.id = bar.id';
+
+		$this->assertThat(
+			$q->innerJoin($condition),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$q2->join('INNER', $condition);
+
+		$this->assertThat(
+			$q->join,
+			$this->equalTo($q2->join),
+			'Tests that innerJoin is an alias for join.'
+		);
+	}
+
+	/**
+	 * Test for JOIN clause using dataprovider to test all types of join.
+	 *
+	 * @param   string  $type        Type of JOIN, could be INNER, OUTER, LEFT, RIGHT
+	 * @param   string  $conditions  Join condition
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 * @dataProvider  dataTestJoin
+	 */
+	public function testJoin($type, $conditions)
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->join('INNER', 'foo ON foo.id = bar.id'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->join[0]),
+			$this->equalTo('INNER JOIN foo ON foo.id = bar.id'),
+			'Tests that first join renders correctly.'
+		);
+
+		$q->join('OUTER', 'goo ON goo.id = car.id');
+
+		$this->assertThat(
+			trim($q->join[1]),
+			$this->equalTo('OUTER JOIN goo ON goo.id = car.id'),
+			'Tests that second join renders correctly.'
+		);
+	}
+
+	/**
+	 * Test for LEFT JOIN clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testLeftJoin()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+		$q2 = new JDatabaseQueryPostgresql($this->dbo);
+		$condition = 'foo ON foo.id = bar.id';
+
+		$this->assertThat(
+			$q->leftJoin($condition),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$q2->join('LEFT', $condition);
+
+		$this->assertThat(
+			$q->join,
+			$this->equalTo($q2->join),
+			'Tests that innerJoin is an alias for join.'
+		);
+	}
+
+	/**
+	 * Tests the quoteName method.
+	 *
+	 * @param   boolean  $quoted    The value of the quoted argument.
+	 * @param   string   $expected  The expected result.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 * @dataProvider  dataTestNullDate
+	 */
+	public function testNullDate($quoted, $expected)
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->nullDate($quoted),
+			$this->equalTo($expected),
+			'The nullDate method should be a proxy for the JDatabase::getNullDate method.'
+		);
+	}
+
+	/**
+	 * Test for ORDER clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testOrder()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->order('column'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->order),
+			$this->equalTo('ORDER BY column'),
+			'Tests rendered value.'
+		);
+
+		$q->order('col2');
+		$this->assertThat(
+			trim($q->order),
+			$this->equalTo('ORDER BY column,col2'),
+			'Tests rendered value.'
+		);
+	}
+
+	/**
+	 * Test for OUTER JOIN clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testOuterJoin()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+		$q2 = new JDatabaseQueryPostgresql($this->dbo);
+		$condition = 'foo ON foo.id = bar.id';
+
+		$this->assertThat(
+			$q->outerJoin($condition),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$q2->join('OUTER', $condition);
+
+		$this->assertThat(
+			$q->join,
+			$this->equalTo($q2->join),
+			'Tests that innerJoin is an alias for join.'
+		);
+	}
+
+	/**
+	 * Tests the quoteName method.
+	 *
+	 * @param   boolean  $text      The value to be quoted.
+	 * @param   boolean  $escape    True to escape the string, false to leave it unchanged.
+	 * @param   string   $expected  The expected result.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 * @dataProvider  dataTestQuote
+	 */
+	public function testQuote($text, $escape, $expected)
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->quoteName("test"),
+			$this->equalTo('"test"'),
+			'The quoteName method should be a proxy for the JDatabase::escape method.'
+		);
+	}
+
+	/**
+	 * Tests the quoteName method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testQuoteName()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->quoteName('test'),
+			$this->equalTo('"test"'),
+			'The quoteName method should be a proxy for the JDatabase::escape method.'
+		);
+	}
+
+	/**
+	 * Test for RIGHT JOIN clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testRightJoin()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+		$q2 = new JDatabaseQueryPostgresql($this->dbo);
+		$condition = 'foo ON foo.id = bar.id';
+
+		$this->assertThat(
+			$q->rightJoin($condition),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$q2->join('RIGHT', $condition);
+
+		$this->assertThat(
+			$q->join,
+			$this->equalTo($q2->join),
+			'Tests that innerJoin is an alias for join.'
+		);
+	}
+
+	/**
+	 * Test for SELECT clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testSelect()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->select('foo'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			$q->type,
+			$this->equalTo('select'),
+			'Tests the type property is set correctly.'
+		);
+
+		$this->assertThat(
+			trim($q->select),
+			$this->equalTo('SELECT foo'),
+			'Tests the select element is set correctly.'
+		);
+
+		$q->select('bar');
+
+		$this->assertThat(
+			trim($q->select),
+			$this->equalTo('SELECT foo,bar'),
+			'Tests the second use appends correctly.'
+		);
+
+		$q->select(
+			array(
+				'goo', 'car'
+			)
+		);
+
+		$this->assertThat(
+			trim($q->select),
+			$this->equalTo('SELECT foo,bar,goo,car'),
+			'Tests the second use appends correctly.'
+		);
+	}
+
+	/**
+	 * Test for WHERE clause using a simple condition and with glue for second one.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testWhere()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+		$this->assertThat(
+			$q->where('foo = 1'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->where),
+			$this->equalTo('WHERE foo = 1'),
+			'Tests rendered value.'
+		);
+
+		// Add another column.
+		$q->where(
+			array(
+				'bar = 2',
+				'goo = 3',
+			)
+		);
+
+		$this->assertThat(
+			trim($q->where),
+			$this->equalTo('WHERE foo = 1 AND bar = 2 AND goo = 3'),
+			'Tests rendered value after second use and array input.'
+		);
+
+		// Clear the where
+		TestReflection::setValue($q, 'where', null);
+		$q->where(
+			array(
+				'bar = 2',
+				'goo = 3',
+			),
+			'OR'
+		);
+
+		$this->assertThat(
+			trim($q->where),
+			$this->equalTo('WHERE bar = 2 OR goo = 3'),
+			'Tests rendered value with glue.'
+		);
+	}
+
+	/**
+	 * Tests the JDatabaseQueryPostgresql::escape method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testEscape()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->escape('foo'),
+			$this->equalTo('_foo_')
+		);
+	}
+
+	/**
+	 * Test for FOR UPDATE clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testForUpdate ()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->forUpdate('#__foo'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->forUpdate),
+			$this->equalTo('FOR UPDATE OF #__foo'),
+			'Tests rendered value.'
+		);
+
+		$q->forUpdate('#__bar');
+		$this->assertThat(
+			trim($q->forUpdate),
+			$this->equalTo('FOR UPDATE OF #__foo, #__bar'),
+			'Tests rendered value.'
+		);
+
+		// Testing glue
+		TestReflection::setValue($q, 'forUpdate', null);
+		$q->forUpdate('#__foo', ';');
+		$q->forUpdate('#__bar');
+		$this->assertThat(
+			trim($q->forUpdate),
+			$this->equalTo('FOR UPDATE OF #__foo; #__bar'),
+			'Tests rendered value.'
+		);
+	}
+
+	/**
+	 * Test for FOR SHARE clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testForShare ()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->forShare('#__foo'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->forShare),
+			$this->equalTo('FOR SHARE OF #__foo'),
+			'Tests rendered value.'
+		);
+
+		$q->forShare('#__bar');
+		$this->assertThat(
+			trim($q->forShare),
+			$this->equalTo('FOR SHARE OF #__foo, #__bar'),
+			'Tests rendered value.'
+		);
+
+		// Testing glue
+		TestReflection::setValue($q, 'forShare', null);
+		$q->forShare('#__foo', ';');
+		$q->forShare('#__bar');
+		$this->assertThat(
+			trim($q->forShare),
+			$this->equalTo('FOR SHARE OF #__foo; #__bar'),
+			'Tests rendered value.'
+		);
+	}
+
+	/**
+	 * Test for NOWAIT clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testNoWait ()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->noWait(),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->noWait),
+			$this->equalTo('NOWAIT'),
+			'Tests rendered value.'
+		);
+	}
+
+	/**
+	 * Test for LIMIT clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testLimit()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->limit('5'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->limit),
+			$this->equalTo('LIMIT 5'),
+			'Tests rendered value.'
+		);
+	}
+
+	/**
+	 * Test for OFFSET clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testOffset()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->offset('10'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->offset),
+			$this->equalTo('OFFSET 10'),
+			'Tests rendered value.'
+		);
+	}
+
+	/**
+	 * Test for RETURNING clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testReturning()
+	{
+		$q = new JDatabaseQueryPostgresql($this->dbo);
+
+		$this->assertThat(
+			$q->returning('id'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->returning),
+			$this->equalTo('RETURNING id'),
+			'Tests rendered value.'
+		);
+	}
+}


### PR DESCRIPTION
This driver implements inherited function from JDatabaseDriver class and add some other useful function to be able to use Joomla! on PostgreSQL database.
There is also a class that inherits from JDatabaseQuery to be able to create query object using PostgreSQL dialect.
These two classes are tested by other two classes under "test" folder.

PostgreSQL's added functions:
- getAlterDbCharacterSet, set database encoding
- getCreateDbQuery, returns a query string to create a database using $option array members
- getRandom, get a random number
- getStringPositionSQL, returns string's position inside another string
- getTableSequences, returns an array of table's sequences information
- releaseTransactionSavepoint, release given savepoint during transaction
- showTables, lists all table in database
- transactionSavepoint, creates transaction savepoint

Overridden functions:
- connected
- dropTable
- escape
- execute
- fetchArray
- fetchAssoc
- fetchObject
- freeResult
- getAffectedRows
- getCollation
- getNumRows
- getQuery
- getTableColumns
- getTableCreate
- getTableKeys
- getTableList
- getVersion
- insertid
- insertObject
- lockTable
- renameTable
- replacePrefix
- select
- setUTF
- transactionCommit
- transactionRollback
- transactionStart
- unlockTables
- updateObject

PostgreSQL database query added functions:
- limit, a possible replace for limit in setQuery
- offset, a possible replace for limit in setQuery
- forShare, lock table/row during SELECT
- forUpdate, lock table/row during SELECT
- getInsertTable, used in "indertid()" to retrieve last INSERT INTO's table name
- noWait, no wait a locked table
- returning, an INSERT INTO optional clause to returns last insert id

Added also Postgresql's exporter and importer classes and their test classes.
