### PR TITLE
CMS Separation: Check if CMS constants are defined

### DIFF
--- a/libraries/joomla/environment/uri.php
+++ b/libraries/joomla/environment/uri.php
@@ -226,9 +226,12 @@ class JURI
 				self::$base['prefix'] = $uri->toString(array('scheme', 'host', 'port'));
 				self::$base['path'] = rtrim($uri->toString(array('path')), '/\\');
 
-				if (JPATH_BASE == JPATH_ADMINISTRATOR)
+				if (defined('JPATH_BASE') && defined('JPATH_ADMINISTRATOR'))
 				{
-					self::$base['path'] .= '/administrator';
+					if (JPATH_BASE == JPATH_ADMINISTRATOR)
+					{
+						self::$base['path'] .= '/administrator';
+					}
 				}
 			}
 			else


### PR DESCRIPTION
For now, this would be helpful when using JURI outside of the CMS. 

(Later, passing in the application path will be helpful)
