### PR TITLE
Remove dependency on several classes from the database package.

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -180,20 +180,22 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 		// Instantiate variables.
 		$connectors = array();
 
-		// Get a list of types.
-		$types = JFolder::files(__DIR__ . '/driver');
+		// Get an iterator and loop trough the driver classes.
+		$iterator = new DirectoryIterator(__DIR__ . '/driver');
 
-		// Loop through the types and find the ones that are available.
-		foreach ($types as $type)
+		foreach ($iterator as $file)
 		{
-			// Ignore some files.
-			if (($type == 'index.html') || stripos($type, 'importer') || stripos($type, 'exporter') || stripos($type, 'query') || stripos($type, 'exception'))
+			$fileName = $file->getFilename();
+
+			// Only load for php files.
+			// Note: DirectoryIterator::getExtension only available PHP >= 5.3.6
+			if (!$file->isFile() || substr($fileName, strrpos($fileName, '.') + 1) != 'php')
 			{
 				continue;
 			}
 
 			// Derive the class name from the type.
-			$class = str_ireplace('.php', '', 'JDatabaseDriver' . ucfirst(trim($type)));
+			$class = str_ireplace('.php', '', 'JDatabaseDriver' . ucfirst(trim($fileName)));
 
 			// If the class doesn't exist we have nothing left to do but look at the next type.  We did our best.
 			if (!class_exists($class))
@@ -206,7 +208,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 			if ($class::isSupported() || $class::test())
 			{
 				// Connector names should not have file extensions.
-				$connectors[] = str_ireplace('.php', '', $type);
+				$connectors[] = str_ireplace('.php', '', $fileName);
 			}
 		}
 

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -1020,7 +1020,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	/**
 	 * Get the query string to create new Database in correct PostgreSQL syntax.
 	 *
-	 * @param   JObject  $options  JObject coming from "initialise" function to pass user
+	 * @param   object  $options  object coming from "initialise" function to pass user
 	 * 									and database name to database driver.
 	 * @param   boolean  $utf      True if the database supports the UTF-8 character set,
 	 * 									not used in PostgreSQL "CREATE DATABASE" query.

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -1020,7 +1020,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	/**
 	 * Get the query string to create new Database in correct PostgreSQL syntax.
 	 *
-	 * @param   object  $options  object coming from "initialise" function to pass user
+	 * @param   object   $options  object coming from "initialise" function to pass user
 	 * 									and database name to database driver.
 	 * @param   boolean  $utf      True if the database supports the UTF-8 character set,
 	 * 									not used in PostgreSQL "CREATE DATABASE" query.

--- a/libraries/joomla/database/exception.php
+++ b/libraries/joomla/database/exception.php
@@ -20,6 +20,6 @@ JLog::add('JDatabaseException is deprecated, use SPL Exceptions instead.', JLog:
  * @since       11.1
  * @deprecated  12.3 Use semantic exceptions instead
  */
-class JDatabaseException extends Exception
+class JDatabaseException extends RuntimeException
 {
 }

--- a/libraries/joomla/database/exporter/mysql.php
+++ b/libraries/joomla/database/exporter/mysql.php
@@ -53,7 +53,7 @@ class JDatabaseExporterMysql extends JDatabaseExporter
 	/**
 	 * An array of options for the exporter.
 	 *
-	 * @var    JObject
+	 * @var    object
 	 * @since  11.1
 	 */
 	protected $options = null;
@@ -67,7 +67,7 @@ class JDatabaseExporterMysql extends JDatabaseExporter
 	 */
 	public function __construct()
 	{
-		$this->options = new JObject;
+		$this->options = new stdClass;
 
 		$this->cache = array('columns' => array(), 'keys' => array());
 
@@ -292,7 +292,7 @@ class JDatabaseExporterMysql extends JDatabaseExporter
 	 */
 	public function withStructure($setting = true)
 	{
-		$this->options->set('with-structure', (boolean) $setting);
+		$this->options->with-structure = (boolean) $setting;
 
 		return $this;
 	}

--- a/libraries/joomla/database/exporter/mysql.php
+++ b/libraries/joomla/database/exporter/mysql.php
@@ -292,7 +292,7 @@ class JDatabaseExporterMysql extends JDatabaseExporter
 	 */
 	public function withStructure($setting = true)
 	{
-		$this->options->with-structure = (boolean) $setting;
+		$this->options->withStructure = (boolean) $setting;
 
 		return $this;
 	}

--- a/libraries/joomla/database/exporter/postgresql.php
+++ b/libraries/joomla/database/exporter/postgresql.php
@@ -53,7 +53,7 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 	/**
 	 * An array of options for the exporter.
 	 *
-	 * @var    JObject
+	 * @var    object
 	 * @since  12.1
 	 */
 	protected $options = null;
@@ -67,7 +67,7 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 	 */
 	public function __construct()
 	{
-		$this->options = new JObject;
+		$this->options = new stdClass;
 
 		$this->cache = array('columns' => array(), 'keys' => array());
 
@@ -306,7 +306,7 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 	 */
 	public function withStructure($setting = true)
 	{
-		$this->options->set('with-structure', (boolean) $setting);
+		$this->options->with-structure = (boolean) $setting;
 
 		return $this;
 	}

--- a/libraries/joomla/database/exporter/postgresql.php
+++ b/libraries/joomla/database/exporter/postgresql.php
@@ -306,7 +306,7 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 	 */
 	public function withStructure($setting = true)
 	{
-		$this->options->with-structure = (boolean) $setting;
+		$this->options->withStructure = (boolean) $setting;
 
 		return $this;
 	}

--- a/libraries/joomla/database/factory.php
+++ b/libraries/joomla/database/factory.php
@@ -177,24 +177,6 @@ class JDatabaseFactory
 	}
 
 	/**
-	 * Static method to get an instance of a JTable class if it can be found in
-	 * the table include paths.  To add include paths for searching for JTable
-	 * classes @see JTable::addIncludePath().
-	 *
-	 * @param   string  $type    The type (name) of the JTable class to get an instance of.
-	 * @param   string  $prefix  An optional prefix for the table class name.
-	 * @param   array   $config  An optional array of configuration values for the JTable object.
-	 *
-	 * @return  mixed    A JTable object if found or boolean false if one could not be found.
-	 *
-	 * @since   12.1
-	 */
-	public function getTable($type, $prefix = 'JTable', $config = array())
-	{
-		return JTable::getInstance($type, $prefix, $config);
-	}
-
-	/**
 	 * Gets an instance of a factory object to return on subsequent calls of getInstance.
 	 *
 	 * @param   JDatabaseFactory  $instance  A JDatabaseFactory object.

--- a/libraries/joomla/database/importer/mysql.php
+++ b/libraries/joomla/database/importer/mysql.php
@@ -646,7 +646,7 @@ class JDatabaseImporterMysql extends JDatabaseImporter
 	 */
 	public function withStructure($setting = true)
 	{
-		$this->options->with-structure = (boolean) $setting;
+		$this->options->withStructure = (boolean) $setting;
 
 		return $this;
 	}

--- a/libraries/joomla/database/importer/mysql.php
+++ b/libraries/joomla/database/importer/mysql.php
@@ -51,7 +51,7 @@ class JDatabaseImporterMysql extends JDatabaseImporter
 	/**
 	 * An array of options for the exporter.
 	 *
-	 * @var    JObject
+	 * @var    object
 	 * @since  11.1
 	 */
 	protected $options = null;
@@ -65,7 +65,7 @@ class JDatabaseImporterMysql extends JDatabaseImporter
 	 */
 	public function __construct()
 	{
-		$this->options = new JObject;
+		$this->options = new stdClass;
 
 		$this->cache = array('columns' => array(), 'keys' => array());
 
@@ -646,7 +646,7 @@ class JDatabaseImporterMysql extends JDatabaseImporter
 	 */
 	public function withStructure($setting = true)
 	{
-		$this->options->set('with-structure', (boolean) $setting);
+		$this->options->with-structure = (boolean) $setting;
 
 		return $this;
 	}

--- a/libraries/joomla/database/importer/postgresql.php
+++ b/libraries/joomla/database/importer/postgresql.php
@@ -788,7 +788,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 	 */
 	public function withStructure($setting = true)
 	{
-		$this->options->with-structure = (boolean) $setting;
+		$this->options->withStructure = (boolean) $setting;
 
 		return $this;
 	}

--- a/libraries/joomla/database/importer/postgresql.php
+++ b/libraries/joomla/database/importer/postgresql.php
@@ -51,7 +51,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 	/**
 	 * An array of options for the exporter.
 	 *
-	 * @var    JObject
+	 * @var    object
 	 * @since  12.1
 	 */
 	protected $options = null;
@@ -65,7 +65,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 	 */
 	public function __construct()
 	{
-		$this->options = new JObject;
+		$this->options = new stdClass;
 
 		$this->cache = array('columns' => array(), 'keys' => array());
 
@@ -788,7 +788,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 	 */
 	public function withStructure($setting = true)
 	{
-		$this->options->set('with-structure', (boolean) $setting);
+		$this->options->with-structure = (boolean) $setting;
 
 		return $this;
 	}

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Categories
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -13,7 +13,7 @@ defined('JPATH_PLATFORM') or die;
  * JCategories Class.
  *
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Categories
  * @since       11.1
  */
 class JCategories

--- a/libraries/legacy/help/help.php
+++ b/libraries/legacy/help/help.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Language
+ * @subpackage  Help
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -13,7 +13,7 @@ defined('JPATH_PLATFORM') or die;
  * Help system class
  *
  * @package     Joomla.Platform
- * @subpackage  Language
+ * @subpackage  Help
  * @since       11.1
  */
 class JHelp

--- a/libraries/legacy/menu/menu.php
+++ b/libraries/legacy/menu/menu.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Menu
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -13,7 +13,7 @@ defined('JPATH_PLATFORM') or die;
  * JMenu class
  *
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Menu
  * @since       11.1
  */
 class JMenu extends JObject

--- a/libraries/legacy/pathway/pathway.php
+++ b/libraries/legacy/pathway/pathway.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Pathway
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * The user's navigated path within the application.
  *
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Pathway
  * @since       11.1
  */
 class JPathway extends JObject

--- a/libraries/legacy/request/request.php
+++ b/libraries/legacy/request/request.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Environment
+ * @subpackage  Request
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -31,7 +31,7 @@ JLog::add('JRequest is deprecated.', JLog::WARNING, 'deprecated');
  * can be passed through an input filter to avoid injection or returned raw.
  *
  * @package     Joomla.Platform
- * @subpackage  Environment
+ * @subpackage  Request
  * @since       11.1
  * @deprecated  12.1  Get the JInput object from the application instead
  */

--- a/tests/suites/unit/joomla/database/database/JDatabaseExporterMySqlTest.php
+++ b/tests/suites/unit/joomla/database/database/JDatabaseExporterMySqlTest.php
@@ -549,21 +549,21 @@ class JDatabaseExporterMySqlTest extends PHPUnit_Framework_TestCase
 		);
 
 		$this->assertThat(
-			$instance->options->get('with-structure'),
+			$instance->options->withStructure,
 			$this->isTrue(),
 			'The default use of withStructure should result in true.'
 		);
 
 		$instance->withStructure(true);
 		$this->assertThat(
-			$instance->options->get('with-structure'),
+			$instance->options->withStructure,
 			$this->isTrue(),
 			'The explicit use of withStructure with true should result in true.'
 		);
 
 		$instance->withStructure(false);
 		$this->assertThat(
-			$instance->options->get('with-structure'),
+			$instance->options->withStructure,
 			$this->isFalse(),
 			'The explicit use of withStructure with false should result in false.'
 		);

--- a/tests/suites/unit/joomla/database/database/JDatabaseExporterPostgresqlTest.php
+++ b/tests/suites/unit/joomla/database/database/JDatabaseExporterPostgresqlTest.php
@@ -649,21 +649,21 @@ class JDatabaseExporterPostgresqlTest extends PHPUnit_Framework_TestCase
 		);
 
 		$this->assertThat(
-			$instance->options->get('with-structure'),
+			$instance->options->withStructure,
 			$this->isTrue(),
 			'The default use of withStructure should result in true.'
 		);
 
 		$instance->withStructure(true);
 		$this->assertThat(
-			$instance->options->get('with-structure'),
+			$instance->options->withStructure,
 			$this->isTrue(),
 			'The explicit use of withStructure with true should result in true.'
 		);
 
 		$instance->withStructure(false);
 		$this->assertThat(
-			$instance->options->get('with-structure'),
+			$instance->options->withStructure,
 			$this->isFalse(),
 			'The explicit use of withStructure with false should result in false.'
 		);

--- a/tests/suites/unit/joomla/database/database/JDatabaseImporterMySqlTest.php
+++ b/tests/suites/unit/joomla/database/database/JDatabaseImporterMySqlTest.php
@@ -825,21 +825,21 @@ class JDatabaseImporterMySqlTest extends PHPUnit_Framework_TestCase
 		);
 
 		$this->assertThat(
-			$instance->options->get('with-structure'),
+			$instance->options->withStructure,
 			$this->isTrue(),
 			'The default use of withStructure should result in true.'
 		);
 
 		$instance->withStructure(true);
 		$this->assertThat(
-			$instance->options->get('with-structure'),
+			$instance->options->withStructure,
 			$this->isTrue(),
 			'The explicit use of withStructure with true should result in true.'
 		);
 
 		$instance->withStructure(false);
 		$this->assertThat(
-			$instance->options->get('with-structure'),
+			$instance->options->withStructure,
 			$this->isFalse(),
 			'The explicit use of withStructure with false should result in false.'
 		);

--- a/tests/suites/unit/joomla/database/database/JDatabaseImporterPostgresqlTest.php
+++ b/tests/suites/unit/joomla/database/database/JDatabaseImporterPostgresqlTest.php
@@ -1036,21 +1036,21 @@ class JDatabaseImporterPostgresqlTest extends PHPUnit_Framework_TestCase
 		);
 
 		$this->assertThat(
-			$instance->options->get('with-structure'),
+			$instance->options->withStructure,
 			$this->isTrue(),
 			'The default use of withStructure should result in true.'
 		);
 
 		$instance->withStructure(true);
 		$this->assertThat(
-			$instance->options->get('with-structure'),
+			$instance->options->withStructure,
 			$this->isTrue(),
 			'The explicit use of withStructure with true should result in true.'
 		);
 
 		$instance->withStructure(false);
 		$this->assertThat(
-			$instance->options->get('with-structure'),
+			$instance->options->withStructure,
 			$this->isFalse(),
 			'The explicit use of withStructure with false should result in false.'
 		);


### PR DESCRIPTION
Classes the dependency on is removed:
JError
JObject
JFolder
JTable

The JTable one may be a bit controversial since it meant I had to remove JDatabaseFactory::getTable() but considering it's just a proxy for JTable::getInstance() I don't see it as being worth adding an additional dependency - especially considering that the table package has it's own very large set of dependencies.

I also made JDatabaseException a subclass of RuntimeException. This way catching RuntimeExceptions (which are now used in the database package) will also catch JDatabaseExceptions.
