### PR TITLE
pulled to platform as suggested by infograf768

### DIFF
--- a/libraries/legacy/toolbar/button/confirm.php
+++ b/libraries/legacy/toolbar/button/confirm.php
@@ -47,7 +47,7 @@ class JToolbarButtonConfirm extends JButton
 		$class = $this->fetchIconClass($name);
 		$doTask = $this->_getCommand($msg, $name, $task, $list);
 
-		$html = "<a href=\"#\" onclick=\"$doTask\" class=\"toolbar\">\n";
+		$html = "<a href=\"javascript:void(0)\" onclick=\"$doTask\" class=\"toolbar\">\n";
 		$html .= "<span class=\"$class\">\n";
 		$html .= "</span>\n";
 		$html .= "$text\n";

--- a/libraries/legacy/toolbar/button/help.php
+++ b/libraries/legacy/toolbar/button/help.php
@@ -42,7 +42,7 @@ class JToolbarButtonHelp extends JButton
 		$class = $this->fetchIconClass('help');
 		$doTask = $this->_getCommand($ref, $com, $override, $component);
 
-		$html = "<a href=\"#\" onclick=\"$doTask\" rel=\"help\" class=\"toolbar\">\n";
+		$html = "<a href=\"javascript:void(0)\" onclick=\"$doTask\" rel=\"help\" class=\"toolbar\">\n";
 		$html .= "<span class=\"$class\">\n";
 		$html .= "</span>\n";
 		$html .= "$text\n";

--- a/libraries/legacy/toolbar/button/standard.php
+++ b/libraries/legacy/toolbar/button/standard.php
@@ -44,7 +44,7 @@ class JToolbarButtonStandard extends JButton
 		$class = $this->fetchIconClass($name);
 		$doTask = $this->_getCommand($text, $task, $list);
 
-		$html = "<a href=\"#\" onclick=\"$doTask\" class=\"toolbar\">\n";
+		$html = "<a href=\"javascript:void(0)\" onclick=\"$doTask\" class=\"toolbar\">\n";
 		$html .= "<span class=\"$class\">\n";
 		$html .= "</span>\n";
 		$html .= "$i18n_text\n";


### PR DESCRIPTION
[19:36] <And_One> ian the problem is that the submit doesn´t occur because the function just add a # to the url
[19:36] <And_One> IE submit works, but FF doesn´t
[19:36] <And_One> there is a simple fix for it
[19:37] <And_One> replace href="#" with href="javascript: void(0)"
[19:40] <And_One> i used the latest nightly build of http://www.firefox64bit.com/
[19:40] @jools Title: Firefox 64-bit (at www.firefox64bit.com)
[19:40] <ian_mac> it only happens in the latest build?
[19:41] <And_One> i just started with the conversion of joomleague 1.5 to joomla 2.5 and stumbled over the problem with my first click on the save button ;)
[19:43] == lisa_s [~Birgit@dslb-088-066-031-105.pools.arcor-ip.net] has joined #joomla
[19:45] == lisa_s [~Birgit@dslb-088-066-031-105.pools.arcor-ip.net] has left #joomla []
[19:45] == ezrafree [ezra@gware/developer/ezrafree] has quit [Quit: [A] as below, so above, and beyond I imagine ..]
[19:46] == Draecos [~Draecos@212.105.160.143] has joined #joomla
[19:48] <And_One> the problem is that if you have a onclick function, the function have to return true or false to prevent the execution of the href="'#" because # is a valid href (anchor)  
[19:49] == voidcoder [~psychicis@82-171-102-39.ip.telfort.nl] has quit [Read error: Connection reset by peer]
[19:53] == sun [~sun@drupal.org/user/54136/view] has joined #joomla
[19:54] <ian_mac> file a bug report I guess
[19:54] <ian_mac> _shrug_
[19:54] <ian_mac> it works on current FF versions AFAIK
[19:58] <And_One> i found a forum topic about the same problem some hours ago but did not saved the link
[19:58] <And_One> he described the same problem
