### PR TITLE
JLogger changes (Bug that broke logging, LogException, DBO, Priorities in parent)

### DIFF
--- a/libraries/joomla/log/entry.php
+++ b/libraries/joomla/log/entry.php
@@ -81,7 +81,7 @@ class JLogEntry
 		$this->message = (string) $message;
 
 		// Sanitize the priority.
-		if (!in_array($priority, $this->priorities, true))
+		if (!in_array($priority, $this->priorities))
 		{
 			$priority = JLog::INFO;
 		}

--- a/libraries/joomla/log/log.php
+++ b/libraries/joomla/log/log.php
@@ -402,11 +402,11 @@ class JLog
 		foreach ((array) $this->lookup as $signature => $rules)
 		{
 			// Check to make sure the priority matches the logger.
-			if ($priority & $rules->priorities)
+			if ($priority == $rules->priorities || $rules->priorities == JLog::ALL)
 			{
-
 				// If either there are no set categories (meaning all) or the specific category is set, add this logger.
-				if (empty($category) || empty($rules->categories) || in_array($category, $rules->categories))
+				if (count($rules->categories) == 0
+					|| in_array($category, $rules->categories))
 				{
 					$loggers[] = $signature;
 				}

--- a/libraries/joomla/log/log.php
+++ b/libraries/joomla/log/log.php
@@ -11,8 +11,6 @@ defined('JPATH_PLATFORM') or die;
 
 jimport('joomla.log.logger');
 
-JLoader::register('LogException', JPATH_PLATFORM . '/joomla/log/logexception.php');
-
 JLoader::discover('JLogger', __DIR__ . '/loggers');
 
 // @deprecated  12.1
@@ -293,7 +291,7 @@ class JLog
 	 *
 	 * @param   array  $entry  Array of values to map to the format string for the log file.
 	 *
-	 * @return  boolean  True on success.
+	 * @return  mixed  null|boolean
 	 *
 	 * @since         11.1
 	 *
@@ -352,7 +350,7 @@ class JLog
 	 * @return  void
 	 *
 	 * @since   11.1
-	 * @throws  LogException
+	 * @throws  InvalidArgumentException
 	 */
 	protected function addLogEntry(JLogEntry $entry)
 	{
@@ -372,7 +370,7 @@ class JLog
 				}
 				else
 				{
-					throw new LogException(JText::_('Unable to create a JLogger instance: '));
+					throw new InvalidArgumentException('Unable to create a JLogger instance: '. $class);
 				}
 			}
 

--- a/libraries/joomla/log/logger.php
+++ b/libraries/joomla/log/logger.php
@@ -29,6 +29,20 @@ abstract class JLogger
 	protected $options = array();
 
 	/**
+	 * @var    array  Translation array for JLogEntry priorities to text strings.
+	 * @since  11.1
+	 */
+	protected $priorities = array(
+		JLog::EMERGENCY => 'EMERGENCY',
+		JLog::ALERT => 'ALERT',
+		JLog::CRITICAL => 'CRITICAL',
+		JLog::ERROR => 'ERROR',
+		JLog::WARNING => 'WARNING',
+		JLog::NOTICE => 'NOTICE',
+		JLog::INFO => 'INFO',
+		JLog::DEBUG => 'DEBUG');
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   array  &$options  Log object options.

--- a/libraries/joomla/log/loggers/database.php
+++ b/libraries/joomla/log/loggers/database.php
@@ -79,7 +79,7 @@ class JLoggerDatabase extends JLogger
 		parent::__construct($options);
 
 		// If both the database object and driver options are empty we want to use the system database connection.
-		if (empty($this->options['db_object']) && empty($this->options['db_driver']))
+		if (empty($this->options['dbo']) && empty($this->options['db_driver']))
 		{
 			$this->dbo = JFactory::getDBO();
 			$this->driver = JFactory::getConfig()->get('dbtype');

--- a/libraries/joomla/log/loggers/database.php
+++ b/libraries/joomla/log/loggers/database.php
@@ -72,7 +72,6 @@ class JLoggerDatabase extends JLogger
 	 * @param   array  &$options  Log object options.
 	 *
 	 * @since   11.1
-	 * @throws  LogException
 	 */
 	public function __construct(array &$options)
 	{
@@ -93,6 +92,7 @@ class JLoggerDatabase extends JLogger
 		// We need to get the database connection settings from the configuration options.
 		else
 		{
+			$this->dbo = (empty($this->options['dbo'])) ? null : $this->options['dbo'];
 			$this->driver = (empty($this->options['db_driver'])) ? 'mysql' : $this->options['db_driver'];
 			$this->host = (empty($this->options['db_host'])) ? '127.0.0.1' : $this->options['db_host'];
 			$this->user = (empty($this->options['db_user'])) ? 'root' : $this->options['db_user'];
@@ -134,7 +134,7 @@ class JLoggerDatabase extends JLogger
 	 * @return  void
 	 *
 	 * @since   11.1
-	 * @throws  LogException
+	 * @throws  RuntimeException
 	 */
 	protected function connect()
 	{
@@ -151,17 +151,12 @@ class JLoggerDatabase extends JLogger
 		{
 			$db = JDatabase::getInstance($options);
 
-			if ($db instanceof Exception)
-			{
-				throw new LogException('Database Error: ' . (string) $db);
-			}
-
 			// Assign the database connector to the class.
 			$this->dbo = $db;
 		}
-		catch (RuntimeException $e)
+		catch (Exception $e)
 		{
-			throw new LogException($e->getMessage());
+			throw new RuntimeException($e->getMessage());
 		}
 	}
 }

--- a/libraries/joomla/log/loggers/echo.php
+++ b/libraries/joomla/log/loggers/echo.php
@@ -21,20 +21,6 @@ jimport('joomla.log.logger');
 class JLoggerEcho extends JLogger
 {
 	/**
-	 * @var    array  Translation array for JLogEntry priorities to text strings.
-	 * @since  11.1
-	 */
-	protected $priorities = array(
-		JLog::EMERGENCY => 'EMERGENCY',
-		JLog::ALERT => 'ALERT',
-		JLog::CRITICAL => 'CRITICAL',
-		JLog::ERROR => 'ERROR',
-		JLog::WARNING => 'WARNING',
-		JLog::NOTICE => 'NOTICE',
-		JLog::INFO => 'INFO',
-		JLog::DEBUG => 'DEBUG');
-
-	/**
 	 * Method to add an entry to the log.
 	 *
 	 * @param   JLogEntry  $entry  The log entry object to add to the log.

--- a/libraries/joomla/log/loggers/echo.php
+++ b/libraries/joomla/log/loggers/echo.php
@@ -31,6 +31,6 @@ class JLoggerEcho extends JLogger
 	 */
 	public function addEntry(JLogEntry $entry)
 	{
-		echo $this->priorities[$entry->priority] . ': ' . $entry->message . (empty($entry->category) ? '' : ' [' . $entry->category . ']') . "\n";
+		echo $this->priorities[$entry->priority] . ': ' . $entry->message . (empty($entry->category) ? '' : ' [' . $entry->category . ']') . "<br />";
 	}
 }

--- a/libraries/joomla/log/loggers/formattedtext.php
+++ b/libraries/joomla/log/loggers/formattedtext.php
@@ -50,20 +50,6 @@ class JLoggerFormattedText extends JLogger
 	protected $path;
 
 	/**
-	 * @var    array  Translation array for JLogEntry priorities to text strings.
-	 * @since  11.1
-	 */
-	protected $priorities = array(
-		JLog::EMERGENCY => 'EMERGENCY',
-		JLog::ALERT => 'ALERT',
-		JLog::CRITICAL => 'CRITICAL',
-		JLog::ERROR => 'ERROR',
-		JLog::WARNING => 'WARNING',
-		JLog::NOTICE => 'NOTICE',
-		JLog::INFO => 'INFO',
-		JLog::DEBUG => 'DEBUG');
-
-	/**
 	 * Constructor.
 	 *
 	 * @param   array  &$options  Log object options.
@@ -127,7 +113,7 @@ class JLoggerFormattedText extends JLogger
 	 * @return  boolean  True on success.
 	 *
 	 * @since   11.1
-	 * @throws  LogException
+	 * @throws  RuntimeException
 	 */
 	public function addEntry(JLogEntry $entry)
 	{
@@ -182,7 +168,7 @@ class JLoggerFormattedText extends JLogger
 		// Write the new entry to the file.
 		if (!fputs($this->file, $line . "\n"))
 		{
-			throw new LogException;
+			throw new RuntimeException('Cannot write to log file.');
 		}
 	}
 
@@ -226,6 +212,7 @@ class JLoggerFormattedText extends JLogger
 	 * @return  void
 	 *
 	 * @since   11.1
+	 * @throws  RuntimeException
 	 */
 	protected function initFile()
 	{
@@ -247,13 +234,13 @@ class JLoggerFormattedText extends JLogger
 		// Open the file for writing (append mode).
 		if (!$this->file = fopen($this->path, 'a'))
 		{
-			// Throw exception.
+			throw new RuntimeException('Cannot open file for writing log');
 		}
 		if ($head)
 		{
 			if (!fputs($this->file, $head))
 			{
-				throw new LogException;
+				throw new RuntimeException('Cannot fput file for log');
 			}
 		}
 	}

--- a/libraries/joomla/log/loggers/syslog.php
+++ b/libraries/joomla/log/loggers/syslog.php
@@ -12,9 +12,9 @@ defined('JPATH_PLATFORM') or die;
 jimport('joomla.log.logger');
 
 /**
- * Joomla! SysLog Log class
+ * Joomla! Syslog Log class
  *
- * This class is designed to call the PHP SysLog function call which is then sent to the
+ * This class is designed to call the PHP Syslog function call which is then sent to the
  * system wide log system. For Linux/Unix based systems this is the syslog subsystem, for
  * the Windows based implementations this can be found in the Event Log. For Windows,
  * permissions may prevent PHP from properly outputting messages.
@@ -23,21 +23,8 @@ jimport('joomla.log.logger');
  * @subpackage  Log
  * @since       11.1
  */
-class JLoggerSysLog extends JLogger
+class JLoggerSyslog extends JLogger
 {
-	/**
-	 * @var    array  Translation array for JLogEntry priorities to SysLog priority names.
-	 * @since  11.1
-	 */
-	protected $priorities = array(
-		JLog::EMERGENCY => 'EMERG',
-		JLog::ALERT => 'ALERT',
-		JLog::CRITICAL => 'CRIT',
-		JLog::ERROR => 'ERR',
-		JLog::WARNING => 'WARNING',
-		JLog::NOTICE => 'NOTICE',
-		JLog::INFO => 'INFO',
-		JLog::DEBUG => 'DEBUG');
 
 	/**
 	 * Constructor.
@@ -51,13 +38,13 @@ class JLoggerSysLog extends JLogger
 		// Call the parent constructor.
 		parent::__construct($options);
 
-		// Ensure that we have an identity string for the SysLog entries.
+		// Ensure that we have an identity string for the Syslog entries.
 		if (empty($this->options['sys_ident']))
 		{
 			$this->options['sys_ident'] = 'Joomla Platform';
 		}
 
-		// If the option to add the process id to SysLog entries is set use it, otherwise default to true.
+		// If the option to add the process id to Syslog entries is set use it, otherwise default to true.
 		if (isset($this->options['sys_add_pid']))
 		{
 			$this->options['sys_add_pid'] = (bool) $this->options['sys_add_pid'];
@@ -67,7 +54,7 @@ class JLoggerSysLog extends JLogger
 			$this->options['sys_add_pid'] = true;
 		}
 
-		// If the option to also send SysLog entries to STDERR is set use it, otherwise default to false.
+		// If the option to also send Syslog entries to STDERR is set use it, otherwise default to false.
 		if (isset($this->options['sys_use_stderr']))
 		{
 			$this->options['sys_use_stderr'] = (bool) $this->options['sys_use_stderr'];
@@ -77,7 +64,7 @@ class JLoggerSysLog extends JLogger
 			$this->options['sys_use_stderr'] = false;
 		}
 
-		// Build the SysLog options from our log object options.
+		// Build the Syslog options from our log object options.
 		$sysOptions = 0;
 		if ($this->options['sys_add_pid'])
 		{
@@ -88,7 +75,7 @@ class JLoggerSysLog extends JLogger
 			$sysOptions = $sysOptions | LOG_PERROR;
 		}
 
-		// Open the SysLog connection.
+		// Open the Syslog connection.
 		openlog((string) $this->options['sys_ident'], $sysOptions, LOG_USER);
 	}
 
@@ -116,7 +103,7 @@ class JLoggerSysLog extends JLogger
 		// Generate the value for the priority based on predefined constants.
 		$priority = constant(strtoupper('LOG_' . $this->priorities[$entry->priority]));
 
-		// Send the entry to SysLog.
+		// Send the entry to Syslog.
 		syslog($priority, '[' . $entry->category . '] ' . $entry->message);
 	}
 }

--- a/libraries/joomla/log/loggers/w3c.php
+++ b/libraries/joomla/log/loggers/w3c.php
@@ -15,16 +15,16 @@ jimport('joomla.log.logger');
 JLoader::register('JLoggerFormattedText', __DIR__ . '/formattedtext.php');
 
 /**
- * Joomla! W3C Logging class
+ * Joomla! W3c Logging class
  *
- * This class is designed to build log files based on the W3C specification
+ * This class is designed to build log files based on the W3c specification
  * at: http://www.w3.org/TR/WD-logfile.html
  *
  * @package     Joomla.Platform
  * @subpackage  Log
  * @since       11.1
  */
-class JLoggerW3C extends JLoggerFormattedText
+class JLoggerW3c extends JLoggerFormattedText
 {
 	/**
 	 * @var    string  The format which each entry follows in the log file.  All fields must be

--- a/tests/suites/unit/joomla/log/JLogTest.php
+++ b/tests/suites/unit/joomla/log/JLogTest.php
@@ -158,8 +158,8 @@ class JLogTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testAddLoggerAutoInstantiationInvalidLogger()
 	{
-		// We are expecting a LogException to be thrown since we are trying to add a bogus logger.
-		$this->setExpectedException('LogException');
+		// We are expecting an InvalidArgumentException to be thrown since we are trying to add a bogus logger.
+		$this->setExpectedException('InvalidArgumentException');
 
 		JLog::setInstance(null);
 

--- a/tests/suites/unit/joomla/log/JLogTest.php
+++ b/tests/suites/unit/joomla/log/JLogTest.php
@@ -124,7 +124,7 @@ class JLogTest extends PHPUnit_Framework_TestCase
 		// Add a loggers to the JLog object.
 		JLog::addLogger(array('logger' => 'echo'), JLog::ALL);
 
-		$this->expectOutputString("DEBUG: TESTING [deprecated]\n");
+		$this->expectOutputString("DEBUG: TESTING [deprecated]<br />");
 		$log->addLogEntry(new JLogEntry('TESTING', JLog::DEBUG, 'DePrEcAtEd'));
 	}
 
@@ -143,7 +143,7 @@ class JLogTest extends PHPUnit_Framework_TestCase
 
 		JLog::addLogger(array('logger' => 'echo'), JLog::ALL);
 
-		$this->expectOutputString("WARNING: TESTING [deprecated]\n");
+		$this->expectOutputString("WARNING: TESTING [deprecated]<br />");
 		JLog::add(new JLogEntry('TESTING', JLog::WARNING, 'DePrEcAtEd'));
 	}
 

--- a/tests/suites/unit/joomla/log/LogExceptionTest.php
+++ b/tests/suites/unit/joomla/log/LogExceptionTest.php
@@ -15,7 +15,7 @@ include_once JPATH_PLATFORM . '/joomla/log/logexception.php';
 class LogExceptionTest extends PHPUnit_Framework_TestCase {
 
     /**
-     * @var LogException
+     * @var InvalidArgumentException
      */
     protected $object;
 
@@ -24,7 +24,6 @@ class LogExceptionTest extends PHPUnit_Framework_TestCase {
      * This method is called before a test is executed.
      */
     protected function setUp() {
-        //$this->object = new LogException;
     }
 
     /**
@@ -32,7 +31,7 @@ class LogExceptionTest extends PHPUnit_Framework_TestCase {
      * This method is called after a test is executed.
      */
     protected function tearDown() {
-        
+
     }
 
 	/**
@@ -44,5 +43,3 @@ class LogExceptionTest extends PHPUnit_Framework_TestCase {
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 }
-
-?>

--- a/tests/suites/unit/joomla/log/loggers/JLoggerDatabaseTest.php
+++ b/tests/suites/unit/joomla/log/loggers/JLoggerDatabaseTest.php
@@ -122,7 +122,7 @@ class JLoggerDatabaseTest extends TestCaseDatabase
 	 *
 	 * @since   11.3
 	 *
-	 * @expectedException LogException
+	 * @expectedException RuntimeException
 	 */
 	public function testConnect02()
 	{

--- a/tests/suites/unit/joomla/log/loggers/JLoggerEchoTest.php
+++ b/tests/suites/unit/joomla/log/loggers/JLoggerEchoTest.php
@@ -25,7 +25,7 @@ class JLoggerEchoTest extends PHPUnit_Framework_TestCase
 		// Get an instance of the logger.
 		$logger = new JLoggerEcho($config);
 
-		$this->expectOutputString("DEBUG: TESTING [deprecated]\n");
+		$this->expectOutputString("DEBUG: TESTING [deprecated]<br />");
 		$logger->addEntry(new JLogEntry('TESTING', JLog::DEBUG, 'DePrEcAtEd'));
 	}
 
@@ -40,7 +40,7 @@ class JLoggerEchoTest extends PHPUnit_Framework_TestCase
 		// Get an instance of the logger.
 		$logger = new JLoggerEcho($config);
 
-		$this->expectOutputString("CRITICAL: TESTING2 [bam]\n");
+		$this->expectOutputString("CRITICAL: TESTING2 [bam]<br />");
 		$logger->addEntry(new JLogEntry('TESTING2', JLog::CRITICAL, 'BAM'));
 	}
 
@@ -55,7 +55,7 @@ class JLoggerEchoTest extends PHPUnit_Framework_TestCase
 		// Get an instance of the logger.
 		$logger = new JLoggerEcho($config);
 
-		$this->expectOutputString("ERROR: Testing3\n");
+		$this->expectOutputString("ERROR: Testing3<br />");
 		$logger->addEntry(new JLogEntry('Testing3', JLog::ERROR));
 	}
 
@@ -70,7 +70,7 @@ class JLoggerEchoTest extends PHPUnit_Framework_TestCase
 		// Get an instance of the logger.
 		$logger = new JLoggerEcho($config);
 
-		$this->expectOutputString("INFO: Testing 4\n");
+		$this->expectOutputString("INFO: Testing 4<br />");
 		$logger->addEntry(new JLogEntry('Testing 4'));
 	}
 }


### PR DESCRIPTION
Changes:
- findLoggers is broken, this patch includes a fix that enables the method to start finding loggers again 
- swapped out LogException for an SPL Exception option
- added ability to pass in the DBO for the database logger
- moved redundant list of priorities into parent
- renamed SysLog to Syslog and WC3 to Wc3 (inline with other filename/class naming standards)
- updated unit tests
