### PR TITLE
grid.php calls isCheckedOut statically

### DIFF
--- a/libraries/joomla/html/html/grid.php
+++ b/libraries/joomla/html/html/grid.php
@@ -146,7 +146,7 @@ abstract class JHtmlGrid
 		}
 		else
 		{
-			$result = JTable::isCheckedOut($userid, $row->checked_out);
+			$result = false;
 		}
 
 		$checked = '';


### PR DESCRIPTION
I use Joomla 2.5.1, and my request is about file libraries/joomla/database/table.php. Now (in latest trunk joomla-platform - it is in libraries/joomla/table/table.php). But neverthless, request is the same. There is a function isCheckedOut in this file. I worked on my site and receive many such messages

"Strict Standards: Non-static method JTable::isCheckedOut() should not be called statically in /srv/www/libraries/joomla/html/html/grid.php on line 198"

As discussed here https://github.com/joomla/joomla-platform/issues/1116 by AmyStephen, i change the code
