### PR TITLE
Remove a workaround for PHP 5.3.0 in JLanguage.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,7 +16,7 @@ Requirements
 ------------
 
 * PHP 5.2.4+ for Platform versions 11.x
-* PHP 5.3+ for Platform versions 12.x  
+* PHP 5.3.1+ for Platform versions 12.x  
 
 
 Installation

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -800,31 +800,14 @@ class JLanguage extends JObject
 	 */
 	protected function parse($filename)
 	{
-		$version = phpversion();
-
 		// Capture hidden PHP errors from the parsing.
 		$php_errormsg = null;
 		$track_errors = ini_get('track_errors');
 		ini_set('track_errors', true);
 
-		if ($version >= '5.3.1')
-		{
-			$contents = file_get_contents($filename);
-			$contents = str_replace('_QQ_', '"\""', $contents);
-			$strings = @parse_ini_string($contents);
-		}
-		else
-		{
-			$strings = @parse_ini_file($filename);
-
-			if ($version == '5.3.0' && is_array($strings))
-			{
-				foreach ($strings as $key => $string)
-				{
-					$strings[$key] = str_replace('_QQ_', '"', $string);
-				}
-			}
-		}
+		$contents = file_get_contents($filename);
+		$contents = str_replace('_QQ_', '"\""', $contents);
+		$strings = @parse_ini_string($contents);
 
 		// Restore error tracking to what it was before.
 		ini_set('track_errors', $track_errors);


### PR DESCRIPTION
This raises the minimum requirement to 5.3.1.

Even Ubuntut 8.0.4 (the oldest still supported LTS) has PHP 5.3.2 and Debian stable has PHP 5.3.3 so I see no harm in requiring 5.3.1.
