### PR TITLE
To avoid Fatal error with JEditor::getButtons (for issue #660)

### DIFF
--- a/libraries/joomla/html/editor.php
+++ b/libraries/joomla/html/editor.php
@@ -467,7 +467,7 @@ class JEditor extends JObject
 				$result[] = $temp;
 			}
 
-			}
+		}
 
 		return $result;
 	}

--- a/libraries/joomla/html/editor.php
+++ b/libraries/joomla/html/editor.php
@@ -454,20 +454,17 @@ class JEditor extends JObject
 			{
 				$plugin = new $className($this, (array) $plugin);
 			}
-
-                    try
+                        else 
                         {
+                            throw new Exception("Class does not exists "+$className);
+                        }
+
 			// Try to authenticate
-                        // Unsafe operation, might cause an exception if $className not exists                        
                         if ($temp = $plugin->onDisplay($editor, $this->asset, $this->author))
                         {
                             $result[] = $temp;
                         }
-                        }catch (Exception $e)
-                        {
-                            echo 'Exception while authenticating';
-                            echo 'Message ' . $e->getMessage(); //Print the error message
-                        }
+                        
 		}
 
 		return $result;

--- a/libraries/joomla/html/editor.php
+++ b/libraries/joomla/html/editor.php
@@ -426,8 +426,8 @@ class JEditor extends JObject
 	 *
 	 * @return  array
 	 *
-         * @throws	InvalidArgumentException	If plugin required does not exists
-         *   
+     * @throws	InvalidArgumentException	If plugin required does not exists
+     *   
 	 * @since   11.1
 	 */
 	public function getButtons($editor, $buttons = true)
@@ -466,7 +466,6 @@ class JEditor extends JObject
 			{
 				$result[] = $temp;
 			}
-
 		}
 
 		return $result;

--- a/libraries/joomla/html/editor.php
+++ b/libraries/joomla/html/editor.php
@@ -426,6 +426,8 @@ class JEditor extends JObject
 	 *
 	 * @return  array
 	 *
+         * @throws   InvalidArgumentException    If plugin required does not exists
+         *   
 	 * @since   11.1
 	 */
 	public function getButtons($editor, $buttons = true)
@@ -456,7 +458,7 @@ class JEditor extends JObject
 			}
                         else 
                         {
-                            throw new Exception("Class does not exists "+$className);
+                            throw new InvalidArgumentException("Class does not exists "+$className);
                         }
 
 			// Try to authenticate

--- a/libraries/joomla/html/editor.php
+++ b/libraries/joomla/html/editor.php
@@ -426,8 +426,8 @@ class JEditor extends JObject
 	 *
 	 * @return  array
 	 *
-     * @throws	InvalidArgumentException	If plugin required does not exists
-     *   
+	 * @throws	InvalidArgumentException	If plugin required does not exists
+	 *   
 	 * @since   11.1
 	 */
 	public function getButtons($editor, $buttons = true)

--- a/libraries/joomla/html/editor.php
+++ b/libraries/joomla/html/editor.php
@@ -458,7 +458,7 @@ class JEditor extends JObject
 			}
 			else
 			{
-				throw new InvalidArgumentException('Class does not exists ' . $className);
+				throw new InvalidArgumentException('Class does not exists: ' . $className);
 			}
 
 			// Try to authenticate

--- a/libraries/joomla/html/editor.php
+++ b/libraries/joomla/html/editor.php
@@ -455,17 +455,18 @@ class JEditor extends JObject
 				$plugin = new $className($this, (array) $plugin);
 			}
 
-                        try{
+                    try
+                        {
 			// Try to authenticate
-                            // Unsafe opearation, might cause an exception if $className not exists
-                        
-                            if ($temp = $plugin->onDisplay($editor, $this->asset, $this->author))
-                            {
-                                    $result[] = $temp;
-                            }
-                        }  catch (Exception $e){
-                            echo 'Exception while authenticating.';
-                            echo 'Message '.$e->getMessage(); // print the error message
+                        // Unsafe opearation, might cause an exception if $className not exists                        
+                        if ($temp = $plugin->onDisplay($editor, $this->asset, $this->author))
+                        {
+                            $result[] = $temp;
+                        }
+                        }catch (Exception $e)
+                        {
+                            echo 'Exception while authenticating';
+                            echo 'Message ' . $e->getMessage(); //Print the error message
                         }
 		}
 

--- a/libraries/joomla/html/editor.php
+++ b/libraries/joomla/html/editor.php
@@ -458,7 +458,7 @@ class JEditor extends JObject
                     try
                         {
 			// Try to authenticate
-                        // Unsafe opearation, might cause an exception if $className not exists                        
+                        // Unsafe operation, might cause an exception if $className not exists                        
                         if ($temp = $plugin->onDisplay($editor, $this->asset, $this->author))
                         {
                             $result[] = $temp;

--- a/libraries/joomla/html/editor.php
+++ b/libraries/joomla/html/editor.php
@@ -463,11 +463,11 @@ class JEditor extends JObject
 
 			// Try to authenticate
 			if ($temp = $plugin->onDisplay($editor, $this->asset, $this->author))
-                        {
-                            $result[] = $temp;
-                        }
-                        
-		}
+			{
+				$result[] = $temp;
+			}
+
+			}
 
 		return $result;
 	}

--- a/libraries/joomla/html/editor.php
+++ b/libraries/joomla/html/editor.php
@@ -426,7 +426,7 @@ class JEditor extends JObject
 	 *
 	 * @return  array
 	 *
-         * @throws   InvalidArgumentException    If plugin required does not exists
+         * @throws	InvalidArgumentException	If plugin required does not exists
          *   
 	 * @since   11.1
 	 */
@@ -456,13 +456,13 @@ class JEditor extends JObject
 			{
 				$plugin = new $className($this, (array) $plugin);
 			}
-                        else 
-                        {
-                            throw new InvalidArgumentException("Class does not exists "+$className);
-                        }
+			else
+			{
+				throw new InvalidArgumentException('Class does not exists ' . $className);
+			}
 
 			// Try to authenticate
-                        if ($temp = $plugin->onDisplay($editor, $this->asset, $this->author))
+			if ($temp = $plugin->onDisplay($editor, $this->asset, $this->author))
                         {
                             $result[] = $temp;
                         }

--- a/libraries/joomla/html/editor.php
+++ b/libraries/joomla/html/editor.php
@@ -455,11 +455,18 @@ class JEditor extends JObject
 				$plugin = new $className($this, (array) $plugin);
 			}
 
+                        try{
 			// Try to authenticate
-			if ($temp = $plugin->onDisplay($editor, $this->asset, $this->author))
-			{
-				$result[] = $temp;
-			}
+                            // Unsafe opearation, might cause an exception if $className not exists
+                        
+                            if ($temp = $plugin->onDisplay($editor, $this->asset, $this->author))
+                            {
+                                    $result[] = $temp;
+                            }
+                        }  catch (Exception $e){
+                            echo 'Exception while authenticating.';
+                            echo 'Message '.$e->getMessage(); // print the error message
+                        }
 		}
 
 		return $result;


### PR DESCRIPTION
File: joomla-platform / libraries / joomla / html / editor.php
Method: getButtons()

Issue: If the $className would not exists (due to plugin class is missing) , assigning to $temp variable becomes unsafe

Solution: Put the assiging inside a try catch block, so that not existance of plugin class would not disturb the flow of foreach loop 

Signed-off-by: Buddhima Wijeweera 
