### PR TITLE
The dl() function has been removed from most PHP SAPI's in 5.3.

### DIFF
--- a/libraries/joomla/archive/bzip2.php
+++ b/libraries/joomla/archive/bzip2.php
@@ -29,16 +29,6 @@ class JArchiveBzip2 implements JArchiveExtractable
 	private $_data = null;
 
 	/**
-	 * Constructor tries to load the bz2 extension if not loaded
-	 *
-	 * @since   11.1
-	 */
-	public function __construct()
-	{
-		self::loadExtension();
-	}
-
-	/**
 	 * Extract a Bzip2 compressed file to a given path
 	 *
 	 * @param   string  $archive      Path to Bzip2 archive to extract
@@ -181,31 +171,6 @@ class JArchiveBzip2 implements JArchiveExtractable
 	 */
 	public static function isSupported()
 	{
-		self::loadExtension();
-
 		return extension_loaded('bz2');
-	}
-
-	/**
-	 * Load the bzip2 extension
-	 *
-	 * @return  void
-	 *
-	 * @since   11.3
-	 */
-	private static function loadExtension()
-	{
-		// Is bz2 extension loaded?  If not try to load it
-		if (!extension_loaded('bz2'))
-		{
-			if (JPATH_ISWIN)
-			{
-				@ dl('php_bz2.dll');
-			}
-			else
-			{
-				@ dl('bz2.so');
-			}
-		}
 	}
 }

--- a/libraries/joomla/archive/zip.php
+++ b/libraries/joomla/archive/zip.php
@@ -531,20 +531,7 @@ class JArchiveZip implements JArchiveExtractable
 		}
 		elseif ($this->_metadata[$key]['_method'] == 0x12)
 		{
-			// Is bz2 extension loaded?  If not try to load it
-			if (!extension_loaded('bz2'))
-			{
-				if (JPATH_ISWIN)
-				{
-					@dl('php_bz2.dll');
-				}
-				else
-				{
-					@dl('bz2.so');
-				}
-			}
-
-			// If bz2 extension is successfully loaded use it
+			// If bz2 extension is loaded use it
 			if (extension_loaded('bz2'))
 			{
 				return bzdecompress(substr($this->_data, $this->_metadata[$key]['_dataStart'], $this->_metadata[$key]['csize']));

--- a/libraries/joomla/client/ftp.php
+++ b/libraries/joomla/client/ftp.php
@@ -38,18 +38,6 @@ if (!defined("FTP_ASCII"))
 	define("FTP_ASCII", 0);
 }
 
-// Is FTP extension loaded?  If not try to load it
-if (!extension_loaded('ftp'))
-{
-	if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
-	{
-		@ dl('php_ftp.dll');
-	}
-	else
-	{
-		@ dl('ftp.so');
-	}
-}
 if (!defined('FTP_NATIVE'))
 {
 	define('FTP_NATIVE', (function_exists('ftp_connect')) ? 1 : 0);

--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 // PHP mbstring and iconv local configuration
 
 // Check if mbstring extension is loaded and attempt to load it if not present except for windows
-if (extension_loaded('mbstring') || ((!strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && dl('mbstring.so'))))
+if (extension_loaded('mbstring'))
 {
 	// Make sure to suppress the output in case ini_set is disabled
 	@ini_set('mbstring.internal_encoding', 'UTF-8');
@@ -21,7 +21,7 @@ if (extension_loaded('mbstring') || ((!strtoupper(substr(PHP_OS, 0, 3)) === 'WIN
 }
 
 // Same for iconv
-if (function_exists('iconv') || ((!strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && dl('iconv.so'))))
+if (function_exists('iconv')))
 {
 	// These are settings that can be set inside code
 	iconv_set_encoding("internal_encoding", "UTF-8");


### PR DESCRIPTION
The @'s masked the error but apparently it's a problem on some hosts.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28333
