### PR TITLE
Fix a PHP strict warning in JDate::setTimezone()

### DIFF
--- a/libraries/joomla/utilities/date.php
+++ b/libraries/joomla/utilities/date.php
@@ -393,7 +393,7 @@ class JDate extends DateTime
 	 *
 	 * @since   11.1
 	 */
-	public function setTimezone(DateTimeZone $tz)
+	public function setTimezone($tz)
 	{
 		$this->tz = $tz;
 		return parent::setTimezone($tz);


### PR DESCRIPTION
This fixes a PHP strict warning, since PHP's [DateTime::setTimezone()](http://www.php.net/manual/en/datetime.settimezone.php) seems not using type hinting internally (tested on PHP 5.4.0) Sorry for the mess..
