### PR TITLE
Fixed id of the language inputbox in the label tag

### DIFF
--- a/libraries/joomla/html/html/batch.php
+++ b/libraries/joomla/html/html/batch.php
@@ -80,7 +80,7 @@ abstract class JHtmlBatch
 	{
 		// Create the batch selector to change the language on a selection list.
 		$lines = array(
-			'<label id="batch-language-lbl" for="batch-language" class="hasTip"'
+			'<label id="batch-language-lbl" for="batch-language-id" class="hasTip"'
 			. ' title="' . JText::_('JLIB_HTML_BATCH_LANGUAGE_LABEL') . '::' . JText::_('JLIB_HTML_BATCH_LANGUAGE_LABEL_DESC') . '">',
 			JText::_('JLIB_HTML_BATCH_LANGUAGE_LABEL'),
 			'</label>',


### PR DESCRIPTION
The label for the language selector had a wrong "for" attribut, thus clicking on the label didn't select the inputbox.
