### PR TITLE
Add optional identity to JApplicationBase; make dependency injection more flexible in JApplicationWeb

### DIFF
--- a/libraries/joomla/application/base.php
+++ b/libraries/joomla/application/base.php
@@ -51,6 +51,7 @@ abstract class JApplicationBase extends JObject
 	 *
 	 * @return  void
 	 *
+	 * @codeCoverageIgnore
 	 * @since   12.1
 	 */
 	public function close($code = 0)

--- a/libraries/joomla/application/base.php
+++ b/libraries/joomla/application/base.php
@@ -21,20 +21,28 @@ jimport('joomla.event.dispatcher');
 abstract class JApplicationBase extends JObject
 {
 	/**
-	 * The application input object.
-	 *
-	 * @var    JInput
-	 * @since  12.1
-	 */
-	public $input = null;
-
-	/**
 	 * The application dispatcher object.
 	 *
 	 * @var    JDispatcher
 	 * @since  12.1
 	 */
 	protected $dispatcher;
+
+	/**
+	 * The application identity object.
+	 *
+	 * @var    JUser
+	 * @since  12.1
+	 */
+	protected $identity;
+
+	/**
+	 * The application input object.
+	 *
+	 * @var    JInput
+	 * @since  12.1
+	 */
+	public $input = null;
 
 	/**
 	 * Method to close the application.
@@ -91,16 +99,42 @@ abstract class JApplicationBase extends JObject
 	}
 
 	/**
-	 * Method to create an event dispatcher for the application. The logic and options for creating
-	 * this object are adequately generic for default cases but for many applications it will make
-	 * sense to override this method and create event dispatchers based on more specific needs.
+	 * Allows the application to load a custom or default dispatcher.
 	 *
-	 * @return  void
+	 * The logic and options for creating this object are adequately generic for default cases
+	 * but for many applications it will make sense to override this method and create event
+	 * dispatchers, if required, based on more specific needs.
+	 *
+	 * @param   JDispatcher  $dispatcher  An optional dispatcher object. If omitted, the factory dispatcher is created.
+	 *
+	 * @return  JApplicationBase This method is chainable.
 	 *
 	 * @since   12.1
 	 */
-	protected function loadDispatcher()
+	public function loadDispatcher(JDispatcher $dispatcher = null)
 	{
-		$this->dispatcher = JDispatcher::getInstance();
+		$this->dispatcher = ($dispatcher === null) ? JDispatcher::getInstance() : $dispatcher;
+
+		return $this;
+	}
+
+	/**
+	 * Allows the application to load a custom or default identity.
+	 *
+	 * The logic and options for creating this object are adequately generic for default cases
+	 * but for many applications it will make sense to override this method and create an identity,
+	 * if required, based on more specific needs.
+	 *
+	 * @param   JUser  $identity  An optional identity object. If omitted, the factory user is created.
+	 *
+	 * @return  JApplicationBase This method is chainable.
+	 *
+	 * @since   12.1
+	 */
+	public function loadIdentity(JUser $identity = null)
+	{
+		$this->identity = ($identity === null) ? JFactory::getUser() : $identity;
+
+		return $this;
 	}
 }

--- a/libraries/joomla/application/cli.php
+++ b/libraries/joomla/application/cli.php
@@ -82,16 +82,7 @@ class JApplicationCli extends JApplicationBase
 			$this->config = new JRegistry;
 		}
 
-		// If a dispatcher object is given use it.
-		if ($dispatcher instanceof JDispatcher)
-		{
-			$this->dispatcher = $dispatcher;
-		}
-		// Create the dispatcher based on the application logic.
-		else
-		{
-			$this->loadDispatcher();
-		}
+		$this->loadDispatcher($dispatcher);
 
 		// Load the configuration object.
 		$this->loadConfiguration($this->fetchConfigurationData());

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -201,6 +201,7 @@ class JApplicationWeb extends JApplicationBase
 	 *
 	 * @return  JApplicationWeb  Instance of $this to allow chaining.
 	 *
+	 * @deprecated  13.1
 	 * @see     loadSession()
 	 * @see     loadDocument()
 	 * @see     loadLanguage()
@@ -209,64 +210,25 @@ class JApplicationWeb extends JApplicationBase
 	 */
 	public function initialise($session = null, $document = null, $language = null, $dispatcher = null)
 	{
-		// If a session object is given use it.
-		if ($session instanceof JSession)
-		{
-			$this->session = $session;
-		}
-		// We don't have a session, nor do we want one.
-		elseif ($session === false)
-		{
-			// Do nothing.
-		}
 		// Create the session based on the application logic.
-		else
+		if ($session !== false)
 		{
-			$this->loadSession();
+			$this->loadSession($session);
 		}
 
-		// If a document object is given use it.
-		if ($document instanceof JDocument)
-		{
-			$this->document = $document;
-		}
-		// We don't have a document, nor do we want one.
-		elseif ($document === false)
-		{
-			// Do nothing.
-		}
 		// Create the document based on the application logic.
-		else
+		if ($document !== false)
 		{
-			$this->loadDocument();
+			$this->loadDocument($document);
 		}
 
-		// If a language object is given use it.
-		if ($language instanceof JLanguage)
-		{
-			$this->language = $language;
-		}
-		// We don't have a language, nor do we want one.
-		elseif ($language === false)
-		{
-			// Do nothing.
-		}
 		// Create the language based on the application logic.
-		else
+		if ($language !== false)
 		{
-			$this->loadLanguage();
+			$this->loadLanguage($language);
 		}
 
-		// If a dispatcher object is given use it.
-		if ($dispatcher instanceof JDispatcher)
-		{
-			$this->dispatcher = $dispatcher;
-		}
-		// Create the dispatcher based on the application logic.
-		else
-		{
-			$this->loadDispatcher();
-		}
+		$this->loadDispatcher($dispatcher);
 
 		return $this;
 	}
@@ -1003,44 +965,67 @@ class JApplicationWeb extends JApplicationBase
 	}
 
 	/**
-	 * Method to create a document for the Web application.  The logic and options for creating this
-	 * object are adequately generic for default cases but for many applications it will make sense
-	 * to override this method and create document objects based on more specific needs.
+	 * Allows the application to load a custom or default document.
 	 *
-	 * @return  void
+	 * The logic and options for creating this object are adequately generic for default cases
+	 * but for many applications it will make sense to override this method and create a document,
+	 * if required, based on more specific needs.
+	 *
+	 * @param   JDocument  $document  An optional document object. If omitted, the factory document is created.
+	 *
+	 * @return  JApplicationWeb This method is chainable.
 	 *
 	 * @since   11.3
 	 */
-	protected function loadDocument()
+	public function loadDocument(JDocument $document = null)
 	{
-		$this->document = JFactory::getDocument();
+		$this->document = ($document === null) ? JFactory::getDocument() : $document;
+
+		return $this;
 	}
 
 	/**
-	 * Method to create a language for the Web application.  The logic and options for creating this
-	 * object are adequately generic for default cases but for many applications it will make sense
-	 * to override this method and create language objects based on more specific needs.
+	 * Allows the application to load a custom or default document.
 	 *
-	 * @return  void
+	 * The logic and options for creating this object are adequately generic for default cases
+	 * but for many applications it will make sense to override this method and create an language,
+	 * if required, based on more specific needs.
+	 *
+	 * @param   JLanguage  $language  An optional language object. If omitted, the factory language is created.
+	 *
+	 * @return  JApplicationWeb This method is chainable.
 	 *
 	 * @since   11.3
 	 */
-	protected function loadLanguage()
+	public function loadLanguage(JLanguage $language = null)
 	{
-		$this->language = JFactory::getLanguage();
+		$this->language = ($language === null) ? JFactory::getLanguage() : $language;
+
+		return $this;
 	}
 
 	/**
-	 * Method to create a session for the Web application.  The logic and options for creating this
-	 * object are adequately generic for default cases but for many applications it will make sense
-	 * to override this method and create session objects based on more specific needs.
+	 * Allows the application to load a custom or default document.
 	 *
-	 * @return  void
+	 * The logic and options for creating this object are adequately generic for default cases
+	 * but for many applications it will make sense to override this method and create a session,
+	 * if required, based on more specific needs.
+	 *
+	 * @param   JSession  $session  An optional session object. If omitted, the session is created.
+	 *
+	 * @return  JApplicationWeb This method is chainable.
 	 *
 	 * @since   11.3
 	 */
-	protected function loadSession()
+	protected function loadSession(JSession $session)
 	{
+		if ($session !== null)
+		{
+			$this->session = $session;
+
+			return $this;
+		}
+
 		// Generate a session name.
 		$name = md5($this->get('secret') . $this->get('session_name', get_class($this)));
 
@@ -1073,6 +1058,8 @@ class JApplicationWeb extends JApplicationBase
 
 		// Set the session object.
 		$this->session = $session;
+
+		return $this;
 	}
 
 	/**

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -1017,7 +1017,7 @@ class JApplicationWeb extends JApplicationBase
 	 *
 	 * @since   11.3
 	 */
-	protected function loadSession(JSession $session)
+	protected function loadSession(JSession $session = null)
 	{
 		if ($session !== null)
 		{

--- a/tests/suites/unit/joomla/application/JApplicationBaseTest.php
+++ b/tests/suites/unit/joomla/application/JApplicationBaseTest.php
@@ -21,7 +21,7 @@ class JApplicationBaseTest extends TestCase
 	/**
 	 * An instance of the object to test.
 	 *
-	 * @var    JApplicationCliInspector
+	 * @var    JApplicationBaseInspector
 	 * @since  11.3
 	 */
 	protected $class;
@@ -37,7 +37,7 @@ class JApplicationBaseTest extends TestCase
 	{
 		parent::setUp();
 
-		// Get a new JApplicationBaseInspector instance.
+		// Create the class object to be tested.
 		$this->class = new JApplicationBaseInspector;
 	}
 
@@ -67,10 +67,7 @@ class JApplicationBaseTest extends TestCase
 	 */
 	public function testLoadDispatcher()
 	{
-		// Inject the mock dispatcher into the JDispatcher singleton.
-		TestReflection::setValue('JDispatcher', 'instance', $this->getMockDispatcher());
-
-		TestReflection::invoke($this->class, 'loadDispatcher');
+		$this->class->loadDispatcher($this->getMockDispatcher());
 
 		$this->assertAttributeInstanceOf(
 			'JDispatcher',
@@ -79,7 +76,38 @@ class JApplicationBaseTest extends TestCase
 			'Tests that the dispatcher object is the correct class.'
 		);
 
-		$this->assertEquals('ok', TestReflection::getValue($this->class, 'dispatcher')->test(), 'Tests that we got the dispatcher from the factory.');
+		// Inject a mock value into the JDispatcher singleton.
+		TestReflection::setValue('JDispatcher', 'instance', 'foo');
+		$this->class->loadDispatcher();
+
+		$this->assertEquals('foo', TestReflection::getValue($this->class, 'dispatcher'), 'Tests that we got the dispatcher from the factory.');
+	}
+
+	/**
+	 * Tests the JApplicationBase::loadIdentity method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 * @covers  JApplicationBase::loadIdentity
+	 */
+	public function testLoadIdentity()
+	{
+		$this->class->loadIdentity($this->getMock('JUser', array(), array(), '', false));
+
+		$this->assertAttributeInstanceOf(
+			'JUser',
+			'identity',
+			$this->class,
+			'Tests that the identity object is the correct class.'
+		);
+
+		// Mock the session.
+		JFactory::$session = $this->getMockSession(array('get.user.id' => 99));
+
+		$this->class->loadIdentity();
+
+		$this->assertEquals(99, TestReflection::getValue($this->class, 'identity')->get('id'), 'Tests that we got the identity from the factory.');
 	}
 
 	/**

--- a/tests/suites/unit/joomla/application/JApplicationWebTest.php
+++ b/tests/suites/unit/joomla/application/JApplicationWebTest.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
-include_once __DIR__.'/stubs/JApplicationWebInspector.php';
+include_once __DIR__ . '/stubs/JApplicationWebInspector.php';
 
 /**
  * Test class for JApplicationWeb.
@@ -1106,18 +1106,6 @@ class JApplicationWebTest extends TestCase
 	}
 
 	/**
-	 * Tests the JApplicationWeb::loadDispatcher method.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.3
-	 */
-	public function testLoadDispatcher()
-	{
-		$this->markTestIncomplete();
-	}
-
-	/**
 	 * Tests the JApplicationWeb::loadDocument method.
 	 *
 	 * @return  void
@@ -1129,7 +1117,7 @@ class JApplicationWebTest extends TestCase
 		// Inject the mock dispatcher into the JDispatcher singleton.
 		TestReflection::setValue('JDispatcher', 'instance', $this->getMockDispatcher());
 
-		TestReflection::invoke($this->class, 'loadDocument');
+		$this->class->loadDocument();
 
 		$this->assertInstanceOf(
 			'JDocument',
@@ -1153,7 +1141,7 @@ class JApplicationWebTest extends TestCase
 	 */
 	public function testLoadLanguage()
 	{
-		TestReflection::invoke($this->class, 'loadLanguage');
+		$this->class->loadLanguage();
 
 		$this->assertInstanceOf(
 			'JLanguage',

--- a/tests/suites/unit/joomla/application/stubs/JApplicationBaseInspector.php
+++ b/tests/suites/unit/joomla/application/stubs/JApplicationBaseInspector.php
@@ -17,4 +17,5 @@
  */
 class JApplicationBaseInspector extends JApplicationBase
 {
+	// Required because JApplicationBase is abstract.
 }


### PR DESCRIPTION
Add optional "identity" has been added to JApplicationBase. This is in preparation for being able to support applications that act as web services, or connect with other web services that need to have some sort of identity (most probably a user but other cases are possible).  The loadDispatcher method has been made public and a new loadIdentity method (coupled, for now, to JUser) has been added.  If the application needs either of these dependancies, it simply calls the loader.  Passing no argument loads a default object but dependency injection is allowed by passing an object to the method.  If neither is called, then no dispatcher or identity support is assumed.

The initialise method in JApplicationWeb has been deprecated in favour of making the loadDocument, loadLanguage and loadSession public which allows for better scaling for more optional dependancies in the future. The tri-state behaviour is the same as for the loaders in JApplicationBase.  No call means the object is not supported, a call without argument loads a default object and a call with an argument injects the object into the application.

All dependency loaders are chainable.
