### PR TITLE
Check for install method versus discover_install

### DIFF
--- a/libraries/joomla/installer/adapters/component.php
+++ b/libraries/joomla/installer/adapters/component.php
@@ -1700,7 +1700,7 @@ class JInstallerComponent extends JAdapterInstance
 		ob_start();
 		ob_implicit_flush(false);
 
-		if ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'discover_install'))
+		if ($this->parent->manifestClass && method_exists($this->parent->manifestClass, 'install'))
 		{
 
 			if ($this->parent->manifestClass->install($this) === false)


### PR DESCRIPTION
In a rather odd twist, in the discover_install method of the component install adapter, we check if there is a discover_install method in the script file (which isn't documented anywhere as actually needed), which presumably causes this check to always fail.  Should it succeed, the script file's install method is the one actually triggered.

This is one of two potential solutions to the problem.  I've changed the check so that we check if the install method exists.  The other option, which would need documenting, would be to use a discover_install method in the script files.

On an unrelated note, the component adapter is the only one which actually triggers the script file at discover_install, though it is supported in many other adapters, so once this is sorted out, the next goal is to get that support into the other adapters.
