### PR TITLE
Set JInputFiles constructor

### DIFF
--- a/libraries/joomla/input/files.php
+++ b/libraries/joomla/input/files.php
@@ -21,6 +21,32 @@ class JInputFiles extends JInput
 	protected $decodedData = array();
 
 	/**
+	 * Constructor.
+	 *
+	 * @param   array  $source   Ignored.
+	 * @param   array  $options  Array of configuration parameters (Optional)
+	 *
+	 * @since   12.1
+	 */
+	public function __construct(array $source = null, array $options = array())
+	{
+		if (isset($options['filter']))
+		{
+			$this->filter = $options['filter'];
+		}
+		else
+		{
+			$this->filter = JFilterInput::getInstance();
+		}
+
+		// Set the data source.
+		$this->data = & $_FILES;
+
+		// Set the options for the class.
+		$this->options = $options;
+	}
+
+	/**
 	 * Gets a value from the input data.
 	 *
 	 * @param   string  $name     Name of the value to get.


### PR DESCRIPTION
So a while back on the CMS list, it was brought up that you can't use JInputFiles to pull from the `$_FILES` superglobal.  According to Ian (https://groups.google.com/d/topic/joomla-dev-cms/0CR3NKmiBg8/discussion), there should be a constructor similar to that in JInputCookie.  Well, this finally adds that constructor.
