### PR TITLE
added .moor-box  label

### DIFF
--- a/libraries/joomla/html/html/behavior.php
+++ b/libraries/joomla/html/html/behavior.php
@@ -684,7 +684,8 @@ abstract class JHtmlBehavior
 						item.type = 'color';
 					} else {
 						new MooRainbow(item,
-						{
+						{       
+							id:item.id,
 							imgPath: '" . JURI::root(true)
 			. "/media/system/images/mooRainbow/',
 							onComplete: function(color) {

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -754,4 +754,22 @@ class JImage
 
 		return $width;
 	}
+	
+	/**
+	 * Method to give the used Memory for the current handle free
+	 *
+	 * @return  void
+	 * @see     http://de2.php.net/imagedestroy
+	 */
+	public function destroy()
+	{
+		// Make sure the resource handle is valid.
+		if ( !$this->isLoaded() )
+		{
+			throw new LogicException( 'No valid image was loaded.' );
+		}
+        
+		return imagedestroy( $this->handle );
+
+	}
 }

--- a/libraries/joomla/installer/adapters/file.php
+++ b/libraries/joomla/installer/adapters/file.php
@@ -390,6 +390,7 @@ class JInstallerFile extends JAdapterInstance
 	public function uninstall($id)
 	{
 		// Initialise variables.
+		$db = JFactory::getDbo();
 		$row = JTable::getInstance('extension');
 		if (!$row->load($id))
 		{
@@ -489,8 +490,7 @@ class JInstallerFile extends JAdapterInstance
 			}
 
 			// Remove the schema version
-			$db = JFactory::getDbo();
-			$query = $db->getQuery(true);
+		        $query = $db->getQuery(true);
 			$query->delete()
 				->from('#__schemas')
 				->where('extension_id = ' . $row->extension_id);

--- a/media/system/css/mooRainbow.css
+++ b/media/system/css/mooRainbow.css
@@ -55,7 +55,7 @@
 	border-left-color: #f5f5f5;
 	border-top-color: #f5f5f5;
 }
-label {
+.moor-box label {
 	font-family: mono;
 }
 /* Following are just <label> */
@@ -83,7 +83,7 @@ label {
 	margin-top: 190px;
 	margin-left: 315px;
 }
-span.moor-ballino { /* Style hue ° (degree) !! */
+span.moor-ballino { /* Style hue (degree) !! */
 	/*display: none;*/
 	visibility: hidden;
 	margin-top: 190px;


### PR DESCRIPTION
The ".moor-box label" is needed to box the colorpicker in his-self namespace.
Joomla Forms will be display normally and the colorpicker use his own label class to have the functionality that the founder of the rainbow css prefers .
