### PR TITLE
Allow media field to be disabled fully

### DIFF
--- a/libraries/legacy/form/field/media.php
+++ b/libraries/legacy/form/field/media.php
@@ -113,27 +113,30 @@ class JFormFieldMedia extends JFormField
 			$folder = '';
 		}
 		// The button.
-		$html[] = '<div class="button2-left">';
-		$html[] = '	<div class="blank">';
-		$html[] = '		<a class="modal" title="' . JText::_('JLIB_FORM_BUTTON_SELECT') . '"' . ' href="'
-			. ($this->element['readonly'] ? ''
-			: ($link ? $link
-				: 'index.php?option=com_media&amp;view=images&amp;tmpl=component&amp;asset=' . $asset . '&amp;author='
-				. $this->form->getValue($authorField)) . '&amp;fieldid=' . $this->id . '&amp;folder=' . $folder) . '"'
-			. ' rel="{handler: \'iframe\', size: {x: 800, y: 500}}">';
-		$html[] = JText::_('JLIB_FORM_BUTTON_SELECT') . '</a>';
-		$html[] = '	</div>';
-		$html[] = '</div>';
+		if ($this->element['disabled'] != true)
+		{
+			$html[] = '<div class="button2-left">';
+			$html[] = '	<div class="blank">';
+			$html[] = '		<a class="modal" title="' . JText::_('JLIB_FORM_BUTTON_SELECT') . '"' . ' href="'
+				. ($this->element['readonly'] ? ''
+				: ($link ? $link
+					: 'index.php?option=com_media&amp;view=images&amp;tmpl=component&amp;asset=' . $asset . '&amp;author='
+					. $this->form->getValue($authorField)) . '&amp;fieldid=' . $this->id . '&amp;folder=' . $folder) . '"'
+				. ' rel="{handler: \'iframe\', size: {x: 800, y: 500}}">';
+			$html[] = JText::_('JLIB_FORM_BUTTON_SELECT') . '</a>';
+			$html[] = '	</div>';
+			$html[] = '</div>';
 
-		$html[] = '<div class="button2-left">';
-		$html[] = '	<div class="blank">';
-		$html[] = '		<a title="' . JText::_('JLIB_FORM_BUTTON_CLEAR') . '"' . ' href="#" onclick="';
-		$html[] = 'jInsertFieldValue(\'\', \'' . $this->id . '\');';
-		$html[] = 'return false;';
-		$html[] = '">';
-		$html[] = JText::_('JLIB_FORM_BUTTON_CLEAR') . '</a>';
-		$html[] = '	</div>';
-		$html[] = '</div>';
+			$html[] = '<div class="button2-left">';
+			$html[] = '	<div class="blank">';
+			$html[] = '		<a title="' . JText::_('JLIB_FORM_BUTTON_CLEAR') . '"' . ' href="#" onclick="';
+			$html[] = 'jInsertFieldValue(\'\', \'' . $this->id . '\');';
+			$html[] = 'return false;';
+			$html[] = '">';
+			$html[] = JText::_('JLIB_FORM_BUTTON_CLEAR') . '</a>';
+			$html[] = '	</div>';
+			$html[] = '</div>';
+		}
 
 		return implode("\n", $html);
 	}


### PR DESCRIPTION
In either the form XML or in a model's getForm method (for those extending JModelForm), it is possible to set the disabled attribute on form fields.  In trying to use this for some code I'm working on, I've found that in its current form, the media field cannot truly be disabled or read-only.  In using `$form->setFieldAttribute('logo', 'disabled', 'true');` in my model's getForm method, the Select and Clear buttons are still active and usable.  So, for this field to be truly disabled, I've added a check for the disabled element prior to rendering the two buttons.

Use Case:
I'm using the same model in the back end to load a form with one of two layouts: the regular edit layout, and a "details" layout which loads the form data in basically a read-only state and adds a little more data to be viewed by the user.
