### PR TITLE
Removed JString usage in JStringNormalise

### DIFF
--- a/libraries/joomla/string/normalise.php
+++ b/libraries/joomla/string/normalise.php
@@ -29,7 +29,7 @@ abstract class JStringNormalise
 	 */
 	public static function fromCamelCase($input)
 	{
-		return JString::trim(preg_replace('#([A-Z])#', ' $1', $input));
+		return trim(preg_replace('#([A-Z])#', ' $1', $input));
 	}
 
 	/**
@@ -45,8 +45,8 @@ abstract class JStringNormalise
 	{
 		// Convert words to uppercase and then remove spaces.
 		$input = self::toSpaceSeparated($input);
-		$input = JString::ucwords($input);
-		$input = JString::str_ireplace(' ', '', $input);
+		$input = ucwords($input);
+		$input = str_ireplace(' ', '', $input);
 
 		return $input;
 	}
@@ -63,7 +63,7 @@ abstract class JStringNormalise
 	public static function toDashSeparated($input)
 	{
 		// Convert spaces and underscores to dashes.
-		$input = JString::str_ireplace(array(' ', '_'), '-', $input);
+		$input = str_ireplace(array(' ', '_'), '-', $input);
 
 		// Remove duplicate dashes.
 		$input = preg_replace('#-+#', '-', $input);
@@ -83,7 +83,7 @@ abstract class JStringNormalise
 	public static function toSpaceSeparated($input)
 	{
 		// Convert underscores and dashes to spaces.
-		$input = JString::str_ireplace(array('_', '-'), ' ', $input);
+		$input = str_ireplace(array('_', '-'), ' ', $input);
 
 		// Remove duplicate spaces.
 		$input = preg_replace('#\s+#', ' ', $input);
@@ -103,7 +103,7 @@ abstract class JStringNormalise
 	public static function toUnderscoreSeparated($input)
 	{
 		// Convert spaces and dashes to underscores.
-		$input = JString::str_ireplace(array(' ', '-'), '_', $input);
+		$input = str_ireplace(array(' ', '-'), '_', $input);
 
 		// Remove duplicate underscores.
 		$input = preg_replace('#_+#', '_', $input);
@@ -130,11 +130,11 @@ abstract class JStringNormalise
 		$input = preg_replace('#^[0-9]+.*$#', '', $input);
 
 		// Lowercase the first character.
-		$first = JString::substr($input, 0, 1);
-		$first = JString::strtolower($first);
+		$first = substr($input, 0, 1);
+		$first = strtolower($first);
 
 		// Replace the first character with the lowercase character.
-		$input = JString::substr_replace($input, $first, 0, 1);
+		$input = substr_replace($input, $first, 0, 1);
 
 		return $input;
 	}
@@ -152,7 +152,7 @@ abstract class JStringNormalise
 	{
 		// Remove spaces and dashes, then convert to lower case.
 		$input = self::toUnderscoreSeparated($input);
-		$input = JString::strtolower($input);
+		$input = strtolower($input);
 
 		return $input;
 	}

--- a/libraries/joomla/string/normalise.php
+++ b/libraries/joomla/string/normalise.php
@@ -21,21 +21,36 @@ abstract class JStringNormalise
 	/**
 	 * Method to convert a string from camel case.
 	 *
-	 * @param   string  $input  The string input.
+	 * This method offers two modes. Grouped allows for splitting on groups of uppercase characters as follows:
+	 *
+	 * "FooBarABCDef"            becomes  array("Foo", "Bar", "ABC", "Def")
+	 * "JFooBar"                 becomes  array("J", "Foo", "Bar")
+	 * "J001FooBar002"           becomes  array("J001", "Foo", "Bar002")
+	 * "abcDef"                  becomes  array("abc", "Def")
+	 * "abc_defGhi_Jkl"          becomes  array("abc_def", "Ghi_Jkl")
+	 * "ThisIsA_NASAAstronaut"   becomes  array("This", "Is", "A_NASA", "Astronaut"))
+	 * "JohnFitzgerald_Kennedy"  becomes  array("John", "Fitzgerald_Kennedy"))
+	 *
+	 * Non-grouped will split strings at each uppercase character.
+	 *
+	 * @param   string   $input    The string input (ASCII only).
+	 * @param   boolean  $grouped  Optionally allows splitting on groups of uppercase characters.
 	 *
 	 * @return  string  The space separated string.
 	 *
 	 * @since   12.1
 	 */
-	public static function fromCamelCase($input)
+	public static function fromCamelCase($input, $grouped = false)
 	{
-		return trim(preg_replace('#([A-Z])#', ' $1', $input));
+		return $grouped
+			? preg_split('/(?<=[^A-Z_])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][^A-Z_])/x', $input)
+			: trim(preg_replace('#([A-Z])#', ' $1', $input));
 	}
 
 	/**
 	 * Method to convert a string into camel case.
 	 *
-	 * @param   string  $input  The string input.
+	 * @param   string  $input  The string input (ASCII only).
 	 *
 	 * @return  string  The camel case string.
 	 *
@@ -54,7 +69,7 @@ abstract class JStringNormalise
 	/**
 	 * Method to convert a string into dash separated form.
 	 *
-	 * @param   string  $input  The string input.
+	 * @param   string  $input  The string input (ASCII only).
 	 *
 	 * @return  string  The dash separated string.
 	 *
@@ -63,10 +78,7 @@ abstract class JStringNormalise
 	public static function toDashSeparated($input)
 	{
 		// Convert spaces and underscores to dashes.
-		$input = str_ireplace(array(' ', '_'), '-', $input);
-
-		// Remove duplicate dashes.
-		$input = preg_replace('#-+#', '-', $input);
+		$input = preg_replace('#[ \-_]+#', '-', $input);
 
 		return $input;
 	}
@@ -74,7 +86,7 @@ abstract class JStringNormalise
 	/**
 	 * Method to convert a string into space separated form.
 	 *
-	 * @param   string  $input  The string input.
+	 * @param   string  $input  The string input (ASCII only).
 	 *
 	 * @return  string  The space separated string.
 	 *
@@ -83,10 +95,7 @@ abstract class JStringNormalise
 	public static function toSpaceSeparated($input)
 	{
 		// Convert underscores and dashes to spaces.
-		$input = str_ireplace(array('_', '-'), ' ', $input);
-
-		// Remove duplicate spaces.
-		$input = preg_replace('#\s+#', ' ', $input);
+		$input = preg_replace('#[ \-_]+#', ' ', $input);
 
 		return $input;
 	}
@@ -94,7 +103,7 @@ abstract class JStringNormalise
 	/**
 	 * Method to convert a string into underscore separated form.
 	 *
-	 * @param   string  $input  The string input.
+	 * @param   string  $input  The string input (ASCII only).
 	 *
 	 * @return  string  The underscore separated string.
 	 *
@@ -103,10 +112,7 @@ abstract class JStringNormalise
 	public static function toUnderscoreSeparated($input)
 	{
 		// Convert spaces and dashes to underscores.
-		$input = str_ireplace(array(' ', '-'), '_', $input);
-
-		// Remove duplicate underscores.
-		$input = preg_replace('#_+#', '_', $input);
+		$input = preg_replace('#[ \-_]+#', '_', $input);
 
 		return $input;
 	}
@@ -114,7 +120,7 @@ abstract class JStringNormalise
 	/**
 	 * Method to convert a string into variable form.
 	 *
-	 * @param   string  $input  The string input.
+	 * @param   string  $input  The string input (ASCII only).
 	 *
 	 * @return  string  The variable string.
 	 *
@@ -142,7 +148,7 @@ abstract class JStringNormalise
 	/**
 	 * Method to convert a string into key form.
 	 *
-	 * @param   string  $input  The string input.
+	 * @param   string  $input  The string input (ASCII only).
 	 *
 	 * @return  string  The key string.
 	 *

--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -78,11 +78,14 @@ abstract class JString
 	 *
 	 * @return  array   The splitted string.
 	 *
+	 * @deprecated  12.3
 	 * @since   11.3
 	 */
 	public static function splitCamelCase($string)
 	{
-		return preg_split('/(?<=[^A-Z_])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][^A-Z_])/x', $string);
+		JLog::add('JString::splitCamelCase has been deprecated. Use JStringNormalise::fromCamelCase.', JLog::WARNING, 'deprecated');
+
+		return JStringNormalise::fromCamelCase($string, true);
 	}
 
 	/**

--- a/tests/suites/unit/joomla/string/JStringNormaliseTest.php
+++ b/tests/suites/unit/joomla/string/JStringNormaliseTest.php
@@ -19,7 +19,26 @@ require_once JPATH_PLATFORM . '/joomla/string/normalise.php';
 class JStringNormaliseTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * Method to test JStringNormalise::fromCamelCase().
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	public function getFromCamelCaseData()
+	{
+		return array(
+			// string, expected
+			array('FooBarABCDef', array('Foo', 'Bar', 'ABC', 'Def')),
+			array('JFooBar', array('J', 'Foo', 'Bar')),
+			array('J001FooBar002', array('J001', 'Foo', 'Bar002')),
+			array('abcDef', array('abc', 'Def')),
+			array('abc_defGhi_Jkl', array('abc_def', 'Ghi_Jkl')),
+			array('ThisIsA_NASAAstronaut', array('This', 'Is', 'A_NASA', 'Astronaut')),
+			array('JohnFitzgerald_Kennedy', array('John', 'Fitzgerald_Kennedy')),
+		);
+	}
+
+	/**
+	 * Method to test JStringNormalise::fromCamelCase(string, false).
 	 *
 	 * @param   string  $expected  The expected value from the method.
 	 * @param   string  $input     The input value for the method.
@@ -29,9 +48,25 @@ class JStringNormaliseTest extends PHPUnit_Framework_TestCase
 	 * @dataProvider  seedFromCamelCase
 	 * @since   11.3
 	 */
-	public function testFromCamelCase($expected, $input)
+	public function testFromCamelCase_nongrouped($expected, $input)
 	{
 		$this->assertEquals($expected, JStringNormalise::fromCamelcase($input));
+	}
+
+	/**
+	 * Method to test JStringNormalise::fromCamelCase(string, true).
+	 *
+	 * @param   string  $expected  The expected value from the method.
+	 * @param   string  $input     The input value for the method.
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider  getFromCamelCaseData
+	 * @since   11.3
+	 */
+	public function testFromCamelCase_grouped($input, $expected)
+	{
+		$this->assertEquals($expected, JStringNormalise::fromCamelcase($input, true));
 	}
 
 	/**

--- a/tests/suites/unit/joomla/string/JStringTest.php
+++ b/tests/suites/unit/joomla/string/JStringTest.php
@@ -25,16 +25,6 @@ class JStringTest extends PHPUnit_Framework_TestCase
 	/**
 	 * @return  array
 	 *
-	 * @since   11.3
-	 */
-	public function getSplitCamelCaseData()
-	{
-		return JStringTest_DataSet::$splitCamelCase;
-	}
-
-	/**
-	 * @return  array
-	 *
 	 * @since   11.2
 	 */
 	public function getIncrementData()
@@ -260,20 +250,6 @@ class JStringTest extends PHPUnit_Framework_TestCase
 	public function getValidData()
 	{
 		return JStringTest_DataSet::$validTests;
-	}
-
-	/**
-	 * @return  void
-	 *
-	 * @dataProvider  getSplitCamelCaseData
-	 * @since   11.3
-	 */
-	public function testSplitCamelCase($string, $expected)
-	{
-		$this->assertThat(
-			JString::splitCamelCase($string),
-			$this->equalTo($expected)
-		);
 	}
 
 	/**

--- a/tests/suites/unit/joomla/string/TestHelpers/JString-helper-dataset.php
+++ b/tests/suites/unit/joomla/string/TestHelpers/JString-helper-dataset.php
@@ -17,25 +17,6 @@
 class JStringTest_DataSet
 {
 	/**
-	 * Tests for JString::splitCamelCase.
-	 *
-	 * Each element contains $string, $expect
-	 *
-	 * @var    array
-	 * @since  11.3
-	 */
-	static public $splitCamelCase = array(
-		// string, expected
-		array('FooBarABCDef', array('Foo', 'Bar', 'ABC', 'Def')),
-		array('JFooBar', array('J', 'Foo', 'Bar')),
-		array('J001FooBar002', array('J001', 'Foo', 'Bar002')),
-		array('abcDef', array('abc', 'Def')),
-		array('abc_defGhi_Jkl', array('abc_def', 'Ghi_Jkl')),
-		array('ThisIsA_NASAAstronaut', array('This', 'Is', 'A_NASA', 'Astronaut')),
-		array('JohnFitzgerald_Kennedy', array('John', 'Fitzgerald_Kennedy')),
-	);
-
-	/**
 	 * Tests for JString::increment.
 	 *
 	 * Each element contains $haystack, $needle, $offset, $expect,


### PR DESCRIPTION
Using JString instead of normal string methods causes a significant performance hit. Removing the JString wrapper fixes this problem. As this class was designed for programatic values, this should not cause much of an issue.

Also deprecate JString::splitCamelCase and merged it with JStringNormalise::fromCamelCase.
