### PR TITLE
Implement the JsonSerializable interface in JRegistry

### DIFF
--- a/libraries/compat/jsonserializable.php
+++ b/libraries/compat/jsonserializable.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @package     Joomla.Compat
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * JsonSerializable interface. This file should only be loaded on PHP < 5.4
+ * It allows us to implement it in classes without requiring PHP 5.4
+ *
+ * @package     Joomla.Platform
+ * @since       12.2
+ * @link        http://www.php.net/manual/en/jsonserializable.jsonserialize.php
+ */
+interface JsonSerializable
+{
+	/**
+	 * Return data which should be serialized by json_encode().
+	 *
+	 * @return  mixed
+	 *
+	 * @since   12.2
+	 */
+	public function jsonSerialize();
+}

--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -57,6 +57,12 @@ JLoader::register('JRoute', JPATH_PLATFORM . '/joomla/application/route.php');
 // Register the folder for the moved JHtml classes
 JHtml::addIncludePath(JPATH_PLATFORM . '/legacy/html');
 
+// Register classes for compatability with PHP 5.3
+if (version_compare(PHP_VERSION, '5.4.0', '<'))
+{
+	JLoader::register('JsonSerializable', __DIR__ . '/compat/jsonserializable.php');
+}
+
 // Add deprecated constants
 // @deprecated 12.3
 define('JPATH_ISWIN', IS_WIN);

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -47,6 +47,12 @@ JLoader::setup();
 // Import the base Joomla Platform libraries.
 JLoader::import('joomla.factory');
 
+// Register classes for compatability with PHP 5.3
+if (version_compare(PHP_VERSION, '5.4.0', '<'))
+{
+	JLoader::register('JsonSerializable', __DIR__ . '/compat/jsonserializable.php');
+}
+
 // Register classes that don't follow one file per class naming conventions.
 JLoader::register('JText', JPATH_PLATFORM . '/joomla/language/text.php');
 JLoader::register('JRoute', JPATH_PLATFORM . '/joomla/application/route.php');

--- a/libraries/joomla/registry/registry.php
+++ b/libraries/joomla/registry/registry.php
@@ -18,7 +18,7 @@ jimport('joomla.utilities.arrayhelper');
  * @subpackage  Registry
  * @since       11.1
  */
-class JRegistry
+class JRegistry implements JsonSerializable
 {
 	/**
 	 * Registry Object
@@ -79,6 +79,20 @@ class JRegistry
 	public function __toString()
 	{
 		return $this->toString();
+	}
+
+	/**
+	 * Implementation for the JsonSerializable interface.
+	 * Allows us to pass JRegistry objects to json_encode.
+	 *
+	 * @return  object
+	 *
+	 * @since   12.2
+	 * @note    The interface is only present in PHP 5.4 and up.
+	 */
+	public function jsonSerialize()
+	{
+		return $this->data;
 	}
 
 	/**

--- a/tests/suites/unit/joomla/registry/JRegistryTest.php
+++ b/tests/suites/unit/joomla/registry/JRegistryTest.php
@@ -28,7 +28,8 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Test the JRegistry::__clone method.
-	 * @
+	 *
+	 * @covers  JRegistry::__clone
 	 */
 	public function test__clone()
 	{
@@ -50,6 +51,8 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Test the JRegistry::__toString method.
+	 *
+	 * @covers  JRegistry::__toString
 	 */
 	public function test__toString()
 	{
@@ -65,7 +68,54 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 		);
 	}
 
+	/**
+	 * Test the JRegistry::jsonSerialize method.
+	 *
+	 * @covers  JRegistry::jsonSerialize
+	 */
+	public function testJsonSerialize()
+	{
+		if (version_compare(PHP_VERSION, '5.4.0', '<'))
+		{
+			$this->markTestSkipped('This test requires PHP 5.4 or newer.');
+		}
 
+		$object = new stdClass();
+		$a = new JRegistry($object);
+		$a->set('foo', 'bar');
+
+		// __toString only allows for a JSON value.
+		$this->assertThat(
+			json_encode($a),
+			$this->equalTo('{"foo":"bar"}'),
+			'Line: '.__LINE__.'.'
+		);
+	}
+
+	/**
+	 * Tests serializing JRegistry objects.
+	 */
+	public function testSerialize()
+	{
+		$a = new JRegistry();
+		$a->set('foo', 'bar');
+
+		$serialized = serialize($a);
+		$b = unserialize($serialized);
+
+		// __toString only allows for a JSON value.
+		$this->assertThat(
+			$b,
+			$this->equalTo($a),
+			'Line: '.__LINE__.'.'
+		);
+	}
+
+	/**
+	 * Test the JRegistry::def method.
+	 *
+	 * @covers  JRegistry::def
+	 */
 	public function testDef()
 	{
 		$a = new JRegistry();
@@ -85,6 +135,8 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Tet the JRegistry::bindData method.
+	 *
+	 * @covers  JRegistry::bindData
 	 */
 	public function testBindData()
 	{
@@ -121,7 +173,9 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the JReigstry::exists method.
+	 * Test the JRegistry::exists method.
+	 *
+	 * @covers  JRegistry::exists
 	 */
 	public function testExists()
 	{
@@ -162,7 +216,9 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 	}
 
 	/*
-	 * Test the JRegistry get method
+	 * Test the JRegistry::get method
+	 *
+	 * @covers  JRegistry::get
 	 */
 	public function testGet()
 	{
@@ -174,6 +230,8 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Test the JRegistry::getInstance method.
+	 *
+	 * @covers  JRegistry::getInstance
 	 */
 	public function testGetInstance()
 	{
@@ -206,6 +264,8 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Test the JRegistry::loadArray method.
+	 *
+	 * @covers  JRegistry::loadArray
 	 */
 	public function testLoadArray()
 	{
@@ -227,6 +287,8 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Test the JRegistry::loadFile method.
+	 *
+	 * @covers  JRegistry::loadFile
 	 */
 	public function testLoadFile()
 	{
@@ -269,6 +331,8 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Test the JRegistry::loadString() method.
+	 *
+	 * @covers  JRegistry::loadString
 	 */
 	public function testLoadString()
 	{
@@ -316,6 +380,8 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Test the JRegistry::loadObject method.
+	 *
+	 * @covers  JRegistry::loadObject
 	 */
 	public function testLoadObject()
 	{
@@ -345,6 +411,8 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Test the JRegistry::merge method.
+	 *
+	 * @covers  JRegistry::merge
 	 */
 	public function testMerge()
 	{
@@ -402,6 +470,8 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Test the JRegistry::set method.
+	 *
+	 * @covers  JRegistry::set
 	 */
 	public function testSet()
 	{
@@ -417,6 +487,8 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Test the JRegistry::toArray method.
+	 *
+	 * @covers  JRegistry::toArray
 	 */
 	public function testToArray()
 	{
@@ -440,6 +512,8 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Test the JRegistry::toObject method.
+	 *
+	 * @covers  JRegistry::toObject
 	 */
 	public function testToObject()
 	{
@@ -463,6 +537,8 @@ class JRegistryTest extends PHPUnit_Framework_TestCase
 
 	/**
 	 * Test the JRegistry::toString method.
+	 *
+	 * @covers  JRegistry::toString
 	 */
 	public function testToString()
 	{


### PR DESCRIPTION
This is would be the first use of one of the new PHP 5.4 features, but it maintains compatibility with PHP 5.3.

How to use:

```
$a = new JRegistry();
$a->set('foo', 'bar');
echo json_encode($a);
```

This isn't immediately useful since PHP 5.4 is very rare for now, but it may be appreciated by someone building a custom app who runs 5.4.
