### PR TITLE
Table Package: db error and Exception/JText changes

### DIFF
--- a/libraries/joomla/table/asset.php
+++ b/libraries/joomla/table/asset.php
@@ -87,12 +87,7 @@ class JTableAsset extends JTableNested
 		{
 			return false;
 		}
-		// Check for a database error.
-		if ($error = $this->_db->getErrorMsg())
-		{
-			$this->setError($error);
-			return false;
-		}
+
 		return $this->load($assetId);
 	}
 
@@ -124,14 +119,7 @@ class JTableAsset extends JTableNested
 			}
 			else
 			{
-				if ($error = $this->_db->getErrorMsg())
-				{
-					$this->setError($error);
-				}
-				else
-				{
-					$this->setError(JText::_('JLIB_DATABASE_ERROR_INVALID_PARENT_ID'));
-				}
+				$this->setError('Invalid Parent ID');
 				return false;
 			}
 		}

--- a/libraries/joomla/table/extension.php
+++ b/libraries/joomla/table/extension.php
@@ -168,13 +168,6 @@ class JTableExtension extends JTable
 		$this->_db->setQuery($query);
 		$this->_db->execute();
 
-		// Check for a database error.
-		if ($this->_db->getErrorNum())
-		{
-			$this->setError($this->_db->getErrorMsg());
-			return false;
-		}
-
 		// If checkin is supported and all rows were adjusted, check them in.
 		if ($checkin && (count($pks) == $this->_db->getAffectedRows()))
 		{

--- a/libraries/joomla/table/menutype.php
+++ b/libraries/joomla/table/menutype.php
@@ -134,11 +134,7 @@ class JTableMenuType extends JTable
 			$query->set('menutype=' . $this->_db->quote($this->menutype));
 			$query->where('menutype=' . $this->_db->quote($table->menutype));
 			$this->_db->setQuery($query);
-			if (!$this->_db->execute())
-			{
-				$this->setError(JText::sprintf('JLIB_DATABASE_ERROR_STORE_FAILED', get_class($this), $this->_db->getErrorMsg()));
-				return false;
-			}
+			$this->_db->execute();
 
 			// Update the module items
 			$query = $this->_db->getQuery(true);
@@ -150,11 +146,7 @@ class JTableMenuType extends JTable
 			$query->where('module=' . $this->_db->quote('mod_menu'));
 			$query->where('params LIKE ' . $this->_db->quote('%"menutype":' . json_encode($table->menutype) . '%'));
 			$this->_db->setQuery($query);
-			if (!$this->_db->execute())
-			{
-				$this->setError(JText::sprintf('JLIB_DATABASE_ERROR_STORE_FAILED', get_class($this), $this->_db->getErrorMsg()));
-				return false;
-			}
+			$this->_db->execute();
 		}
 		return parent::store($updateNulls);
 	}
@@ -221,11 +213,7 @@ class JTableMenuType extends JTable
 			$query->where('menutype=' . $this->_db->quote($table->menutype));
 			$query->where('client_id=0');
 			$this->_db->setQuery($query);
-			if (!$this->_db->execute())
-			{
-				$this->setError(JText::sprintf('JLIB_DATABASE_ERROR_DELETE_FAILED', get_class($this), $this->_db->getErrorMsg()));
-				return false;
-			}
+			$this->_db->execute();
 
 			// Update the module items
 			$query = $this->_db->getQuery(true);
@@ -234,11 +222,7 @@ class JTableMenuType extends JTable
 			$query->where('module=' . $this->_db->quote('mod_menu'));
 			$query->where('params LIKE ' . $this->_db->quote('%"menutype":' . json_encode($table->menutype) . '%'));
 			$this->_db->setQuery($query);
-			if (!$this->_db->execute())
-			{
-				$this->setError(JText::sprintf('JLIB_DATABASE_ERROR_DELETE_FAILED', get_class($this), $this->_db->getErrorMsg()));
-				return false;
-			}
+			$this->_db->execute();
 		}
 		return parent::delete($pk);
 	}

--- a/libraries/joomla/table/session.php
+++ b/libraries/joomla/table/session.php
@@ -189,14 +189,7 @@ class JTableSession extends JTable
 		$query->where($this->_db->quoteName($this->_tbl_key) . ' = ' . $this->_db->quote($this->$k));
 		$this->_db->setQuery($query);
 
-		if ($this->_db->execute())
-		{
-			return true;
-		}
-		else
-		{
-			$this->setError($this->_db->getErrorMsg());
-			return false;
-		}
+		$this->_db->execute();
+		return true;
 	}
 }

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -131,6 +131,7 @@ abstract class JTable extends JObject
 	 * @return  mixed  An array of the field names, or false if an error occurs.
 	 *
 	 * @since   11.1
+	 * @throws  UnexpectedValueException
 	 */
 	public function getFields()
 	{
@@ -144,9 +145,7 @@ abstract class JTable extends JObject
 
 			if (empty($fields))
 			{
-				$e = new JException(JText::_('JLIB_DATABASE_ERROR_COLUMNS_NOT_FOUND'));
-				$this->setError($e);
-				return false;
+				throw new UnexpectedValueException(sprintf('No columns found for %s table', $name));
 			}
 			$cache = $fields;
 		}
@@ -426,15 +425,14 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/bind
 	 * @since   11.1
+	 * @throws  UnexpectedValueException
 	 */
 	public function bind($src, $ignore = array())
 	{
 		// If the source value is not an array or object return false.
 		if (!is_object($src) && !is_array($src))
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_BIND_FAILED_INVALID_SOURCE_ARGUMENT', get_class($this)));
-			$this->setError($e);
-			return false;
+			throw new UnexpectedValueException(sprintf('%s: :bind failed. Invalid source argument.', get_class($this)));
 		}
 
 		// If the source value is an object, get its accessible properties.
@@ -477,6 +475,8 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/load
 	 * @since   11.1
+	 * @throws  RuntimeException
+	 * @throws  UnexpectedValueException
 	 */
 	public function load($keys = null, $reset = true)
 	{
@@ -516,9 +516,7 @@ abstract class JTable extends JObject
 			// Check that $field is in the table.
 			if (!in_array($field, $fields))
 			{
-				$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_CLASS_IS_MISSING_FIELD', get_class($this), $field));
-				$this->setError($e);
-				return false;
+				throw new UnexpectedValueException(sprintf('Missing field in the database: %s &#160; %s.', get_class($this), $field));
 			}
 			// Add the search tuple to the query.
 			$query->where($this->_db->quoteName($field) . ' = ' . $this->_db->quote($value));
@@ -526,32 +524,12 @@ abstract class JTable extends JObject
 
 		$this->_db->setQuery($query);
 
-		try
-		{
-			$row = $this->_db->loadAssoc();
-		}
-		catch (RuntimeException $e)
-		{
-			$je = new JException($e->getMessage());
-			$this->setError($je);
-			return false;
-		}
-
-		// Legacy error handling switch based on the JError::$legacy switch.
-		// @deprecated  12.1
-		if (JError::$legacy && $this->_db->getErrorNum())
-		{
-			$e = new JException($this->_db->getErrorMsg());
-			$this->setError($e);
-			return false;
-		}
+		$row = $this->_db->loadAssoc();
 
 		// Check that we have a result.
 		if (empty($row))
 		{
-			$e = new JException(JText::_('JLIB_DATABASE_ERROR_EMPTY_ROW_RETURNED'));
-			$this->setError($e);
-			return false;
+			throw new RuntimeException('The database row is empty.');
 		}
 
 		// Bind the object with the row and return.
@@ -602,19 +580,11 @@ abstract class JTable extends JObject
 		// If a primary key exists update the object, otherwise insert it.
 		if ($this->$k)
 		{
-			$stored = $this->_db->updateObject($this->_tbl, $this, $this->_tbl_key, $updateNulls);
+			$this->_db->updateObject($this->_tbl, $this, $this->_tbl_key, $updateNulls);
 		}
 		else
 		{
-			$stored = $this->_db->insertObject($this->_tbl, $this, $this->_tbl_key);
-		}
-
-		// If the store failed return false.
-		if (!$stored)
-		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_STORE_FAILED', get_class($this), $this->_db->getErrorMsg()));
-			$this->setError($e);
-			return false;
+			$this->_db->insertObject($this->_tbl, $this, $this->_tbl_key);
 		}
 
 		// If the table is not set to track assets return true.
@@ -683,12 +653,7 @@ abstract class JTable extends JObject
 			$query->where($this->_db->quoteName($k) . ' = ' . (int) $this->$k);
 			$this->_db->setQuery($query);
 
-			if (!$this->_db->execute())
-			{
-				$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_STORE_FAILED_UPDATE_ASSET_ID', $this->_db->getErrorMsg()));
-				$this->setError($e);
-				return false;
-			}
+			$this->_db->execute();
 		}
 
 		return true;
@@ -760,6 +725,7 @@ abstract class JTable extends JObject
 	 *
 	 * @link	http://docs.joomla.org/JTable/delete
 	 * @since   11.1
+	 * @throws  UnexpectedValueException
 	 */
 	public function delete($pk = null)
 	{
@@ -770,9 +736,7 @@ abstract class JTable extends JObject
 		// If no primary key is given, return false.
 		if ($pk === null)
 		{
-			$e = new JException(JText::_('JLIB_DATABASE_ERROR_NULL_PRIMARY_KEY'));
-			$this->setError($e);
-			return false;
+			throw new UnexpectedValueException('Null primary key not allowed.');
 		}
 
 		// If tracking assets, remove the asset first.
@@ -806,12 +770,7 @@ abstract class JTable extends JObject
 		$this->_db->setQuery($query);
 
 		// Check for a database error.
-		if (!$this->_db->execute())
-		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_DELETE_FAILED', get_class($this), $this->_db->getErrorMsg()));
-			$this->setError($e);
-			return false;
-		}
+		$this->_db->execute();
 
 		return true;
 	}
@@ -848,9 +807,7 @@ abstract class JTable extends JObject
 		// If no primary key is given, return false.
 		if ($pk === null)
 		{
-			$e = new JException(JText::_('JLIB_DATABASE_ERROR_NULL_PRIMARY_KEY'));
-			$this->setError($e);
-			return false;
+			throw new UnexpectedValueException('Null primary key not allowed.');
 		}
 
 		// Get the current time in MySQL format.
@@ -863,13 +820,7 @@ abstract class JTable extends JObject
 		$query->set($this->_db->quoteName('checked_out_time') . ' = ' . $this->_db->quote($time));
 		$query->where($this->_tbl_key . ' = ' . $this->_db->quote($pk));
 		$this->_db->setQuery($query);
-
-		if (!$this->_db->execute())
-		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_CHECKOUT_FAILED', get_class($this), $this->_db->getErrorMsg()));
-			$this->setError($e);
-			return false;
-		}
+		$this->_db->execute();
 
 		// Set table values in the object.
 		$this->checked_out = (int) $userId;
@@ -904,9 +855,7 @@ abstract class JTable extends JObject
 		// If no primary key is given, return false.
 		if ($pk === null)
 		{
-			$e = new JException(JText::_('JLIB_DATABASE_ERROR_NULL_PRIMARY_KEY'));
-			$this->setError($e);
-			return false;
+			throw new UnexpectedValueException('Null primary key not allowed.');
 		}
 
 		// Check the row in by primary key.
@@ -918,12 +867,7 @@ abstract class JTable extends JObject
 		$this->_db->setQuery($query);
 
 		// Check for a database error.
-		if (!$this->_db->execute())
-		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_CHECKIN_FAILED', get_class($this), $this->_db->getErrorMsg()));
-			$this->setError($e);
-			return false;
-		}
+		$this->_db->execute();
 
 		// Set table values in the object.
 		$this->checked_out = 0;
@@ -966,14 +910,7 @@ abstract class JTable extends JObject
 		$query->set($this->_db->quoteName('hits') . ' = (' . $this->_db->quoteName('hits') . ' + 1)');
 		$query->where($this->_tbl_key . ' = ' . $this->_db->quote($pk));
 		$this->_db->setQuery($query);
-
-		// Check for a database error.
-		if (!$this->_db->execute())
-		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_HIT_FAILED', get_class($this), $this->_db->getErrorMsg()));
-			$this->setError($e);
-			return false;
-		}
+		$this->_db->execute();
 
 		// Set table values in the object.
 		$this->hits++;
@@ -1035,9 +972,7 @@ abstract class JTable extends JObject
 		// If there is no ordering field set an error and return false.
 		if (!property_exists($this, 'ordering'))
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_CLASS_DOES_NOT_SUPPORT_ORDERING', get_class($this)));
-			$this->setError($e);
-			return false;
+			throw new UnexpectedValueException(sprintf('%s does not support ordering.', get_class($this)));
 		}
 
 		// Get the largest ordering value for a given where clause.
@@ -1052,15 +987,6 @@ abstract class JTable extends JObject
 
 		$this->_db->setQuery($query);
 		$max = (int) $this->_db->loadResult();
-
-		// Check for a database error.
-		if ($this->_db->getErrorNum())
-		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_GET_NEXT_ORDER_FAILED', get_class($this), $this->_db->getErrorMsg()));
-			$this->setError($e);
-
-			return false;
-		}
 
 		// Return the largest ordering value + 1.
 		return ($max + 1);
@@ -1082,7 +1008,7 @@ abstract class JTable extends JObject
 		// If there is no ordering field set an error and return false.
 		if (!property_exists($this, 'ordering'))
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_CLASS_DOES_NOT_SUPPORT_ORDERING', get_class($this)));
+			throw new UnexpectedValueException(sprintf('%s does not support ordering.', get_class($this)));
 			$this->setError($e);
 			return false;
 		}
@@ -1106,15 +1032,6 @@ abstract class JTable extends JObject
 		$this->_db->setQuery($query);
 		$rows = $this->_db->loadObjectList();
 
-		// Check for a database error.
-		if ($this->_db->getErrorNum())
-		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_REORDER_FAILED', get_class($this), $this->_db->getErrorMsg()));
-			$this->setError($e);
-
-			return false;
-		}
-
 		// Compact the ordering values.
 		foreach ($rows as $i => $row)
 		{
@@ -1130,17 +1047,7 @@ abstract class JTable extends JObject
 					$query->set('ordering = ' . ($i + 1));
 					$query->where($this->_tbl_key . ' = ' . $this->_db->quote($row->$k));
 					$this->_db->setQuery($query);
-
-					// Check for a database error.
-					if (!$this->_db->execute())
-					{
-						$e = new JException(
-							JText::sprintf('JLIB_DATABASE_ERROR_REORDER_UPDATE_ROW_FAILED', get_class($this), $i, $this->_db->getErrorMsg())
-						);
-						$this->setError($e);
-
-						return false;
-					}
+					$this->_db->execute();
 				}
 			}
 		}
@@ -1160,15 +1067,14 @@ abstract class JTable extends JObject
 	 *
 	 * @link    http://docs.joomla.org/JTable/move
 	 * @since   11.1
+	 * @throws  UnexpectedValueException
 	 */
 	public function move($delta, $where = '')
 	{
 		// If there is no ordering field set an error and return false.
 		if (!property_exists($this, 'ordering'))
 		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_CLASS_DOES_NOT_SUPPORT_ORDERING', get_class($this)));
-			$this->setError($e);
-			return false;
+			throw new UnexpectedValueException(sprintf('%s does not support ordering.', get_class($this)));
 		}
 
 		// If the change is none, do nothing.
@@ -1218,15 +1124,7 @@ abstract class JTable extends JObject
 			$query->set('ordering = ' . (int) $row->ordering);
 			$query->where($this->_tbl_key . ' = ' . $this->_db->quote($this->$k));
 			$this->_db->setQuery($query);
-
-			// Check for a database error.
-			if (!$this->_db->execute())
-			{
-				$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_MOVE_FAILED', get_class($this), $this->_db->getErrorMsg()));
-				$this->setError($e);
-
-				return false;
-			}
+			$this->_db->execute();
 
 			// Update the ordering field for the row to this instance's ordering value.
 			$query = $this->_db->getQuery(true);
@@ -1234,15 +1132,7 @@ abstract class JTable extends JObject
 			$query->set('ordering = ' . (int) $this->ordering);
 			$query->where($this->_tbl_key . ' = ' . $this->_db->quote($row->$k));
 			$this->_db->setQuery($query);
-
-			// Check for a database error.
-			if (!$this->_db->execute())
-			{
-				$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_MOVE_FAILED', get_class($this), $this->_db->getErrorMsg()));
-				$this->setError($e);
-
-				return false;
-			}
+			$this->_db->execute();
 
 			// Update the instance value.
 			$this->ordering = $row->ordering;
@@ -1255,15 +1145,7 @@ abstract class JTable extends JObject
 			$query->set('ordering = ' . (int) $this->ordering);
 			$query->where($this->_tbl_key . ' = ' . $this->_db->quote($this->$k));
 			$this->_db->setQuery($query);
-
-			// Check for a database error.
-			if (!$this->_db->execute())
-			{
-				$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_MOVE_FAILED', get_class($this), $this->_db->getErrorMsg()));
-				$this->setError($e);
-
-				return false;
-			}
+			$this->_db->execute();
 		}
 
 		return true;
@@ -1303,10 +1185,7 @@ abstract class JTable extends JObject
 			// Nothing to set publishing state on, return false.
 			else
 			{
-				$e = new JException(JText::_('JLIB_DATABASE_ERROR_NO_ROWS_SELECTED'));
-				$this->setError($e);
-
-				return false;
+				throw new UnexpectedValueException('No rows selected for publishing state');
 			}
 		}
 
@@ -1330,15 +1209,7 @@ abstract class JTable extends JObject
 		$query->where($k . ' = ' . implode(' OR ' . $k . ' = ', $pks));
 
 		$this->_db->setQuery($query);
-
-		// Check for a database error.
-		if (!$this->_db->execute())
-		{
-			$e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_PUBLISH_FAILED', get_class($this), $this->_db->getErrorMsg()));
-			$this->setError($e);
-
-			return false;
-		}
+		$this->_db->execute();
 
 		// If checkin is supported and all rows were adjusted, check them in.
 		if ($checkin && (count($pks) == $this->_db->getAffectedRows()))

--- a/libraries/joomla/table/user.php
+++ b/libraries/joomla/table/user.php
@@ -83,17 +83,11 @@ class JTableUser extends JTable
 		$this->_db->setQuery($query);
 		$data = (array) $this->_db->loadAssoc();
 
-		// Check for an error message.
-		if ($this->_db->getErrorNum())
-		{
-			$this->setError($this->_db->getErrorMsg());
-			return false;
-		}
-
 		if (!count($data))
 		{
 			return false;
 		}
+
 		// Bind the data to the table.
 		$return = $this->bind($data);
 
@@ -110,13 +104,6 @@ class JTableUser extends JTable
 
 			// Add the groups to the user data.
 			$this->groups = $this->_db->loadAssocList('id', 'id');
-
-			// Check for an error message.
-			if ($this->_db->getErrorNum())
-			{
-				$this->setError($this->_db->getErrorMsg());
-				return false;
-			}
 		}
 
 		return $return;
@@ -161,12 +148,6 @@ class JTableUser extends JTable
 			// Set the titles for the user groups.
 			$this->groups = $this->_db->loadAssocList('id', 'id');
 
-			// Check for a database error.
-			if ($this->_db->getErrorNum())
-			{
-				$this->setError($this->_db->getErrorMsg());
-				return false;
-			}
 		}
 
 		return $return;
@@ -293,19 +274,12 @@ class JTableUser extends JTable
 		if ($key)
 		{
 			// Already have a table key, update the row.
-			$return = $this->_db->updateObject($this->_tbl, $this, $this->_tbl_key, $updateNulls);
+			$this->_db->updateObject($this->_tbl, $this, $this->_tbl_key, $updateNulls);
 		}
 		else
 		{
 			// Don't have a table key, insert the row.
-			$return = $this->_db->insertObject($this->_tbl, $this, $this->_tbl_key);
-		}
-
-		// Handle error if it exists.
-		if (!$return)
-		{
-			$this->setError(JText::sprintf('JLIB_DATABASE_ERROR_STORE_FAILED', strtolower(get_class($this)), $this->_db->getErrorMsg()));
-			return false;
+			$this->_db->insertObject($this->_tbl, $this, $this->_tbl_key);
 		}
 
 		// Reset groups to the local object.
@@ -313,7 +287,7 @@ class JTableUser extends JTable
 		unset($groups);
 
 		// Store the group data if the user data was saved.
-		if ($return && is_array($this->groups) && count($this->groups))
+		if (is_array($this->groups) && count($this->groups))
 		{
 			// Delete the old user group maps.
 			$query = $this->_db->getQuery(true);
@@ -322,13 +296,6 @@ class JTableUser extends JTable
 			$query->where($this->_db->quoteName('user_id') . ' = ' . (int) $this->id);
 			$this->_db->setQuery($query);
 			$this->_db->execute();
-
-			// Check for a database error.
-			if ($this->_db->getErrorNum())
-			{
-				$this->setError($this->_db->getErrorMsg());
-				return false;
-			}
 
 			// Set the new user group maps.
 			$query->clear();
@@ -342,13 +309,6 @@ class JTableUser extends JTable
 				$query->values($this->id . ', ' . $group);
 				$this->_db->setQuery($query);
 				$this->_db->execute();
-			}
-
-			// Check for a database error.
-			if ($this->_db->getErrorNum())
-			{
-				$this->setError($this->_db->getErrorMsg());
-				return false;
 			}
 		}
 
@@ -381,13 +341,6 @@ class JTableUser extends JTable
 		$this->_db->setQuery($query);
 		$this->_db->execute();
 
-		// Check for a database error.
-		if ($this->_db->getErrorNum())
-		{
-			$this->setError($this->_db->getErrorMsg());
-			return false;
-		}
-
 		// Delete the user group maps.
 		$query->clear();
 		$query->delete();
@@ -395,13 +348,6 @@ class JTableUser extends JTable
 		$query->where($this->_db->quoteName('user_id') . ' = ' . (int) $this->$k);
 		$this->_db->setQuery($query);
 		$this->_db->execute();
-
-		// Check for a database error.
-		if ($this->_db->getErrorNum())
-		{
-			$this->setError($this->_db->getErrorMsg());
-			return false;
-		}
 
 		/*
 		 * Clean Up Related Data.
@@ -414,26 +360,12 @@ class JTableUser extends JTable
 		$this->_db->setQuery($query);
 		$this->_db->execute();
 
-		// Check for a database error.
-		if ($this->_db->getErrorNum())
-		{
-			$this->setError($this->_db->getErrorMsg());
-			return false;
-		}
-
 		$query->clear();
 		$query->delete();
 		$query->from($this->_db->quoteName('#__messages'));
 		$query->where($this->_db->quoteName('user_id_to') . ' = ' . (int) $this->$k);
 		$this->_db->setQuery($query);
 		$this->_db->execute();
-
-		// Check for a database error.
-		if ($this->_db->getErrorNum())
-		{
-			$this->setError($this->_db->getErrorMsg());
-			return false;
-		}
 
 		return true;
 	}
@@ -459,8 +391,7 @@ class JTableUser extends JTable
 			}
 			else
 			{
-				// Do not translate
-				jexit(JText::_('JLIB_DATABASE_ERROR_SETLASTVISIT'));
+				jexit('No userid in setLastVisit');
 			}
 		}
 
@@ -475,13 +406,6 @@ class JTableUser extends JTable
 		$query->where($db->quoteName('id') . '=' . (int) $userId);
 		$db->setQuery($query);
 		$db->execute();
-
-		// Check for a database error.
-		if ($db->getErrorNum())
-		{
-			$this->setError($db->getErrorMsg());
-			return false;
-		}
 
 		return true;
 	}

--- a/libraries/joomla/table/usergroup.php
+++ b/libraries/joomla/table/usergroup.php
@@ -143,6 +143,7 @@ class JTableUsergroup extends JTable
 	 * @return  mixed  Boolean or Exception.
 	 *
 	 * @since   11.1
+	 * @throws  UnexpectedValueException
 	 */
 	public function delete($oid = null)
 	{
@@ -152,15 +153,15 @@ class JTableUsergroup extends JTable
 		}
 		if ($this->id == 0)
 		{
-			return new JException(JText::_('JGLOBAL_CATEGORY_NOT_FOUND'));
+			throw new UnexpectedValueException('Global Category not found');
 		}
 		if ($this->parent_id == 0)
 		{
-			return new JException(JText::_('JLIB_DATABASE_ERROR_DELETE_ROOT_CATEGORIES'));
+			return new JException('Root categories cannot be deleted.');
 		}
 		if ($this->lft == 0 || $this->rgt == 0)
 		{
-			return new JException(JText::_('JLIB_DATABASE_ERROR_DELETE_CATEGORY'));
+			throw new UnexpectedValueException('Left-Right data inconsistency. Cannot delete category.');
 		}
 
 		$db = $this->_db;
@@ -175,7 +176,7 @@ class JTableUsergroup extends JTable
 		$ids = $db->loadColumn();
 		if (empty($ids))
 		{
-			return new JException(JText::_('JLIB_DATABASE_ERROR_DELETE_CATEGORY'));
+			throw new UnexpectedValueException('Left-Right data inconsistency. Cannot delete category.');
 		}
 
 		// Delete the category dependencies
@@ -187,11 +188,7 @@ class JTableUsergroup extends JTable
 		$query->from($db->quoteName($this->_tbl));
 		$query->where($db->quoteName('id') . ' IN (' . implode(',', $ids) . ')');
 		$db->setQuery($query);
-		if (!$db->execute())
-		{
-			$this->setError($db->getErrorMsg());
-			return false;
-		}
+		$db->execute();
 
 		// Delete the usergroup in view levels
 		$replace = array();
@@ -230,11 +227,7 @@ class JTableUsergroup extends JTable
 			$query->update('#__viewlevels');
 			$query->where('id IN (' . implode(',', $match_ids) . ')');
 			$db->setQuery($query);
-			if (!$db->execute())
-			{
-				$this->setError($db->getErrorMsg());
-				return false;
-			}
+			$db->execute();
 		}
 
 		// Delete the user to usergroup mappings for the group(s) from the database.
@@ -244,13 +237,6 @@ class JTableUsergroup extends JTable
 		$query->where($db->quoteName('group_id') . ' IN (' . implode(',', $ids) . ')');
 		$db->setQuery($query);
 		$db->execute();
-
-		// Check for a database error.
-		if ($db->getErrorNum())
-		{
-			$this->setError($db->getErrorMsg());
-			return false;
-		}
 
 		return true;
 	}


### PR DESCRIPTION
I left JException in this PR since I am not certain what the plan is there and wanted to hear back https://groups.google.com/d/msg/joomla-dev-platform/SJopGknhizs/ssWpyIMazgAJ

We can go back through this and change JException to a PHP Exception even after this PR, if it's desired. More than likely, this will result in an API change since currently a failure is indicated by "false" not an exception. But, it's probably a good time to make that change with the 3.0 CMS release. 

This PR, however, is restricted to removing the $db error processing, getting rid of JText with Exception (and JException) calls, and any JError statments.

Also - IMO, the tables 'package' belongs in the CMS, not the framework. Maybe the entire folder should be moved into legacy and left, as is?
