### PR TITLE
To use HEAD method, CURL_NOBODY should be set to true

### DIFF
--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -63,6 +63,9 @@ class JHttpTransportCurl implements JHttpTransport
 
 		// Set the request method.
 		$options[CURLOPT_CUSTOMREQUEST] = strtoupper($method);
+		
+		// Don't wait for body when $method is HEAD
+		$options[CURLOPT_NOBODY] = ($method === 'HEAD');
 
 		// Initialize the certificate store
 		$options[CURLOPT_CAINFO] = __DIR__ . '/cacert.pem';


### PR DESCRIPTION
To use HEAD method, CURL_NOBODY should be set to true. If it's not, curl is waiting for response body, which will never receive and script reaches max_execution_time. Setting CURLOPT_CUSTOMREQUEST makes sense only for methods other than GET or HEAD.

Please refer to 
http://www.php.net/manual/en/function.curl-setopt.php, CURLOPT_NOBODY and 
http://stackoverflow.com/questions/770179/php-curl-head-request-takes-a-long-time-on-some-sites#770200
