### PR TITLE
Bug fix for Issue #529

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -279,9 +279,21 @@ class JMail extends PHPMailer
 		{
 			if (is_array($attachment))
 			{
-				foreach ($attachment as $file)
+				if(!empty($name) && sizeof($attachment) != sizeof($name))
 				{
-					parent::AddAttachment($file, $name, $encoding, $type);
+					throw new RuntimeException("The number of attachments must be equal with the number of name");
+				}
+					
+				for ($i=0; $i<sizeof($attachment); $i++)
+				{
+					if (!empty($name))
+					{
+						parent::AddAttachment($attachment[$i], $name[$i], $encoding, $type);
+					}
+					else
+					{
+						parent::AddAttachment($attachment[$i], $encoding, $type);
+					}
 				}
 			}
 			else

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -279,20 +279,20 @@ class JMail extends PHPMailer
 		{
 			if (is_array($attachment))
 			{
-				if(!empty($name) && sizeof($attachment) != sizeof($name))
+				if (!empty($name) && count($attachment) != count($name))
 				{
 					throw new RuntimeException("The number of attachments must be equal with the number of name");
 				}
-					
-				for ($i=0; $i<sizeof($attachment); $i++)
+
+				foreach ($attachment as $key => $file)
 				{
 					if (!empty($name))
 					{
-						parent::AddAttachment($attachment[$i], $name[$i], $encoding, $type);
+						parent::AddAttachment($file, $name[$key], $encoding, $type);
 					}
 					else
 					{
-						parent::AddAttachment($attachment[$i], $encoding, $type);
+						parent::AddAttachment($file, $name, $encoding, $type);
 					}
 				}
 			}

--- a/tests/suites/unit/joomla/mail/JMailTest.php
+++ b/tests/suites/unit/joomla/mail/JMailTest.php
@@ -119,11 +119,26 @@ class JMailTest extends TestCase
 	/**
 	 * @todo Implement testAddAttachment().
 	 */
-	public function testAddAttachment() {
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete(
-				'This test has not been implemented yet.'
-		);
+	public function testAddAttachment()
+	{
+		$attachments = array(getcwd() . '\tests\bootstrap.php');
+		$names = array('bootstrap');
+
+		$mail = new JMail;
+		$mail->addAttachment($attachments, $names);
+
+		$actual = $mail->GetAttachments();
+		$actual_attachments = array();
+		$actual_names = array();
+
+		foreach ($actual as $attach)
+		{
+			array_push($actual_attachments, $attach[0]);
+			array_push($actual_names, $attach[2]);
+		}
+
+		$this->assertThat($attachments, $this->equalTo($actual_attachments));
+		$this->assertThat($names, $this->equalTo($actual_names));
 	}
 
 	/**

--- a/tests/suites/unit/joomla/mail/JMailTest.php
+++ b/tests/suites/unit/joomla/mail/JMailTest.php
@@ -121,8 +121,8 @@ class JMailTest extends TestCase
 	 */
 	public function testAddAttachment()
 	{
-		$attachments = array(getcwd() . '\tests\bootstrap.php');
-		$names = array('bootstrap');
+		$attachments = array(JPATH_PLATFORM . '/joomla/mail/mail.php');
+		$names = array('mail.php');
 
 		$mail = new JMail;
 		$mail->addAttachment($attachments, $names);


### PR DESCRIPTION
JMail is ignoring name parameter on addAttachment.
