### PR TITLE
Joomla CMS [#27526] Media manager doesn't support multi-byte characters 

### DIFF
--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -53,17 +53,26 @@ class JFile
 	/**
 	 * Makes file name safe to use
 	 *
-	 * @param   string  $file  The name of the file [not full path]
+	 * @param   string   $filename   The name of the file [not full path]
+	 * @param   boolean  $multibyte  Support for multibyte file-name
 	 *
 	 * @return  string  The sanitised string
 	 *
 	 * @since   11.1
 	 */
-	public static function makeSafe($file)
+	public static function makeSafe($filename, $multibyte = false)
 	{
-		$regex = array('#(\.){2,}#', '#[^A-Za-z0-9\.\_\- ]#', '#^\.#');
-
-		return preg_replace($regex, '', $file);
+		if ($multibyte)
+		{
+			$search = "/\?%*:|\"<>#;()&;, ";
+			return str_replace(str_split($search), '_', $filename);
+		}
+		else
+		{
+			$regex = array('#(\.){2,}#', '#[^A-Za-z0-9\.\_\- ]#', '#^\.#');
+			return preg_replace($regex, '', $filename);
+		}
+		
 	}
 
 	/**


### PR DESCRIPTION
This will add support for multi-byte file name on onsafe method of file class. The default is full backward compatible, and not using multi-byte file name.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=27526
