### PR TITLE
Override the JHttp contructor to use JHttpTransportStream.

### DIFF
--- a/libraries/joomla/github/http.php
+++ b/libraries/joomla/github/http.php
@@ -46,9 +46,9 @@ class JGithubHttp extends JHttp
 	 */
 	public function __construct(JRegistry $options = null, JHttpTransport $transport = null)
 	{
-     // Override the JHttp contructor to use JHttpTransportStream.
-     $this->options   = isset($options) ? $options : new JRegistry;
-     $this->transport = isset($transport) ? $transport : new JHttpTransportStream($this->options);
+    // Override the JHttp contructor to use JHttpTransportStream.
+    $this->options   = isset($options) ? $options : new JRegistry;
+    $this->transport = isset($transport) ? $transport : new JHttpTransportStream($this->options);
 
 		// Make sure the user agent string is defined.
 		$this->options->def('userAgent', 'JGitHub/2.0');

--- a/libraries/joomla/github/http.php
+++ b/libraries/joomla/github/http.php
@@ -47,8 +47,8 @@ class JGithubHttp extends JHttp
 	public function __construct(JRegistry $options = null, JHttpTransport $transport = null)
 	{
         // Override the JHttp contructor to use JHttpTransportStream.
-        $this->options   = isset($options) ? $options : new JRegistry;
- 	    $this->transport = isset($transport) ? $transport : new JHttpTransportStream($this->options);
+      $this->options   = isset($options) ? $options : new JRegistry;
+ 	  $this->transport = isset($transport) ? $transport : new JHttpTransportStream($this->options);
 
 		// Make sure the user agent string is defined.
 		$this->options->def('userAgent', 'JGitHub/2.0');

--- a/libraries/joomla/github/http.php
+++ b/libraries/joomla/github/http.php
@@ -46,9 +46,9 @@ class JGithubHttp extends JHttp
 	 */
 	public function __construct(JRegistry $options = null, JHttpTransport $transport = null)
 	{
-        // Override the JHttp contructor to use JHttpTransportStream.
-        $this->options   = isset($options) ? $options : new JRegistry;
-        $this->transport = isset($transport) ? $transport : new JHttpTransportStream($this->options);
+     // Override the JHttp contructor to use JHttpTransportStream.
+     $this->options   = isset($options) ? $options : new JRegistry;
+     $this->transport = isset($transport) ? $transport : new JHttpTransportStream($this->options);
 
 		// Make sure the user agent string is defined.
 		$this->options->def('userAgent', 'JGitHub/2.0');

--- a/libraries/joomla/github/http.php
+++ b/libraries/joomla/github/http.php
@@ -47,8 +47,8 @@ class JGithubHttp extends JHttp
 	public function __construct(JRegistry $options = null, JHttpTransport $transport = null)
 	{
     // Override the JHttp contructor to use JHttpTransportStream.
-        $this->options   = isset($options) ? $options : new JRegistry;
-        $this->transport = isset($transport) ? $transport : new JHttpTransportStream($this->options);
+    $this->options   = isset($options) ? $options : new JRegistry;
+    $this->transport = isset($transport) ? $transport : new JHttpTransportStream($this->options);
 
 		// Make sure the user agent string is defined.
 		$this->options->def('userAgent', 'JGitHub/2.0');

--- a/libraries/joomla/github/http.php
+++ b/libraries/joomla/github/http.php
@@ -47,8 +47,8 @@ class JGithubHttp extends JHttp
 	public function __construct(JRegistry $options = null, JHttpTransport $transport = null)
 	{
         // Override the JHttp contructor to use JHttpTransportStream.
-      $this->options   = isset($options) ? $options : new JRegistry;
- 	  $this->transport = isset($transport) ? $transport : new JHttpTransportStream($this->options);
+        $this->options   = isset($options) ? $options : new JRegistry;
+        $this->transport = isset($transport) ? $transport : new JHttpTransportStream($this->options);
 
 		// Make sure the user agent string is defined.
 		$this->options->def('userAgent', 'JGitHub/2.0');

--- a/libraries/joomla/github/http.php
+++ b/libraries/joomla/github/http.php
@@ -46,8 +46,9 @@ class JGithubHttp extends JHttp
 	 */
 	public function __construct(JRegistry $options = null, JHttpTransport $transport = null)
 	{
-		// Call the JHttp constructor to setup the object.
-		parent::__construct($options, $transport);
+        // Override the JHttp contructor to use JHttpTransportStream.
+        $this->options   = isset($options) ? $options : new JRegistry;
+ 	    $this->transport = isset($transport) ? $transport : new JHttpTransportStream($this->options);
 
 		// Make sure the user agent string is defined.
 		$this->options->def('userAgent', 'JGitHub/2.0');

--- a/libraries/joomla/github/http.php
+++ b/libraries/joomla/github/http.php
@@ -47,8 +47,8 @@ class JGithubHttp extends JHttp
 	public function __construct(JRegistry $options = null, JHttpTransport $transport = null)
 	{
     // Override the JHttp contructor to use JHttpTransportStream.
-    $this->options   = isset($options) ? $options : new JRegistry;
-    $this->transport = isset($transport) ? $transport : new JHttpTransportStream($this->options);
+        $this->options   = isset($options) ? $options : new JRegistry;
+        $this->transport = isset($transport) ? $transport : new JHttpTransportStream($this->options);
 
 		// Make sure the user agent string is defined.
 		$this->options->def('userAgent', 'JGitHub/2.0');


### PR DESCRIPTION
JHttp instantiates a JHttpTransportSocket object which does not handle Github's POST, DELETE, PATCH Requests. A workaround is to override the contrcutor in JGithubHttp to instantiate a JHttpTransportStream Object
