### PR TITLE
JDate separation from deprecated JDatabase class

### DIFF
--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -425,11 +425,21 @@ class JDate extends DateTime
 	 */
 	public function toSql($local = false, JDatabase $dbo = null)
 	{
-		if ($dbo === null)
+		if ($dbo === null && class_exists('JFactory'))
 		{
 			$dbo = JFactory::getDbo();
 		}
-		return $this->format($dbo->getDateFormat(), $local, false);
+
+		if ($dbo === null)
+		{
+			$format = 'Y-m-d H:i:s';
+		}
+		else
+		{
+			$format = $dbo->getDateFormat();
+		}
+
+		return $this->format($format, $local, false);
 	}
 
 	/**


### PR DESCRIPTION
Allows JDate to be used without requiring the JDatabase class (which is deprecated).

I ran in problems using the JLoggerDatabase option because of the toSQL method in JDate and it's coupling with the JDatabase object. 

It makes it possible to use the database logger without being tied into JFactory. Very helpful while ensuring the current usage continues to work.
