### PR TITLE
Add JTEST_HTTP_STUB to phpunit config

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
 		<const name="JTEST_DATABASE_MYSQL_DSN" value="host=localhost;dbname=joomla_ut;user=utuser;pass=ut1234" />
 		<const name="JTEST_DATABASE_MYSQLI_DSN" value="host=localhost;dbname=joomla_ut;user=utuser;pass=ut1234" />
 		<const name="JTEST_DATABASE_POSTGRESQL_DSN" value="host=localhost;port=5432;dbname=joomla_ut;user=utuser;pass=ut1234" />
+		<const name="JTEST_HTTP_STUB" value="http://localhost/joomla-platform/tests/suites/unit/stubs/jhttp_stub.php" />
 	</php> -->
 
 	<testsuite name="AllTests">


### PR DESCRIPTION
Adds the JTEST_HTTP_STUB constant, used in JHttpTransportTest, to the phpunit.xml.dist file.  Default path assumes the platform is checked out at your web root.
