### PR TITLE
Get Identity 

### DIFF
--- a/libraries/joomla/application/base.php
+++ b/libraries/joomla/application/base.php
@@ -60,6 +60,18 @@ abstract class JApplicationBase extends JObject
 	}
 
 	/**
+	 * Get the application identity.
+	 *
+	 * @return  mixed  A JUser object or null.
+	 *
+	 * @since   12.1
+	 */
+	public function getIdentity()
+	{
+		return $this->identity;
+	}
+
+	/**
 	 * Registers a handler to a particular event group.
 	 *
 	 * @param   string    $event    The event name.

--- a/tests/core/mock/application.php
+++ b/tests/core/mock/application.php
@@ -29,6 +29,7 @@ class TestMockApplication
 		$methods = array(
 			'get',
 			'getCfg',
+			'getIdentity',
 			'getRouter',
 			'getTemplate',
 		);

--- a/tests/core/mock/application/web.php
+++ b/tests/core/mock/application/web.php
@@ -36,8 +36,9 @@ class TestMockApplicationWeb
 		$methods = array(
 			'get',
 			'getDocument',
+			'getIdentity',
 			'getLanguage',
-			'getSession',
+			'getSession'
 		);
 
 		// Create the mock.


### PR DESCRIPTION
Added JApplicationBase::getIdentity() to retrieve the user object that the application now supports loading. Also added mock support for this method to the mock builders.
