### PR TITLE
Deprecate JXMLElement

### DIFF
--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -503,8 +503,8 @@ class JAccess
 	/**
 	 * Method to return a list of actions from a string or from an xml for which permissions can be set.
 	 *
-	 * @param   string|JXMLElement  $data   The XML string or an XML element.
-	 * @param   string              $xpath  An optional xpath to search for the fields.
+	 * @param   string|SimpleXMLElement  $data   The XML string or an XML element.
+	 * @param   string                   $xpath  An optional xpath to search for the fields.
 	 *
 	 * @return  boolean|array   False if case of error or the list of actions available.
 	 *
@@ -513,7 +513,7 @@ class JAccess
 	public static function getActionsFromData($data, $xpath = "/access/section[@name='component']/")
 	{
 		// If the data to load isn't already an XML element or string return false.
-		if ((!($data instanceof JXMLElement)) && (!is_string($data)))
+		if ((!($data instanceof SimpleXMLElement)) && (!is_string($data)))
 		{
 			return false;
 		}

--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -378,6 +378,7 @@ abstract class JFactory
 	 *
 	 * @see     JXMLElement
 	 * @since   11.1
+	 * @note    This method will return SimpleXMLElement object in the future. Do not rely on JXMLElement's methods.
 	 * @todo    This may go in a separate class - error reporting may be improved.
 	 */
 	public static function getXML($data, $isFile = true)

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -27,9 +27,9 @@ abstract class JFormField
 	protected $description;
 
 	/**
-	 * The JXMLElement object of the <field /> XML element that describes the form field.
+	 * The SimpleXMLElement object of the <field /> XML element that describes the form field.
 	 *
-	 * @var    JXMLElement
+	 * @var    SimpleXMLElement
 	 * @since  11.1
 	 */
 	protected $element;
@@ -288,11 +288,11 @@ abstract class JFormField
 	/**
 	 * Method to attach a JForm object to the field.
 	 *
-	 * @param   JXmlElement  $element  The JXmlElement object representing the <field /> tag for the form field object.
-	 * @param   mixed        $value    The form field value to validate.
-	 * @param   string       $group    The field name group control value. This acts as as an array container for the field.
-	 *                                 For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                 full field name would end up being "bar[foo]".
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
 	 *
 	 * @return  boolean  True on success.
 	 *
@@ -301,7 +301,7 @@ abstract class JFormField
 	public function setup($element, $value, $group = null)
 	{
 		// Make sure there is a valid JFormField XML element.
-		if (!($element instanceof JXMLElement) || (string) $element->getName() != 'field')
+		if (!($element instanceof SimpleXMLElement) || (string) $element->getName() != 'field')
 		{
 			return false;
 		}

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -101,7 +101,7 @@ class JForm
 	public function bind($data)
 	{
 		// Make sure there is a valid JForm XML document.
-		if (!($this->xml instanceof JXMLElement))
+		if (!($this->xml instanceof SimpleXMLElement))
 		{
 			return false;
 		}
@@ -196,7 +196,7 @@ class JForm
 	public function filter($data, $group = null)
 	{
 		// Make sure there is a valid JForm XML document.
-		if (!($this->xml instanceof JXMLElement))
+		if (!($this->xml instanceof SimpleXMLElement))
 		{
 			return false;
 		}
@@ -272,7 +272,7 @@ class JForm
 	public function getField($name, $group = null, $value = null)
 	{
 		// Make sure there is a valid JForm XML document.
-		if (!($this->xml instanceof JXMLElement))
+		if (!($this->xml instanceof SimpleXMLElement))
 		{
 			return false;
 		}
@@ -306,16 +306,16 @@ class JForm
 	public function getFieldAttribute($name, $attribute, $default = null, $group = null)
 	{
 		// Make sure there is a valid JForm XML document.
-		if (!($this->xml instanceof JXMLElement))
+		if (!($this->xml instanceof SimpleXMLElement))
 		{
-			throw new UnexpectedValueException(sprint('%s::getFieldAttribute `xml` is not an instance of JXMLElement', get_class($this)));
+			throw new UnexpectedValueException(sprint('%s::getFieldAttribute `xml` is not an instance of SimpleXMLElement', get_class($this)));
 		}
 
 		// Find the form field element from the definition.
 		$element = $this->findField($name, $group);
 
 		// If the element exists and the attribute exists for the field return the attribute value.
-		if (($element instanceof JXMLElement) && ((string) $element[$attribute]))
+		if (($element instanceof SimpleXMLElement) && ((string) $element[$attribute]))
 		{
 			return (string) $element[$attribute];
 		}
@@ -392,7 +392,7 @@ class JForm
 		$sets = array();
 
 		// Make sure there is a valid JForm XML document.
-		if (!($this->xml instanceof JXMLElement))
+		if (!($this->xml instanceof SimpleXMLElement))
 		{
 			return $fieldsets;
 		}
@@ -642,7 +642,7 @@ class JForm
 	public function load($data, $replace = true, $xpath = false)
 	{
 		// If the data to load isn't already an XML element or string return false.
-		if ((!($data instanceof JXMLElement)) && (!is_string($data)))
+		if ((!($data instanceof SimpleXMLElement)) && (!is_string($data)))
 		{
 			return false;
 		}
@@ -786,16 +786,16 @@ class JForm
 	public function removeField($name, $group = null)
 	{
 		// Make sure there is a valid JForm XML document.
-		if (!($this->xml instanceof JXMLElement))
+		if (!($this->xml instanceof SimpleXMLElement))
 		{
-			throw new UnexpectedValueException(sprint('%s::getFieldAttribute `xml` is not an instance of JXMLElement', get_class($this)));
+			throw new UnexpectedValueException(sprint('%s::getFieldAttribute `xml` is not an instance of SimpleXMLElement', get_class($this)));
 		}
 
 		// Find the form field element from the definition.
 		$element = $this->findField($name, $group);
 
 		// If the element exists remove it from the form definition.
-		if ($element instanceof JXMLElement)
+		if ($element instanceof SimpleXMLElement)
 		{
 			$dom = dom_import_simplexml($element);
 			$dom->parentNode->removeChild($dom);
@@ -817,9 +817,9 @@ class JForm
 	public function removeGroup($group)
 	{
 		// Make sure there is a valid JForm XML document.
-		if (!($this->xml instanceof JXMLElement))
+		if (!($this->xml instanceof SimpleXMLElement))
 		{
-			throw new UnexpectedValueException(sprint('%s::getFieldAttribute `xml` is not an instance of JXMLElement', get_class($this)));
+			throw new UnexpectedValueException(sprint('%s::getFieldAttribute `xml` is not an instance of SimpleXMLElement', get_class($this)));
 		}
 
 		// Get the fields elements for a given group.
@@ -861,21 +861,21 @@ class JForm
 	 * the field will be set whether it already exists or not.  If it isn't set, then the field
 	 * will not be replaced if it already exists.
 	 *
-	 * @param   JXMLElement  $element  The XML element object representation of the form field.
-	 * @param   string       $group    The optional dot-separated form group path on which to set the field.
-	 * @param   boolean      $replace  True to replace an existing field if one already exists.
+	 * @param   SimpleXMLElement  $element  The XML element object representation of the form field.
+	 * @param   string            $group    The optional dot-separated form group path on which to set the field.
+	 * @param   boolean           $replace  True to replace an existing field if one already exists.
 	 *
 	 * @return  boolean  True on success.
 	 *
 	 * @since   11.1
 	 * @throws  UnexpectedValueException
 	 */
-	public function setField(JXMLElement $element, $group = null, $replace = true)
+	public function setField(SimpleXMLElement $element, $group = null, $replace = true)
 	{
 		// Make sure there is a valid JForm XML document.
-		if (!($this->xml instanceof JXMLElement))
+		if (!($this->xml instanceof SimpleXMLElement))
 		{
-			throw new UnexpectedValueException(sprint('%s::getFieldAttribute `xml` is not an instance of JXMLElement', get_class($this)));
+			throw new UnexpectedValueException(sprint('%s::getFieldAttribute `xml` is not an instance of SimpleXMLElement', get_class($this)));
 		}
 
 		// Find the form field element from the definition.
@@ -888,7 +888,7 @@ class JForm
 		}
 
 		// If an existing field is found and replace flag is true remove the old field.
-		if ($replace && !empty($old) && ($old instanceof JXMLElement))
+		if ($replace && !empty($old) && ($old instanceof SimpleXMLElement))
 		{
 			$dom = dom_import_simplexml($old);
 			$dom->parentNode->removeChild($dom);
@@ -902,7 +902,7 @@ class JForm
 			$fields = &$this->findGroup($group);
 
 			// If an appropriate fields element was found for the group, add the element.
-			if (isset($fields[0]) && ($fields[0] instanceof JXMLElement))
+			if (isset($fields[0]) && ($fields[0] instanceof SimpleXMLElement))
 			{
 				self::addNode($fields[0], $element);
 			}
@@ -935,16 +935,16 @@ class JForm
 	public function setFieldAttribute($name, $attribute, $value, $group = null)
 	{
 		// Make sure there is a valid JForm XML document.
-		if (!($this->xml instanceof JXMLElement))
+		if (!($this->xml instanceof SimpleXMLElement))
 		{
-			throw new UnexpectedValueException(sprint('%s::getFieldAttribute `xml` is not an instance of JXMLElement', get_class($this)));
+			throw new UnexpectedValueException(sprint('%s::getFieldAttribute `xml` is not an instance of SimpleXMLElement', get_class($this)));
 		}
 
 		// Find the form field element from the definition.
 		$element = $this->findField($name, $group);
 
 		// If the element doesn't exist return false.
-		if (!($element instanceof JXMLElement))
+		if (!($element instanceof SimpleXMLElement))
 		{
 			return false;
 		}
@@ -977,17 +977,17 @@ class JForm
 	public function setFields(&$elements, $group = null, $replace = true)
 	{
 		// Make sure there is a valid JForm XML document.
-		if (!($this->xml instanceof JXMLElement))
+		if (!($this->xml instanceof SimpleXMLElement))
 		{
-			throw new UnexpectedValueException(sprint('%s::getFieldAttribute `xml` is not an instance of JXMLElement', get_class($this)));
+			throw new UnexpectedValueException(sprint('%s::getFieldAttribute `xml` is not an instance of SimpleXMLElement', get_class($this)));
 		}
 
 		// Make sure the elements to set are valid.
 		foreach ($elements as $element)
 		{
-			if (!($element instanceof JXMLElement))
+			if (!($element instanceof SimpleXMLElement))
 			{
-				throw new UnexpectedValueException(sprintf('$element not JXmlElement in %s::setFields', get_class($this)));
+				throw new UnexpectedValueException(sprintf('$element not SimpleXMLElement in %s::setFields', get_class($this)));
 			}
 		}
 
@@ -1057,7 +1057,7 @@ class JForm
 	public function validate($data, $group = null)
 	{
 		// Make sure there is a valid JForm XML document.
-		if (!($this->xml instanceof JXMLElement))
+		if (!($this->xml instanceof SimpleXMLElement))
 		{
 			return false;
 		}
@@ -1124,8 +1124,8 @@ class JForm
 	 */
 	protected function filterField($element, $value)
 	{
-		// Make sure there is a valid JXMLElement.
-		if (!($element instanceof JXMLElement))
+		// Make sure there is a valid SimpleXMLElement.
+		if (!($element instanceof SimpleXMLElement))
 		{
 			return false;
 		}
@@ -1377,7 +1377,7 @@ class JForm
 		$fields = array();
 
 		// Make sure there is a valid JForm XML document.
-		if (!($this->xml instanceof JXMLElement))
+		if (!($this->xml instanceof SimpleXMLElement))
 		{
 			return false;
 		}
@@ -1458,7 +1458,7 @@ class JForm
 	 *
 	 * @param   string  $name  The name of the fieldset.
 	 *
-	 * @return  mixed  Boolean false on error or array of JXMLElement objects.
+	 * @return  mixed  Boolean false on error or array of SimpleXMLElement objects.
 	 *
 	 * @since   11.1
 	 */
@@ -1468,7 +1468,7 @@ class JForm
 		$false = false;
 
 		// Make sure there is a valid JForm XML document.
-		if (!($this->xml instanceof JXMLElement))
+		if (!($this->xml instanceof SimpleXMLElement))
 		{
 			return $false;
 		}
@@ -1492,7 +1492,7 @@ class JForm
 	 * @param   boolean  $nested  True to also include fields in nested groups that are inside of the
 	 * group for which to find fields.
 	 *
-	 * @return  mixed  Boolean false on error or array of JXMLElement objects.
+	 * @return  mixed  Boolean false on error or array of SimpleXMLElement objects.
 	 *
 	 * @since   11.1
 	 */
@@ -1503,7 +1503,7 @@ class JForm
 		$fields = array();
 
 		// Make sure there is a valid JForm XML document.
-		if (!($this->xml instanceof JXMLElement))
+		if (!($this->xml instanceof SimpleXMLElement))
 		{
 			return $false;
 		}
@@ -1579,7 +1579,7 @@ class JForm
 		$tmp = array();
 
 		// Make sure there is a valid JForm XML document.
-		if (!($this->xml instanceof JXMLElement))
+		if (!($this->xml instanceof SimpleXMLElement))
 		{
 			return $false;
 		}
@@ -1635,7 +1635,7 @@ class JForm
 			// Only include valid XML objects.
 			foreach ($tmp as $element)
 			{
-				if ($element instanceof JXMLElement)
+				if ($element instanceof SimpleXMLElement)
 				{
 					$groups[] = $element;
 				}
@@ -1658,8 +1658,8 @@ class JForm
 	 */
 	protected function loadField($element, $group = null, $value = null)
 	{
-		// Make sure there is a valid JXMLElement.
-		if (!($element instanceof JXMLElement))
+		// Make sure there is a valid SimpleXMLElement.
+		if (!($element instanceof SimpleXMLElement))
 		{
 			return false;
 		}
@@ -1757,7 +1757,7 @@ class JForm
 	protected function syncPaths()
 	{
 		// Make sure there is a valid JForm XML document.
-		if (!($this->xml instanceof JXMLElement))
+		if (!($this->xml instanceof SimpleXMLElement))
 		{
 			return false;
 		}
@@ -1801,11 +1801,11 @@ class JForm
 	/**
 	 * Method to validate a JFormField object based on field data.
 	 *
-	 * @param   string     $element  The XML element object representation of the form field.
-	 * @param   string     $group    The optional dot-separated form group path on which to find the field.
-	 * @param   mixed      $value    The optional value to use as the default for the field.
-	 * @param   JRegistry  $input    An optional JRegistry object with the entire data set to validate
-	 *                               against the entire form.
+	 * @param   SimpleXMLElement  $element  The XML element object representation of the form field.
+	 * @param   string            $group    The optional dot-separated form group path on which to find the field.
+	 * @param   mixed             $value    The optional value to use as the default for the field.
+	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate
+	 *                                      against the entire form.
 	 *
 	 * @return  mixed  Boolean true if field value is valid, Exception on failure.
 	 *
@@ -1813,7 +1813,7 @@ class JForm
 	 * @throws  InvalidArgumentException
 	 * @throws  UnexpectedValueException
 	 */
-	protected function validateField(JXmlElement $element, $group = null, $value = null, JRegistry $input = null)
+	protected function validateField(SimpleXMLElement $element, $group = null, $value = null, JRegistry $input = null)
 	{
 		// Initialise variables.
 		$valid = true;

--- a/libraries/joomla/form/rule.php
+++ b/libraries/joomla/form/rule.php
@@ -43,13 +43,13 @@ class JFormRule
 	/**
 	 * Method to test the value.
 	 *
-	 * @param   JXmlElement  $element  The JXmlElement object representing the <field /> tag for the form field object.
-	 * @param   mixed        $value    The form field value to validate.
-	 * @param   string       $group    The field name group control value. This acts as as an array container for the field.
-	 *                                 For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                 full field name would end up being "bar[foo]".
-	 * @param   JRegistry    $input    An optional JRegistry object with the entire data set to validate against the entire form.
-	 * @param   JForm        $form     The form object for which the field is being tested.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *

--- a/libraries/joomla/form/rules/color.php
+++ b/libraries/joomla/form/rules/color.php
@@ -21,13 +21,13 @@ class JFormRuleColor extends JFormRule
 	/**
 	 * Method to test for a valid color in hexadecimal.
 	 *
-	 * @param   JXmlElement  $element  The JXmlElement object representing the <field /> tag for the form field object.
-	 * @param   mixed        $value    The form field value to validate.
-	 * @param   string       $group    The field name group control value. This acts as as an array container for the field.
-	 *                                 For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                 full field name would end up being "bar[foo]".
-	 * @param   JRegistry    $input    An optional JRegistry object with the entire data set to validate against the entire form.
-	 * @param   JForm        $form     The form object for which the field is being tested.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *

--- a/libraries/joomla/form/rules/email.php
+++ b/libraries/joomla/form/rules/email.php
@@ -29,13 +29,13 @@ class JFormRuleEmail extends JFormRule
 	/**
 	 * Method to test the email address and optionally check for uniqueness.
 	 *
-	 * @param   JXMLElement  $element  The JXMLElement object representing the <field /> tag for the form field object.
-	 * @param   mixed        $value    The form field value to validate.
-	 * @param   string       $group    The field name group control value. This acts as as an array container for the field.
-	 *                                 For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                 full field name would end up being "bar[foo]".
-	 * @param   JRegistry    $input    An optional JRegistry object with the entire data set to validate against the entire form.
-	 * @param   JForm        $form     The form object for which the field is being tested.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *

--- a/libraries/joomla/form/rules/equals.php
+++ b/libraries/joomla/form/rules/equals.php
@@ -23,13 +23,13 @@ class JFormRuleEquals extends JFormRule
 	 * XML needs a validate attribute of equals and a field attribute
 	 * that is equal to the field to test against.
 	 *
-	 * @param   JXMLElement  $element  The JXmlElement object representing the <field /> tag for the form field object.
-	 * @param   mixed        $value    The form field value to validate.
-	 * @param   string       $group    The field name group control value. This acts as as an array container for the field.
-	 *                                 For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                 full field name would end up being "bar[foo]".
-	 * @param   JRegistry    $input    An optional JRegistry object with the entire data set to validate against the entire form.
-	 * @param   JForm        $form     The form object for which the field is being tested.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *

--- a/libraries/joomla/form/rules/options.php
+++ b/libraries/joomla/form/rules/options.php
@@ -21,13 +21,13 @@ class JFormRuleOptions extends JFormRule
 	/**
 	 * Method to test the value.
 	 *
-	 * @param   JXMLElement  $element  The JXMLElement object representing the <field /> tag for the form field object.
-	 * @param   mixed        $value    The form field value to validate.
-	 * @param   string       $group    The field name group control value. This acts as as an array container for the field.
-	 *                                 For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                 full field name would end up being "bar[foo]".
-	 * @param   JRegistry    $input    An optional JRegistry object with the entire data set to validate against the entire form.
-	 * @param   JForm        $form     The form object for which the field is being tested.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *

--- a/libraries/joomla/form/rules/rules.php
+++ b/libraries/joomla/form/rules/rules.php
@@ -21,13 +21,13 @@ class JFormRuleRules extends JFormRule
 	/**
 	 * Method to test the value.
 	 *
-	 * @param   JXmlElement  $element  The JXmlElement object representing the <field /> tag for the form field object.
-	 * @param   mixed        $value    The form field value to validate.
-	 * @param   string       $group    The field name group control value. This acts as as an array container for the field.
-	 *                                 For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                 full field name would end up being "bar[foo]".
-	 * @param   JRegistry    $input    An optional JRegistry object with the entire data set to validate against the entire form.
-	 * @param   JForm        $form     The form object for which the field is being tested.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
@@ -77,8 +77,8 @@ class JFormRuleRules extends JFormRule
 	/**
 	 * Method to get the list of possible permission action names for the form field.
 	 *
-	 * @param   JXMLElement  $element  The JXMLElement object representing the <field /> tag for the
-	 *                                 form field object.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the
+	 *                                      form field object.
 	 *
 	 * @return  array   A list of permission action names from the form field element definition.
 	 *

--- a/libraries/joomla/form/rules/tel.php
+++ b/libraries/joomla/form/rules/tel.php
@@ -21,13 +21,13 @@ class JFormRuleTel extends JFormRule
 	/**
 	 * Method to test the url for a valid parts.
 	 *
-	 * @param   JXmlElement  $element  The JXmlElement object representing the <field /> tag for the form field object.
-	 * @param   mixed        $value    The form field value to validate.
-	 * @param   string       $group    The field name group control value. This acts as as an array container for the field.
-	 *                                 For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                 full field name would end up being "bar[foo]".
-	 * @param   JRegistry    $input    An optional JRegistry object with the entire data set to validate against the entire form.
-	 * @param   JForm        $form     The form object for which the field is being tested.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *

--- a/libraries/joomla/form/rules/url.php
+++ b/libraries/joomla/form/rules/url.php
@@ -21,13 +21,13 @@ class JFormRuleUrl extends JFormRule
 	/**
 	 * Method to test an external url for a valid parts.
 	 *
-	 * @param   JXmlElement  $element  The JXmlElement object representing the <field /> tag for the form field object.
-	 * @param   mixed        $value    The form field value to validate.
-	 * @param   string       $group    The field name group control value. This acts as as an array container for the field.
-	 *                                 For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                 full field name would end up being "bar[foo]".
-	 * @param   JRegistry    $input    An optional JRegistry object with the entire data set to validate against the entire form.
-	 * @param   JForm        $form     The form object for which the field is being tested.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *

--- a/libraries/joomla/form/rules/username.php
+++ b/libraries/joomla/form/rules/username.php
@@ -21,13 +21,13 @@ class JFormRuleUsername extends JFormRule
 	/**
 	 * Method to test the username for uniqueness.
 	 *
-	 * @param   JXMLElement  $element  The JXMLElement object representing the <field /> tag for the form field object.
-	 * @param   mixed        $value    The form field value to validate.
-	 * @param   string       $group    The field name group control value. This acts as as an array container for the field.
-	 *                                 For example if the field has name="foo" and the group value is set to "bar" then the
-	 *                                 full field name would end up being "bar[foo]".
-	 * @param   JRegistry    $input    An optional JRegistry object with the entire data set to validate against the entire form.
-	 * @param   JForm        $form     The form object for which the field is being tested.
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 * @param   JRegistry         $input    An optional JRegistry object with the entire data set to validate against the entire form.
+	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *

--- a/libraries/joomla/installer/adapters/module.php
+++ b/libraries/joomla/installer/adapters/module.php
@@ -801,7 +801,7 @@ class JInstallerModule extends JAdapterInstance
 		$msg = ob_get_contents();
 		ob_end_clean();
 
-		if (!($this->manifest instanceof JXMLElement))
+		if (!($this->manifest instanceof SimpleXMLElement))
 		{
 			// Make sure we delete the folders
 			JFolder::delete($this->parent->getPath('extension_root'));

--- a/libraries/joomla/installer/adapters/template.php
+++ b/libraries/joomla/installer/adapters/template.php
@@ -390,7 +390,7 @@ class JInstallerTemplate extends JAdapterInstance
 		// We do findManifest to avoid problem when uninstalling a list of extensions: getManifest cache its manifest file
 		$this->parent->findManifest();
 		$manifest = $this->parent->getManifest();
-		if (!($manifest instanceof JXMLElement))
+		if (!($manifest instanceof SimpleXMLElement))
 		{
 			// Kill the extension entry
 			$row->delete($row->extension_id);

--- a/libraries/joomla/installer/extension.php
+++ b/libraries/joomla/installer/extension.php
@@ -86,13 +86,13 @@ class JExtension extends JObject
 	/**
 	 * Constructor
 	 *
-	 * @param   JXMLElement  $element  A JXMLElement from which to load data from
+	 * @param   SimpleXMLElement  $element  A SimpleXMLElement from which to load data from
 	 *
 	 * @since  11.1
 	 */
-	public function __construct(JXMLElement $element = null)
+	public function __construct(SimpleXMLElement $element = null)
 	{
-		if ($element && is_a($element, 'JXMLElement'))
+		if ($element)
 		{
 			$this->type = (string) $element->attributes()->type;
 			$this->id = (string) $element->attributes()->id;

--- a/libraries/joomla/installer/installer.php
+++ b/libraries/joomla/installer/installer.php
@@ -805,7 +805,7 @@ class JInstaller extends JAdapter
 	 * Backward compatible method to parse through a queries element of the
 	 * installation manifest file and take appropriate action.
 	 *
-	 * @param   JXMLElement  $element  The XML node to process
+	 * @param   SimpleXMLElement  $element  The XML node to process
 	 *
 	 * @return  mixed  Number of queries processed or False on error
 	 *
@@ -943,8 +943,8 @@ class JInstaller extends JAdapter
 	/**
 	 * Set the schema version for an extension by looking at its latest update
 	 *
-	 * @param   JXMLElement  $schema  Schema Tag
-	 * @param   integer      $eid     Extension ID
+	 * @param   SimpleXMLElement  $schema  Schema Tag
+	 * @param   integer           $eid     Extension ID
 	 *
 	 * @return  void
 	 *
@@ -1011,10 +1011,10 @@ class JInstaller extends JAdapter
 	/**
 	 * Method to process the updates for an item
 	 *
-	 * @param   JXMLElement  $schema  The XML node to process
-	 * @param   integer      $eid     Extension Identifier
+	 * @param   SimpleXMLElement  $schema  The XML node to process
+	 * @param   integer           $eid     Extension Identifier
 	 *
-	 * @return  boolean      Result of the operations
+	 * @return  boolean           Result of the operations
 	 *
 	 * @since   11.1
 	 */
@@ -1141,10 +1141,10 @@ class JInstaller extends JAdapter
 	 * Method to parse through a files element of the installation manifest and take appropriate
 	 * action.
 	 *
-	 * @param   JXMLElement  $element   The XML node to process
-	 * @param   integer      $cid       Application ID of application to install to
-	 * @param   array        $oldFiles  List of old files (JXMLElement's)
-	 * @param   array        $oldMD5    List of old MD5 sums (indexed by filename with value as MD5)
+	 * @param   SimpleXMLElement  $element   The XML node to process
+	 * @param   integer           $cid       Application ID of application to install to
+	 * @param   array             $oldFiles  List of old files (SimpleXMLElement's)
+	 * @param   array             $oldMD5    List of old MD5 sums (indexed by filename with value as MD5)
 	 *
 	 * @return  boolean      True on success
 	 *
@@ -1201,7 +1201,7 @@ class JInstaller extends JAdapter
 		}
 
 		// Work out what files have been deleted
-		if ($oldFiles && ($oldFiles instanceof JXMLElement))
+		if ($oldFiles && ($oldFiles instanceof SimpleXMLElement))
 		{
 			$oldEntries = $oldFiles->children();
 
@@ -1269,8 +1269,8 @@ class JInstaller extends JAdapter
 	 * Method to parse through a languages element of the installation manifest and take appropriate
 	 * action.
 	 *
-	 * @param   JXMLElement  $element  The XML node to process
-	 * @param   integer      $cid      Application ID of application to install to
+	 * @param   SimpleXMLElement  $element  The XML node to process
+	 * @param   integer           $cid      Application ID of application to install to
 	 *
 	 * @return  boolean  True on success
 	 *
@@ -1386,8 +1386,8 @@ class JInstaller extends JAdapter
 	 * Method to parse through a media element of the installation manifest and take appropriate
 	 * action.
 	 *
-	 * @param   JXMLElement  $element  The XML node to process
-	 * @param   integer      $cid      Application ID of application to install to
+	 * @param   SimpleXMLElement  $element  The XML node to process
+	 * @param   integer           $cid      Application ID of application to install to
 	 *
 	 * @return  boolean     True on success
 	 *
@@ -1956,8 +1956,8 @@ class JInstaller extends JAdapter
 	/**
 	 * Compares two "files" entries to find deleted files/folders
 	 *
-	 * @param   array  $old_files  An array of JXMLElement objects that are the old files
-	 * @param   array  $new_files  An array of JXMLElement objects that are the new files
+	 * @param   array  $old_files  An array of SimpleXMLElement objects that are the old files
+	 * @param   array  $new_files  An array of SimpleXMLElement objects that are the new files
 	 *
 	 * @return  array  An array with the delete files and folders in findDeletedFiles[files] and findDeletedFiles[folders] respectively
 	 *

--- a/libraries/joomla/utilities/xmlelement.php
+++ b/libraries/joomla/utilities/xmlelement.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Platform
  * @subpackage  Utilities
  * @since       11.1
+ * @deprecated  13.3 Use SimpleXMLElement instead.
  */
 class JXMLElement extends SimpleXMLElement
 {
@@ -24,9 +25,11 @@ class JXMLElement extends SimpleXMLElement
 	 * @return  string
 	 *
 	 * @since   11.1
+	 * @deprecated 13.3  Use SimpleXMLElement::getName() instead.
 	 */
 	public function name()
 	{
+		JLog::add('JXMLElement::name() is deprecated, use SimpleXMLElement::getName() instead.', self::WARNING, 'deprecated');
 		return (string) $this->getName();
 	}
 
@@ -40,9 +43,11 @@ class JXMLElement extends SimpleXMLElement
 	 * @return  string
 	 *
 	 * @since   11.1
+	 * @deprecated 13.3  Use SimpleXMLElement::asXML() instead.
 	 */
 	public function asFormattedXML($compressed = false, $indent = "\t", $level = 0)
 	{
+		JLog::add('JXMLElement::asFormattedXML() is deprecated, use SimpleXMLElement::asXML() instead.', self::WARNING, 'deprecated');
 		$out = '';
 
 		// Start a new line, indent by the number indicated in $level


### PR DESCRIPTION
JXMLElement isn't all that useful anymore. It only has two methods, one is just an alias to an internal method of the parent class. The other can be replaced by a method of the parent class in most cases, in case people need to pretty print they can either move the method to their own code or use DOMDocument to do it for them.
