### PR TITLE
Throw an exception before invalid response is parsed by getResponse()

### DIFF
--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -134,6 +134,12 @@ class JHttpTransportCurl implements JHttpTransport
 		$content = curl_exec($ch);
 		curl_close($ch);
 
+		// Received empty response (invalid uri, connection reached timeout);
+		if ($content === false)
+		{
+			throw new RuntimeException('HTTP request failed');
+		}
+
 		return $this->getResponse($content);
 	}
 

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -55,6 +55,7 @@ class JHttpTransportCurl implements JHttpTransport
 	 * @return  JHttpResponse
 	 *
 	 * @since   11.3
+	 * @throws  RuntimeException
 	 */
 	public function request($method, JUri $uri, $data = null, array $headers = null, $timeout = null, $userAgent = null)
 	{

--- a/libraries/joomla/http/transport/socket.php
+++ b/libraries/joomla/http/transport/socket.php
@@ -137,6 +137,12 @@ class JHttpTransportSocket implements JHttpTransport
 			$content .= fgets($connection, 4096);
 		}
 
+		// Received empty response (invalid uri, connection reached timeout);
+		if ($content === "")
+		{
+			throw new RuntimeException('HTTP request failed');
+		}
+
 		return $this->getResponse($content);
 	}
 

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -124,6 +124,12 @@ class JHttpTransportStream implements JHttpTransport
 		// Open the stream for reading.
 		$stream = fopen((string) $uri, 'r', false, $context);
 
+		// fopen($uri) returns false
+		if ($stream === false)
+		{
+			throw new RuntimeException('HTTP request failed');
+		}
+
 		// Get the metadata for the stream, including response headers.
 		$metadata = stream_get_meta_data($stream);
 

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -122,9 +122,9 @@ class JHttpTransportStream implements JHttpTransport
 		$context = stream_context_create(array('http' => $options));
 
 		// Open the stream for reading.
-		$stream = fopen((string) $uri, 'r', false, $context);
+		$stream = @fopen((string) $uri, 'r', false, $context);
 
-		// fopen($uri) returns false
+		// fopen($uri) returns false (invalid uri, connection reached timeout)
 		if ($stream === false)
 		{
 			throw new RuntimeException('HTTP request failed');

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -125,7 +125,7 @@ class JHttpTransportStream implements JHttpTransport
 		// Open the stream for reading.
 		$stream = @fopen((string) $uri, 'r', false, $context);
 
-		// fopen($uri) returns false (invalid uri, connection reached timeout)
+		// When fopen($uri) returns false (invalid uri, connection reached timeout)
 		if ($stream === false)
 		{
 			throw new RuntimeException('HTTP request failed');

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -62,6 +62,7 @@ class JHttpTransportStream implements JHttpTransport
 	 * @return  JHttpResponse
 	 *
 	 * @since   11.3
+	 * @throws  RuntimeException
 	 */
 	public function request($method, JUri $uri, $data = null, array $headers = null, $timeout = null, $userAgent = null)
 	{


### PR DESCRIPTION
to test: JHttpFactory::getHttp()->head('http://blah')

Parsing invalid response (false, "") throws PHP errors as getResponse() assumes $content is consists headers and content.
