### PR TITLE
Fixed conflict between JGrid and JHtmlGrid when autoloaded.

### DIFF
--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -108,7 +108,7 @@ abstract class JHtml
 
 		$className = $prefix . ucfirst($file);
 
-		if (!class_exists($className))
+		if (!class_exists($className, false))
 		{
 			$path = JPath::find(self::$includePaths, strtolower($file) . '.php');
 			if ($path)

--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -115,7 +115,7 @@ abstract class JHtml
 			{
 				require_once $path;
 
-				if (!class_exists($className))
+				if (!class_exists($className, false))
 				{
 					throw new InvalidArgumentException(sprintf('%s not found.', $className), 500);
 				}


### PR DESCRIPTION
Steps to reproduce the error:
1. load JGrid: jimport('joomla.html.grid');
2. call a JHtmlGrid method: JHtml::_('grid.id', $i, $item->id)
3. Now JHtml::_() calls "class_exists" for JHtmlGrid
4. when not found, the Joomla! autoloader tries to find the path for the class JHtmlGrid.
5. the autoloader convert the class JHtmlGrid to the path (libraries/joomla/)html/grid.php
6. This file exists (of course) and will be loaded (again, see step 1), but unfortunately this is the wrong file
7. => Fatal error: Cannot redeclare class JGrid in html\grid.php on line 22

Solution:

The autoloader shouldn't be called in JHtml::_() and JHtml should handle the loading by itself
