### PR TITLE
Avoid division by zero (for issue #708)

### DIFF
--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -654,8 +654,8 @@ class JImage
 	 *
 	 * @return  object
 	 *
-         * @throws  LogicException          If width,height or both given as zero   
-         * 
+	 * @throws  InvalidArgumentException	If width,height or both given as zero   
+	 * 
 	 * @since   11.3
 	 * @throws  InvalidArgumentException
 	 */
@@ -675,9 +675,9 @@ class JImage
 			case self::SCALE_OUTSIDE:
 			
 				// Both $height or $width cannot be zero
-				if($width == 0 || $height == 0)
+				if ($width == 0 || $height == 0)
 				{
-					throw new LogicException(' Both height or width cannot be zero ');
+					throw new InvalidArgumentException(' Width or height cannot be zero with this scale method ');
 				}
 			
 				// If both $width and $height are not equals to zero

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -673,29 +673,20 @@ class JImage
 
 			case self::SCALE_INSIDE:
 			case self::SCALE_OUTSIDE:
-                            
-							// To avoid dividing by $width if it is zero
-							if($width == 0 && $height != 0)
-							{
-								throw new LogicException(' Width cannot be zero ');
-								}
-                            
-							// To avoid dividing by $height if it is zero
-							elseif ($width != 0 && $height == 0)
-							{
-								throw new LogicException(' Height cannot be zero ');
-								}
-                            
-							// Both $height and $width are zero
-							elseif($width == 0 && $height == 0){
-								throw new LogicException(' Both height and width cannot be zero ');
-								}
-                            
-							// If both $width and $height are not equals to zero
-                            else{
-				$rx = $this->getWidth() / $width;
-				$ry = $this->getHeight() / $height;
-                            }
+			
+				// Both $height or $width cannot be zero
+				if($width == 0 || $height == 0)
+				{
+					throw new LogicException(' Both height or width cannot be zero ');
+				}
+			
+				// If both $width and $height are not equals to zero
+				else
+				{
+					$rx = $this->getWidth() / $width;
+					$ry = $this->getHeight() / $height;
+				}
+				
 				if ($scaleMethod == self::SCALE_INSIDE)
 				{
 					$ratio = ($rx > $ry) ? $rx : $ry;

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -671,19 +671,27 @@ class JImage
 
 			case self::SCALE_INSIDE:
 			case self::SCALE_OUTSIDE:
-                            if($width==0 && $height!=0){  // To avoid dividing by $width if it is zero
+                            
+                            // To avoid dividing by $width if it is zero
+                            if($width==0 && $height!=0){
                                 $rx = $this->getWidth() ;
 				$ry = $this->getHeight() / $height;
                             }
-                            elseif ($width!=0 && $height==0) {  // To avoid dividing by $height if it is zero
+                            
+                            // To avoid dividing by $height if it is zero                            
+                            elseif ($width!=0 && $height==0) {
                                $rx = $this->getWidth() / $width;
 				$ry = $this->getHeight() ; 
                             }
-                            else if($width==0 && $height==0){  // Both $height and $width are zero
+                            
+                            // Both $height and $width are zero
+                            elseif($width==0 && $height==0){
                                 $rx = $this->getWidth() / $width;
 				$ry = $this->getHeight() ; 
                             }
-                            else{ // If both $width and $height are not equals to zero
+                            
+                            // If both $width and $height are not equals to zero
+                            else{
 				$rx = $this->getWidth() / $width;
 				$ry = $this->getHeight() / $height;
                             }

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -654,6 +654,8 @@ class JImage
 	 *
 	 * @return  object
 	 *
+         * @throws  LogicException          If width,height or both given as zero   
+         * 
 	 * @since   11.3
 	 * @throws  InvalidArgumentException
 	 */
@@ -672,25 +674,24 @@ class JImage
 			case self::SCALE_INSIDE:
 			case self::SCALE_OUTSIDE:
                             
-                            // To avoid dividing by $width if it is zero
-                            if($width==0 && $height!=0){
-                                $rx = $this->getWidth() ;
-				$ry = $this->getHeight() / $height;
-                            }
+							// To avoid dividing by $width if it is zero
+							if($width == 0 && $height != 0)
+							{
+								throw new LogicException(' Width cannot be zero ');
+								}
                             
-                            // To avoid dividing by $height if it is zero                            
-                            elseif ($width!=0 && $height==0) {
-                               $rx = $this->getWidth() / $width;
-				$ry = $this->getHeight() ; 
-                            }
+							// To avoid dividing by $height if it is zero
+							elseif ($width != 0 && $height == 0)
+							{
+								throw new LogicException(' Height cannot be zero ');
+								}
                             
-                            // Both $height and $width are zero
-                            elseif($width==0 && $height==0){
-                                $rx = $this->getWidth() / $width;
-				$ry = $this->getHeight() ; 
-                            }
+							// Both $height and $width are zero
+							elseif($width == 0 && $height == 0){
+								throw new LogicException(' Both height and width cannot be zero ');
+								}
                             
-                            // If both $width and $height are not equals to zero
+							// If both $width and $height are not equals to zero
                             else{
 				$rx = $this->getWidth() / $width;
 				$ry = $this->getHeight() / $height;

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -671,9 +671,18 @@ class JImage
 
 			case self::SCALE_INSIDE:
 			case self::SCALE_OUTSIDE:
+                            if($width==0 && $height!=0){  // To avoid dividing by $width if it is zero
+                                $rx = $this->getWidth() ;
+				$ry = $this->getHeight() / $height;
+                            }
+                            elseif ($width!=0 && $height==0) {  // To avoid dividing by $height if it is zero
+                               $rx = $this->getWidth() / $width;
+				$ry = $this->getHeight() ; 
+                            }
+                            else{ // If both $width and $height are not equals to zero
 				$rx = $this->getWidth() / $width;
 				$ry = $this->getHeight() / $height;
-
+                            }
 				if ($scaleMethod == self::SCALE_INSIDE)
 				{
 					$ratio = ($rx > $ry) ? $rx : $ry;

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -673,20 +673,20 @@ class JImage
 
 			case self::SCALE_INSIDE:
 			case self::SCALE_OUTSIDE:
-			
+
 				// Both $height or $width cannot be zero
 				if ($width == 0 || $height == 0)
 				{
 					throw new InvalidArgumentException(' Width or height cannot be zero with this scale method ');
 				}
-			
+
 				// If both $width and $height are not equals to zero
 				else
 				{
 					$rx = $this->getWidth() / $width;
 					$ry = $this->getHeight() / $height;
 				}
-				
+
 				if ($scaleMethod == self::SCALE_INSIDE)
 				{
 					$ratio = ($rx > $ry) ? $rx : $ry;

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -679,6 +679,10 @@ class JImage
                                $rx = $this->getWidth() / $width;
 				$ry = $this->getHeight() ; 
                             }
+                            else if($width==0 && $height==0){  // Both $height and $width are zero
+                                $rx = $this->getWidth() / $width;
+				$ry = $this->getHeight() ; 
+                            }
                             else{ // If both $width and $height are not equals to zero
 				$rx = $this->getWidth() / $width;
 				$ry = $this->getHeight() / $height;


### PR DESCRIPTION
File: libraries/joomla/image/image.php
Method: prepareDimensions()

Issue: If zero is given for the one of the arguments $height or $width, following section will produce an error.
Solution: Treat 3 instances where $height=0,$width=0 and both not equals zero

Signed-off-by: Buddhima Wijeweera 
