### PR TITLE
Fixing error in JGithub package

### DIFF
--- a/libraries/joomla/github/http.php
+++ b/libraries/joomla/github/http.php
@@ -46,8 +46,8 @@ class JGithubHttp extends JHttp
 	 */
 	public function __construct(JRegistry $options = null, JHttpTransport $transport = null)
 	{
-		// Call the JHttp constructor to setup the object.
-		parent::__construct($options, $transport);
+        $this->options   = isset($options) ? $options : new JRegistry;
+        $this->transport = isset($transport) ? $transport : new JHttpTransportStream($this->options);
 
 		// Make sure the user agent string is defined.
 		$this->options->def('userAgent', 'JGitHub/2.0');

--- a/libraries/joomla/github/http.php
+++ b/libraries/joomla/github/http.php
@@ -46,8 +46,8 @@ class JGithubHttp extends JHttp
 	 */
 	public function __construct(JRegistry $options = null, JHttpTransport $transport = null)
 	{
-        $this->options   = isset($options) ? $options : new JRegistry;
-        $this->transport = isset($transport) ? $transport : new JHttpTransportStream($this->options);
+		// Call the JHttp constructor to setup the object.
+		parent::__construct($options, $transport);
 
 		// Make sure the user agent string is defined.
 		$this->options->def('userAgent', 'JGitHub/2.0');


### PR DESCRIPTION
Jhithub Package  is not handling POST, PATCH , DELETE Requests well.
The root cause of the error is JGithubHttp which extends JHttp instantaite a JHttpTransportSocket HTTP transport which does not handle the JGithub requests.

The JGithub package is working well in 11.4 release because JHttp instantiates JHttpTransportStream transport direcrlty. In the trunk this has been changed as JHttpFactory::getAvailableDriver($this->options) which returns a JHttpTransportSocket.
