### PR TITLE
Updated database drivers to attempt to reconnect from database servers that have been disconnected.

### DIFF
--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -447,7 +447,7 @@ class JDatabaseDriverMysql extends JDatabaseDriver
 		$this->errorNum = 0;
 		$this->errorMsg = '';
 
-		// Execute the query.
+		// Execute the query. Error suppression is used here to prevent warnings/notices that the connection has been lost.
 		$this->cursor = @mysql_query($sql, $this->connection);
 
 		// If an error occurred handle it.

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -448,16 +448,46 @@ class JDatabaseDriverMysql extends JDatabaseDriver
 		$this->errorMsg = '';
 
 		// Execute the query.
-		$this->cursor = mysql_query($sql, $this->connection);
+		$this->cursor = @mysql_query($sql, $this->connection);
 
 		// If an error occurred handle it.
 		if (!$this->cursor)
 		{
-			$this->errorNum = (int) mysql_errno($this->connection);
-			$this->errorMsg = (string) mysql_error($this->connection) . ' SQL=' . $sql;
+			// Check if the server was disconnected.
+			if (!$this->connected())
+			{
+				try
+				{
+					// Attempt to reconnect.
+					$this->connection = null;
+					$this->connect();
+				}
+				// If connect fails, ignore that exception and throw the normal exception.
+				catch (RuntimeException $e)
+				{
+					// Get the error number and message.
+					$this->errorNum = (int) mysql_errno($this->connection);
+					$this->errorMsg = (string) mysql_error($this->connection) . ' SQL=' . $sql;
 
-			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
-			throw new RuntimeException($this->errorMsg, $this->errorNum);
+					// Throw the normal query exception.
+					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
+					throw new RuntimeException($this->errorMsg, $this->errorNum);
+				}
+
+				// Since we were able to reconnect, run the query again.
+				return $this->execute();
+			}
+			// The server was not disconnected.
+			else
+			{
+				// Get the error number and message.
+				$this->errorNum = (int) mysql_errno($this->connection);
+				$this->errorMsg = (string) mysql_error($this->connection) . ' SQL=' . $sql;
+
+				// Throw the normal query exception.
+				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
+				throw new RuntimeException($this->errorMsg, $this->errorNum);
+			}
 		}
 
 		return $this->cursor;

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -293,7 +293,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriverMysql
 		$this->errorNum = 0;
 		$this->errorMsg = '';
 
-		// Execute the query.
+		// Execute the query. Error suppression is used here to prevent warnings/notices that the connection has been lost.
 		$this->cursor = @mysqli_query($this->connection, $sql);
 
 		// If an error occurred handle it.

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -294,16 +294,42 @@ class JDatabaseDriverMysqli extends JDatabaseDriverMysql
 		$this->errorMsg = '';
 
 		// Execute the query.
-		$this->cursor = mysqli_query($this->connection, $sql);
+		$this->cursor = @mysqli_query($this->connection, $sql);
 
 		// If an error occurred handle it.
 		if (!$this->cursor)
 		{
-			$this->errorNum = (int) mysqli_errno($this->connection);
-			$this->errorMsg = (string) mysqli_error($this->connection) . ' SQL=' . $sql;
+			// Check if the server was disconnected.
+			if (!$this->connected())
+			{
+				try
+				{
+					// Attempt to reconnect.
+					$this->connection = null;
+					$this->connect();
+				}
+				// If connect fails, ignore that exception and throw the normal exception.
+				catch (RuntimeException $e)
+				{
+					$this->errorNum = (int) mysqli_errno($this->connection);
+					$this->errorMsg = (string) mysqli_error($this->connection) . ' SQL=' . $sql;
 
-			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
-			throw new RuntimeException($this->errorMsg, $this->errorNum);
+					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
+					throw new RuntimeException($this->errorMsg, $this->errorNum);
+				}
+
+				// Since we were able to reconnect, run the query again.
+				return $this->execute();
+			}
+			// The server was not disconnected.
+			else
+			{
+				$this->errorNum = (int) mysqli_errno($this->connection);
+				$this->errorMsg = (string) mysqli_error($this->connection) . ' SQL=' . $sql;
+
+				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
+				throw new RuntimeException($this->errorMsg, $this->errorNum);
+			}
 		}
 
 		return $this->cursor;

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -497,31 +497,31 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	 */
 	public function connected()
 	{
+		// Backup the query state.
+		$sql = $this->sql;
+		$limit = $this->limit;
+		$offset = $this->offset;
+		$prepared = $this->prepared;
+
 		try
 		{
-			// Backup the query state.
-			$sql = $this->sql;
-			$limit = $this->limit;
-			$offset = $this->offset;
-			$prepared = $this->prepared;
-
-			// Run a simple query.
+			// Run a simple query to check the connection.
 			$this->setQuery('SELECT 1');
 			$status = (bool) $this->loadResult();
-
-			// Restore the query state.
-			$this->sql = $sql;
-			$this->limit = $limit;
-			$this->offset = $offset;
-			$this->prepared = $prepared;
-
-			return $status;
 		}
-		// If we catch an exception here, the simple query failed so we must not be connected.
+		// If we catch an exception here, we must not be connected.
 		catch (Exception $e)
 		{
-			return false;
+			$status = false;
 		}
+
+		// Restore the query state.
+		$this->sql = $sql;
+		$this->limit = $limit;
+		$this->offset = $offset;
+		$this->prepared = $prepared;
+
+		return $status;
 	}
 
 	/**

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -271,18 +271,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		// Make sure the PDO extension for PHP is installed and enabled.
 		if (!self::isSupported())
 		{
-			// Legacy error handling switch based on the JError::$legacy switch.
-			// @deprecated  12.1
-			if (JError::$legacy)
-			{
-				$this->errorNum = 1;
-				$this->errorMsg = JText::_('JLIB_DATABASE_ERROR_ADAPTER_PDO');
-				return;
-			}
-			else
-			{
-				throw new RuntimeException(JText::_('JLIB_DATABASE_ERROR_ADAPTER_PDO'));
-			}
+			throw new RuntimeException(JText::_('JLIB_DATABASE_ERROR_ADAPTER_PDO'), 1);
 		}
 
 		try
@@ -296,18 +285,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		}
 		catch (PDOException $e)
 		{
-			// Legacy error handling switch based on the JError::$legacy switch.
-			// @deprecated  12.1
-			if (JError::$legacy)
-			{
-				$this->errorNum = 2;
-				$this->errorMsg = JText::_('JLIB_DATABASE_ERROR_CONNECT_PDO') . ': ' . $e->getMessage();
-				return;
-			}
-			else
-			{
-				throw new RuntimeException(JText::_('JLIB_DATABASE_ERROR_CONNECT_PDO') . ': ' . $e->getMessage());
-			}
+			throw new RuntimeException(JText::_('JLIB_DATABASE_ERROR_CONNECT_PDO') . ': ' . $e->getMessage(), 2);
 		}
 	}
 
@@ -370,22 +348,8 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 
 		if (!is_object($this->connection))
 		{
-			// Legacy error handling switch based on the JError::$legacy switch.
-			// @deprecated  12.1
-			if (JError::$legacy)
-			{
-
-				if ($this->debug)
-				{
-					throw new Exception('JDatabaseDriverPDO::query: ' . $this->errorNum . ' - ' . $this->errorMsg, 500);
-				}
-				return false;
-			}
-			else
-			{
-				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database');
-				throw new RuntimeException($this->errorMsg, $this->errorNum);
-			}
+			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database');
+			throw new RuntimeException($this->errorMsg, $this->errorNum);
 		}
 
 		// Take a local copy so that we don't modify the original query and cause issues later
@@ -430,22 +394,38 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		// If an error occurred handle it.
 		if (!$this->executed)
 		{
-			$this->errorNum = (int) $this->connection->errorCode();
-			$this->errorMsg = (string) 'SQL: ' . implode(", ", $this->connection->errorInfo());
-
-			// Legacy error handling switch based on the JError::$legacy switch.
-			// @deprecated  12.1
-			if (JError::$legacy)
+			// Check if the server was disconnected.
+			if (!$this->connected())
 			{
-
-				if ($this->debug)
+				try
 				{
-					throw new Exception('JDatabaseDriverPDO::query: ' . $this->errorNum . ' - ' . $this->errorMsg, 500);
+					// Attempt to reconnect.
+					$this->connection = null;
+					$this->connect();
 				}
-				return false;
+				// If connect fails, ignore that exception and throw the normal exception.
+				catch (RuntimeException $e)
+				{
+					// Get the error number and message.
+					$this->errorNum = (int) $this->connection->errorCode();
+					$this->errorMsg = (string) 'SQL: ' . implode(", ", $this->connection->errorInfo());
+
+					// Throw the normal query exception.
+					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
+					throw new RuntimeException($this->errorMsg, $this->errorNum);
+				}
+
+				// Since we were able to reconnect, run the query again.
+				return $this->execute();
 			}
+			// The server was not disconnected.
 			else
 			{
+				// Get the error number and message.
+				$this->errorNum = (int) $this->connection->errorCode();
+				$this->errorMsg = (string) 'SQL: ' . implode(", ", $this->connection->errorInfo());
+
+				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
 				throw new RuntimeException($this->errorMsg, $this->errorNum);
 			}
@@ -517,7 +497,31 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	 */
 	public function connected()
 	{
-		return $this->connection;
+		try
+		{
+			// Backup the query state.
+			$sql = $this->sql;
+			$limit = $this->limit;
+			$offset = $this->offset;
+			$prepared = $this->prepared;
+
+			// Run a simple query.
+			$this->setQuery('SELECT 1');
+			$status = (bool) $this->loadResult();
+
+			// Restore the query state.
+			$this->sql = $sql;
+			$this->limit = $limit;
+			$this->offset = $offset;
+			$this->prepared = $prepared;
+
+			return $status;
+		}
+		// If we catch an exception here, the simple query failed so we must not be connected.
+		catch (Exception $e)
+		{
+			return false;
+		}
 	}
 
 	/**

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -608,7 +608,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		$this->errorNum = 0;
 		$this->errorMsg = '';
 
-		// Execute the query.
+		// Execute the query. Error suppression is used here to prevent warnings/notices that the connection has been lost.
 		$this->cursor = @pg_query($this->connection, $sql);
 
 		// If an error occurred handle it.

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -608,23 +608,47 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		$this->errorNum = 0;
 		$this->errorMsg = '';
 
-		try
-		{
-			// Execute the query.
-			$this->cursor = pg_query($this->connection, $sql);
-		}
-		catch (Exception $e)
-		{
-			throw new RuntimeException(JText::_('JLIB_DATABASE_QUERY_FAILED') . "\n" . pg_last_error($this->connection) . "\nSQL=" . $sql);
-		}
+		// Execute the query.
+		$this->cursor = @pg_query($this->connection, $sql);
 
+		// If an error occurred handle it.
 		if (!$this->cursor)
 		{
-			$this->errorNum = (int) pg_result_error_field($this->cursor, PGSQL_DIAG_SQLSTATE) . ' ';
-			$this->errorMsg = JText::_('JLIB_DATABASE_QUERY_FAILED') . "\n" . pg_last_error($this->connection) . "\nSQL=$sql";
+			// Check if the server was disconnected.
+			if (!$this->connected())
+			{
+				try
+				{
+					// Attempt to reconnect.
+					$this->connection = null;
+					$this->connect();
+				}
+				// If connect fails, ignore that exception and throw the normal exception.
+				catch (RuntimeException $e)
+				{
+					// Get the error number and message.
+					$this->errorNum = (int) pg_result_error_field($this->cursor, PGSQL_DIAG_SQLSTATE) . ' ';
+					$this->errorMsg = JText::_('JLIB_DATABASE_QUERY_FAILED') . "\n" . pg_last_error($this->connection) . "\nSQL=$sql";
 
-			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
-			throw new RuntimeException($this->errorMsg);
+					// Throw the normal query exception.
+					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
+					throw new RuntimeException($this->errorMsg);
+				}
+
+				// Since we were able to reconnect, run the query again.
+				return $this->execute();
+			}
+			// The server was not disconnected.
+			else
+			{
+				// Get the error number and message.
+				$this->errorNum = (int) pg_result_error_field($this->cursor, PGSQL_DIAG_SQLSTATE) . ' ';
+				$this->errorMsg = JText::_('JLIB_DATABASE_QUERY_FAILED') . "\n" . pg_last_error($this->connection) . "\nSQL=$sql";
+
+				// Throw the normal query exception.
+				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
+				throw new RuntimeException($this->errorMsg);
+			}
 		}
 
 		return $this->cursor;

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -537,23 +537,8 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 
 		if (!is_resource($this->connection))
 		{
-
-			// Legacy error handling switch based on the JError::$legacy switch.
-			// @deprecated  12.1
-			if (JError::$legacy)
-			{
-
-				if ($this->debug)
-				{
-					throw new Exception('JDatabaseDriverSQLAzure::query: ' . $this->errorNum . ' - ' . $this->errorMsg);
-				}
-				return false;
-			}
-			else
-			{
-				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database');
-				throw new RuntimeException($this->errorMsg, $this->errorNum);
-			}
+			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database');
+			throw new RuntimeException($this->errorMsg, $this->errorNum);
 		}
 
 		// Take a local copy so that we don't modify the original query and cause issues later
@@ -589,30 +574,45 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		}
 
 		// Execute the query.
-		$this->cursor = sqlsrv_query($this->connection, $sql, array(), $array);
+		$this->cursor = @sqlsrv_query($this->connection, $sql, array(), $array);
 
 		// If an error occurred handle it.
 		if (!$this->cursor)
 		{
-
-			// Populate the errors.
-			$errors = sqlsrv_errors();
-			$this->errorNum = $errors[0]['SQLSTATE'];
-			$this->errorMsg = $errors[0]['message'] . 'SQL=' . $sql;
-
-			// Legacy error handling switch based on the JError::$legacy switch.
-			// @deprecated  12.1
-			if (JError::$legacy)
+			// Check if the server was disconnected.
+			if (!$this->connected())
 			{
-
-				if ($this->debug)
+				try
 				{
-					throw new Exception('JDatabaseDriverSQLAzure::query: ' . $this->errorNum . ' - ' . $this->errorMsg, 500);
+					// Attempt to reconnect.
+					$this->connection = null;
+					$this->connect();
 				}
-				return false;
+				// If connect fails, ignore that exception and throw the normal exception.
+				catch (RuntimeException $e)
+				{
+					// Get the error number and message.
+					$errors = sqlsrv_errors();
+					$this->errorNum = $errors[0]['SQLSTATE'];
+					$this->errorMsg = $errors[0]['message'] . 'SQL=' . $sql;
+
+					// Throw the normal query exception.
+					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
+					throw new RuntimeException($this->errorMsg, $this->errorNum);
+				}
+
+				// Since we were able to reconnect, run the query again.
+				return $this->execute();
 			}
+			// The server was not disconnected.
 			else
 			{
+				// Get the error number and message.
+				$errors = sqlsrv_errors();
+				$this->errorNum = $errors[0]['SQLSTATE'];
+				$this->errorMsg = $errors[0]['message'] . 'SQL=' . $sql;
+
+				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
 				throw new RuntimeException($this->errorMsg, $this->errorNum);
 			}

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -573,7 +573,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 			$array = array();
 		}
 
-		// Execute the query.
+		// Execute the query. Error suppression is used here to prevent warnings/notices that the connection has been lost.
 		$this->cursor = @sqlsrv_query($this->connection, $sql, array(), $array);
 
 		// If an error occurred handle it.


### PR DESCRIPTION
This fixes an issue where the database server gets disconnected from the PHP connection resource. This can happen in two situations that I am aware of:
- The database server is heavily loaded and drops a connection. 
- The resource was copied into a forked process which happens when forking JDaemon. If the child process closes the connection or finishes execution, the parent resource will be disconnected.

To address these two issues, if a valid cursor is not returned when executing a query, the driver will check if the resource is still connected to the database. If the resource is disconnected, it will attempt to reconnect and execute the query again. If the reconnect fails or if the server still shows as connected, the normal exception will be thrown.

For PDO drivers, this required a better implementation of the connected() method. I attempted to use PDO::getAttribute(ATTR_CONNECTION_STATUS) but that feature is not supported on Sqlite or Oracle, possibly others. To work around that, the connected() method will attempt to execute a simple database query. To prevent contamination of the driver state, the previous query information is backed up and then restored after the query is executed. 
