### PR TITLE
Fix and improve the docblocks in the legacy folder.

### DIFF
--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -30,15 +30,6 @@ class JApplication extends JApplicationBase
 	 * @var    integer
 	 * @since  11.1
 	 */
-	protected $clientId = null;
-
-	/**
-	 * The client identifier.
-	 *
-	 * @var    integer
-	 * @since  11.1
-	 * @deprecated use $clientId or declare as private
-	 */
 	protected $_clientId = null;
 
 	/**
@@ -47,15 +38,6 @@ class JApplication extends JApplicationBase
 	 * @var    array
 	 * @since  11.1
 	 */
-	protected $messageQueue = array();
-
-	/**
-	 * The application message queue.
-	 *
-	 * @var    array
-	 * @since  11.1
-	 * @deprecated use $messageQueue or declare as private
-	 */
 	protected $_messageQueue = array();
 
 	/**
@@ -63,15 +45,6 @@ class JApplication extends JApplicationBase
 	 *
 	 * @var    array
 	 * @since  11.1
-	 */
-	protected $name = null;
-
-	/**
-	 * The name of the application.
-	 *
-	 * @var    array
-	 * @since  11.1
-	 * @deprecated use $name or declare as private
 	 */
 	protected $_name = null;
 

--- a/libraries/legacy/application/helper.php
+++ b/libraries/legacy/application/helper.php
@@ -31,7 +31,6 @@ class JApplicationHelper
 	 *
 	 * @var    array
 	 * @since  11.1
-	 * @deprecated use $clientsor declare as private
 	 */
 	protected static $_clients = null;
 
@@ -175,7 +174,7 @@ class JApplicationHelper
 	 * @return  array  XML metadata.
 	 *
 	 * @since   11.1
-	 * @deprecated  12.1
+	 * @deprecated  13.3
 	 */
 	public static function parseXMLInstallFile($path)
 	{

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Categories
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -13,7 +13,7 @@ defined('JPATH_PLATFORM') or die;
  * JCategories Class.
  *
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Categories
  * @since       11.1
  */
 class JCategories
@@ -32,15 +32,6 @@ class JCategories
 	 * @var    mixed
 	 * @since  11.1
 	 */
-	protected $nodes;
-
-	/**
-	 * Array of category nodes
-	 *
-	 * @var    mixed
-	 * @since  11.1
-	 * @deprecated use $nodes or declare as private
-	 */
 	protected $_nodes;
 
 	/**
@@ -48,15 +39,6 @@ class JCategories
 	 *
 	 * @var    array
 	 * @since  11.1
-	 */
-	protected $checkedCategories;
-
-	/**
-	 * Array of checked categories -- used to save values when _nodes are null
-	 *
-	 * @var    array
-	 * @since  11.1
-	 * @deprecated use $checkedCategories or declare as private
 	 */
 	protected $_checkedCategories;
 
@@ -66,15 +48,6 @@ class JCategories
 	 * @var    string
 	 * @since  11.1
 	 */
-	protected $extension = null;
-
-	/**
-	 * Name of the extension the categories belong to
-	 *
-	 * @var    string
-	 * @since  11.1
-	 * @deprecated use $extension or declare as private
-	 */
 	protected $_extension = null;
 
 	/**
@@ -82,15 +55,6 @@ class JCategories
 	 *
 	 * @var    string
 	 * @since  11.1
-	 */
-	protected $table = null;
-
-	/**
-	 * Name of the linked content table to get category content count
-	 *
-	 * @var    string
-	 * @since  11.1
-	 * @deprecated use $table or declare as private
 	 */
 	protected $_table = null;
 
@@ -100,15 +64,6 @@ class JCategories
 	 * @var    string
 	 * @since  11.1
 	 */
-	protected $field = null;
-
-	/**
-	 * Name of the category field
-	 *
-	 * @var    string
-	 * @since  11.1
-	 * @deprecated use $field or declare as private
-	 */
 	protected $_field = null;
 
 	/**
@@ -116,15 +71,6 @@ class JCategories
 	 *
 	 * @var    string
 	 * @since  11.1
-	 */
-	protected $key = null;
-
-	/**
-	 * Name of the key field
-	 *
-	 * @var    string
-	 * @since  11.1
-	 * @deprecated use $key or declare as private
 	 */
 	protected $_key = null;
 
@@ -134,15 +80,6 @@ class JCategories
 	 * @var    string
 	 * @since  11.1
 	 */
-	protected $statefield = null;
-
-	/**
-	 * Name of the items state field
-	 *
-	 * @var    string
-	 * @since  11.1
-	 * @deprecated use $statefield or declare as private
-	 */
 	protected $_statefield = null;
 
 	/**
@@ -150,15 +87,6 @@ class JCategories
 	 *
 	 * @var    array
 	 * @since  11.1
-	 */
-	protected $options = null;
-
-	/**
-	 * Array of options
-	 *
-	 * @var    array
-	 * @since  11.1
-	 * @deprecated use $options or declare as private
 	 */
 	protected $_options = null;
 
@@ -446,7 +374,7 @@ class JCategories
  * Helper class to load Categorytree
  *
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Categories
  * @since       11.1
  */
 class JCategoryNode extends JObject
@@ -681,27 +609,11 @@ class JCategoryNode extends JObject
 	 * @var    object
 	 * @since  11.1
 	 */
-	protected $parent = null;
-
-	/**
-	 * Parent Category object
-	 *
-	 * @var    object
-	 * @since  11.1
-	 * @deprecated use $parent or declare as private
-	 */
 	protected $_parent = null;
 
 	/**
 	 * @var Array of Children
 	 * @since  11.1
-	 */
-	protected $children = array();
-
-	/**
-	 * @var Array of Children
-	 * @since  11.1
-	 * @deprecated use $children or declare as private
 	 */
 	protected $_children = array();
 
@@ -711,15 +623,6 @@ class JCategoryNode extends JObject
 	 * @var    array
 	 * @since  11.1
 	 */
-	protected $path = array();
-
-	/**
-	 * Path from root to this category
-	 *
-	 * @var    array
-	 * @since  11.1
-	 * @deprecated use $path or declare as private
-	 */
 	protected $_path = array();
 
 	/**
@@ -727,15 +630,6 @@ class JCategoryNode extends JObject
 	 *
 	 * @var    integer
 	 * @since  11.1
-	 */
-	protected $leftSibling = null;
-
-	/**
-	 * Category left of this one
-	 *
-	 * @var    integer
-	 * @since  11.1
-	 * @deprecated use $leftSibling or declare as private
 	 */
 	protected $_leftSibling = null;
 
@@ -745,15 +639,6 @@ class JCategoryNode extends JObject
 	 * @var
 	 * @since  11.1
 	 */
-	protected $rightSibling = null;
-
-	/**
-	 * Category right of this one
-	 *
-	 * @var
-	 * @since  11.1
-	 * @deprecated use $rightSibling or declare as private
-	 */
 	protected $_rightSibling = null;
 
 	/**
@@ -762,15 +647,6 @@ class JCategoryNode extends JObject
 	 * @var boolean
 	 * @since  11.1
 	 */
-	protected $allChildrenloaded = false;
-
-	/**
-	 * true if all children have been loaded
-	 *
-	 * @var boolean
-	 * @since  11.1
-	 * @deprecated use $allChildrenloaded or declare as private
-	 */
 	protected $_allChildrenloaded = false;
 
 	/**
@@ -778,15 +654,6 @@ class JCategoryNode extends JObject
 	 *
 	 * @var
 	 * @since  11.1
-	 */
-	protected $constructor = null;
-
-	/**
-	 * Constructor of this tree
-	 *
-	 * @var
-	 * @since  11.1
-	 * @deprecated use $constructor or declare as private
 	 */
 	protected $_constructor = null;
 

--- a/libraries/legacy/component/helper.php
+++ b/libraries/legacy/component/helper.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Component
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -13,7 +13,7 @@ defined('JPATH_PLATFORM') or die;
  * Component helper class
  *
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Component
  * @since       11.1
  */
 class JComponentHelper
@@ -23,15 +23,6 @@ class JComponentHelper
 	 *
 	 * @var    array
 	 * @since  11.1
-	 */
-	protected static $components = array();
-
-	/**
-	 * The component list cache
-	 *
-	 * @var    array
-	 * @since  11.1
-	 * @deprecated use $components declare as private
 	 */
 	protected static $_components = array();
 

--- a/libraries/legacy/menu/menu.php
+++ b/libraries/legacy/menu/menu.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Menu
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -13,7 +13,7 @@ defined('JPATH_PLATFORM') or die;
  * JMenu class
  *
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Menu
  * @since       11.1
  */
 class JMenu extends JObject
@@ -24,15 +24,6 @@ class JMenu extends JObject
 	 * @var    array
 	 * @since   11.1
 	 */
-	protected $items = array();
-
-	/**
-	 * Array to hold the menu items
-	 *
-	 * @var    array
-	 * @since   11.1
-	 * @deprecated use $items declare as private
-	 */
 	protected $_items = array();
 
 	/**
@@ -41,15 +32,6 @@ class JMenu extends JObject
 	 * @var    integer
 	 * @since   11.1
 	 */
-	protected $default = array();
-
-	/**
-	 * Identifier of the default menu item
-	 *
-	 * @var    integer
-	 * @since   11.1
-	 * @deprecated use $default declare as private
-	 */
 	protected $_default = array();
 
 	/**
@@ -57,15 +39,6 @@ class JMenu extends JObject
 	 *
 	 * @var    integer
 	 * @since  11.1
-	 */
-	protected $active = 0;
-
-	/**
-	 * Identifier of the active menu item
-	 *
-	 * @var    integer
-	 * @since  11.1
-	 * @deprecated use $active declare as private
 	 */
 	protected $_active = 0;
 

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Model
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -13,7 +13,7 @@ defined('JPATH_PLATFORM') or die;
  * Prototype admin model.
  *
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Model
  * @since       11.1
  */
 abstract class JModelAdmin extends JModelForm

--- a/libraries/legacy/model/form.php
+++ b/libraries/legacy/model/form.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Model
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -13,7 +13,7 @@ defined('JPATH_PLATFORM') or die;
  * Prototype form model.
  *
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Model
  * @see         JForm
  * @see         JFormField
  * @see         JformRule
@@ -26,15 +26,6 @@ abstract class JModelForm extends JModel
 	 *
 	 * @var    array
 	 * @since  11.1
-	 */
-	protected $forms = array();
-
-	/**
-	 * Array of form objects.
-	 *
-	 * @var    array
-	 * @since  11.1
-	 * @deprecated use $forms declare as private
 	 */
 	protected $_forms = array();
 

--- a/libraries/legacy/model/item.php
+++ b/libraries/legacy/model/item.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Model
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -13,7 +13,7 @@ defined('JPATH_PLATFORM') or die;
  * Prototype item model.
  *
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Model
  * @since       11.1
  */
 abstract class JModelItem extends JModel
@@ -22,15 +22,6 @@ abstract class JModelItem extends JModel
 	 * An item.
 	 *
 	 * @var    array
-	 * @since  11.1
-	 */
-	protected $item = null;
-
-	/**
-	 * An item.
-	 *
-	 * @var    array
-	 * @deprecated use $item declare as private
 	 */
 	protected $_item = null;
 
@@ -39,15 +30,6 @@ abstract class JModelItem extends JModel
 	 *
 	 * @var    string
 	 * @since  11.1
-	 */
-	protected $context = 'group.type';
-
-	/**
-	 * Model context string.
-	 *
-	 * @var    string
-	 * @since  11.1
-	 * @deprecated use $context declare as private
 	 */
 	protected $_context = 'group.type';
 

--- a/libraries/legacy/model/list.php
+++ b/libraries/legacy/model/list.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Model
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -13,7 +13,7 @@ defined('JPATH_PLATFORM') or die;
  * Model class for handling lists of items.
  *
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Model
  * @since       11.1
  */
 class JModelList extends JModel

--- a/libraries/legacy/model/model.php
+++ b/libraries/legacy/model/model.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Model
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * provides many supporting API functions.
  *
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Model
  * @since       11.1
  */
 abstract class JModel extends JObject
@@ -27,15 +27,6 @@ abstract class JModel extends JObject
 	 * @var    boolean
 	 * @since  11.1
 	 */
-	protected $stateSet = null;
-
-	/**
-	 * Indicates if the internal state has been set
-	 *
-	 * @var    boolean
-	 * @since  11.1
-	 * @deprecated use $stateSet declare as private
-	 */
 	protected $__state_set = null;
 
 	/**
@@ -43,15 +34,6 @@ abstract class JModel extends JObject
 	 *
 	 * @var    object
 	 * @since  11.1
-	 */
-	protected $db;
-
-	/**
-	 * Database Connector
-	 *
-	 * @var    object
-	 * @since  11.1
-	 * @deprecated use $db declare as private
 	 */
 	protected $_db;
 

--- a/libraries/legacy/module/helper.php
+++ b/libraries/legacy/module/helper.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Module
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -13,7 +13,7 @@ defined('JPATH_PLATFORM') or die;
  * Module helper class
  *
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Module
  * @since       11.1
  */
 abstract class JModuleHelper

--- a/libraries/legacy/pathway/pathway.php
+++ b/libraries/legacy/pathway/pathway.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Pathway
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * The user's navigated path within the application.
  *
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  Pathway
  * @since       11.1
  */
 class JPathway extends JObject

--- a/libraries/legacy/request/request.php
+++ b/libraries/legacy/request/request.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Environment
+ * @subpackage  Request
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -31,7 +31,7 @@ JLog::add('JRequest is deprecated.', JLog::WARNING, 'deprecated');
  * can be passed through an input filter to avoid injection or returned raw.
  *
  * @package     Joomla.Platform
- * @subpackage  Environment
+ * @subpackage  Request
  * @since       11.1
  * @deprecated  12.1  Get the JInput object from the application instead
  */
@@ -59,7 +59,7 @@ class JRequest
 	 *
 	 * @since   11.1
 	 *
-	 * @deprecated   12.1
+	 * @deprecated   12.1 Use JInput::getMethod() instead
 	 */
 	public static function getMethod()
 	{

--- a/libraries/legacy/view/view.php
+++ b/libraries/legacy/view/view.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  View
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * Class holding methods for displaying presentation data.
  *
  * @package     Joomla.Platform
- * @subpackage  Application
+ * @subpackage  View
  * @since       11.1
  */
 class JView extends JObject
@@ -25,28 +25,12 @@ class JView extends JObject
 	 *
 	 * @var    array
 	 */
-	protected $name = null;
-
-	/**
-	 * The name of the view
-	 *
-	 * @var    array
-	 * @deprecated use $name declare as private
-	 */
 	protected $_name = null;
 
 	/**
 	 * Registered models
 	 *
 	 * @var    array
-	 */
-	protected $models = array();
-
-	/**
-	 * Registered models
-	 *
-	 * @var    array
-	 * @deprecated use $models declare as private
 	 */
 	protected $_models = array();
 
@@ -55,28 +39,12 @@ class JView extends JObject
 	 *
 	 * @var    string
 	 */
-	protected $basePath = null;
-
-	/**
-	 * The base path of the view
-	 *
-	 * @var    string
-	 * @deprecated use $basePath declare as private
-	 */
 	protected $_basePath = null;
 
 	/**
 	 * The default model
 	 *
 	 * @var	string
-	 */
-	protected $defaultModel = null;
-
-	/**
-	 * The default model
-	 *
-	 * @var	string
-	 * @deprecated use $defaultModel declare as private
 	 */
 	protected $_defaultModel = null;
 
@@ -85,28 +53,12 @@ class JView extends JObject
 	 *
 	 * @var    string
 	 */
-	protected $layout = 'default';
-
-	/**
-	 * Layout name
-	 *
-	 * @var    string
-	 * @deprecated use $layout declare as private
-	 */
 	protected $_layout = 'default';
 
 	/**
 	 * Layout extension
 	 *
 	 * @var    string
-	 */
-	protected $layoutExt = 'php';
-
-	/**
-	 * Layout extension
-	 *
-	 * @var    string
-	 * @deprecated use $layoutExt declare as private
 	 */
 	protected $_layoutExt = 'php';
 
@@ -115,28 +67,12 @@ class JView extends JObject
 	 *
 	 * @var    string
 	 */
-	protected $layoutTemplate = '_';
-
-	/**
-	 * Layout template
-	 *
-	 * @var    string
-	 * @deprecated use $layoutTemplate declare as private
-	 */
 	protected $_layoutTemplate = '_';
 
 	/**
 	 * The set of search directories for resources (templates)
 	 *
 	 * @var array
-	 */
-	protected $path = array('template' => array(), 'helper' => array());
-
-	/**
-	 * The set of search directories for resources (templates)
-	 *
-	 * @var array
-	 * @deprecated use $path declare as private
 	 */
 	protected $_path = array('template' => array(), 'helper' => array());
 
@@ -145,28 +81,12 @@ class JView extends JObject
 	 *
 	 * @var string
 	 */
-	protected $template = null;
-
-	/**
-	 * The name of the default template source file.
-	 *
-	 * @var string
-	 * @deprecated use $template declare as private
-	 */
 	protected $_template = null;
 
 	/**
 	 * The output of the template script.
 	 *
 	 * @var string
-	 */
-	protected $output = null;
-
-	/**
-	 * The output of the template script.
-	 *
-	 * @var string
-	 * @deprecated use $output declare as private
 	 */
 	protected $_output = null;
 
@@ -175,28 +95,12 @@ class JView extends JObject
 	 *
 	 * @var string
 	 */
-	protected $escape = 'htmlspecialchars';
-
-	/**
-	 * Callback for escaping.
-	 *
-	 * @var string
-	 * @deprecated use $escape declare as private
-	 */
 	protected $_escape = 'htmlspecialchars';
 
 	/**
 	 * Charset to use in escaping mechanisms; defaults to urf8 (UTF-8)
 	 *
 	 * @var string
-	 */
-	protected $charset = 'UTF-8';
-
-	/**
-	 * Charset to use in escaping mechanisms; defaults to urf8 (UTF-8)
-	 *
-	 * @var string
-	 * @deprecated use $charset declare as private
 	 */
 	protected $_charset = 'UTF-8';
 


### PR DESCRIPTION
Besides changing the subpackage tags to match the folders the biggest change is to undeprecated the protected class members that start with an underscore.

Those hints - without offering a real alternative - only confuse developers, I don't think we'll want to do a change like this in the legacy folder anyways since those classes are eventually gonna be removed or moved to the CMS.
