### PR TITLE
JText the database connectors in the form field

### DIFF
--- a/libraries/joomla/form/fields/databaseconnection.php
+++ b/libraries/joomla/form/fields/databaseconnection.php
@@ -62,7 +62,7 @@ class JFormFieldDatabaseConnection extends JFormFieldList
 			{
 				if (in_array($support, $available))
 				{
-					$options[$support] = ucfirst($support);
+					$options[$support] = JText::_(ucfirst($support));
 				}
 			}
 		}
@@ -70,7 +70,7 @@ class JFormFieldDatabaseConnection extends JFormFieldList
 		{
 			foreach ($available as $support)
 			{
-				$options[$support] = ucfirst($support);
+				$options[$support] = JText::_(ucfirst($support));
 			}
 		}
 


### PR DESCRIPTION
This allows downstream applications to use a text string for the database options when using the Database Connection form field.  For example, currently when installing the CMS, the option for SQL Server is displayed as "Sqlsrv".  With this change, a language string `SQLSRV="SQL Server"` could be used instead to avoid the use of shorthand driver names.  Of course, if an application decides they don't want to use this feature, then they won't need to with the way the language key is set up.
