### PR TITLE
Fixed JDatabaseQueryPreparable to support binding output parameters

### DIFF
--- a/libraries/joomla/database/driver/sqlite.php
+++ b/libraries/joomla/database/driver/sqlite.php
@@ -256,11 +256,12 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 		$query = $this->getQuery(true);
 
 		$tables = array();
+		$type = 'table';
 
 		$query->select('name');
 		$query->from('sqlite_master');
 		$query->where('type = :type');
-		$query->bind(':type', 'table');
+		$query->bind(':type', $type);
 		$query->order('name');
 
 		$this->setQuery($query);

--- a/libraries/joomla/database/query/oracle.php
+++ b/libraries/joomla/database/query/oracle.php
@@ -37,27 +37,22 @@ class JDatabaseQueryOracle extends JDatabaseQueryPdo implements JDatabaseQueryPr
 	protected $bounded = array();
 
 	/**
-	 * Method to add a variable to an internal $bounded array that
-	 * will later be bound to a prepared SQL statement at the time
-	 * of query execution. Also removes a variable that has been
-	 * bounded from the internal bounded array when the passed in value
-	 * is null.
+	 * Method to add a variable to an internal array that will be bound to a prepared SQL statement before query execution. Also
+	 * removes a variable that has been bounded from the internal bounded array when the passed in value is null.
 	 *
-	 * @param   string|integer  $key            The key that will be used in your SQL
-	 *                                          query to reference the value. Usually
-	 *                                          of the form ':key', but can also be an
-	 *                                          integer.
-	 * @param   mixed           $value          The value that will be bound.
+	 * @param   string|integer  $key            The key that will be used in your SQL query to reference the value. Usually of
+	 *                                          the form ':key', but can also be an integer.
+	 * @param   mixed           &$value         The value that will be bound. The value is passed by reference to support output
+	 *                                          parameters such as those possible with stored procedures.
 	 * @param   integer         $dataType       Constant corresponding to a SQL datatype.
-	 * @param   integer         $length         The length of the variable. Usually required
-	 *                                          for OUTPUT variables.
+	 * @param   integer         $length         The length of the variable. Usually required for OUTPUT parameters.
 	 * @param   array           $driverOptions  Optional driver options to be used.
 	 *
-	 * @return JDatabaseQuery
+	 * @return  JDatabaseQuery
 	 *
-	 * @since 12.1
+	 * @since   12.1
 	 */
-	public function bind($key = null, $value = null, $dataType = PDO::PARAM_STR, $length = 0, $driverOptions = array())
+	public function bind($key = null, &$value = null, $dataType = PDO::PARAM_STR, $length = 0, $driverOptions = array())
 	{
 		// Case 1: Empty Key (reset $bounded array)
 		if (empty($key))
@@ -91,15 +86,14 @@ class JDatabaseQueryOracle extends JDatabaseQueryPdo implements JDatabaseQueryPr
 	}
 
 	/**
-	 * Retrieves the internal $bounded array when key is null and
-	 * returns it by reference. If a key is provided then that
-	 * item is returned from the $bounded array if available.
+	 * Retrieves the bound parameters array when key is null and returns it by reference. If a key is provided then that item is
+	 * returned.
 	 *
-	 * @param   mixed  $key  The bounded variable key to retrieve
+	 * @param   mixed  $key  The bounded variable key to retrieve.
 	 *
-	 * @return array|stdClass
+	 * @return  mixed
 	 *
-	 * @since 12.1
+	 * @since   12.1
 	 */
 	public function &getBounded($key = null)
 	{

--- a/libraries/joomla/database/query/preparable.php
+++ b/libraries/joomla/database/query/preparable.php
@@ -22,34 +22,28 @@ defined('JPATH_PLATFORM') or die;
 interface JDatabaseQueryPreparable
 {
 	/**
-	 * Method to add a variable to an internal $bounded array that
-	 * will later be bound to a prepared SQL statement at the time
-	 * of query execution. Also removes a variable that has been
-	 * bounded from the internal bounded array when the passed in value
-	 * is null.
+	 * Method to add a variable to an internal array that will be bound to a prepared SQL statement before query execution. Also
+	 * removes a variable that has been bounded from the internal bounded array when the passed in value is null.
 	 *
-	 * @param   string|integer  $key            The key that will be used in your SQL
-	 *                                          query to reference the value. Usually
-	 *                                          of the form ':key', but can also be an
-	 *                                          integer.
-	 * @param   mixed           $value          The value that will be bound.
+	 * @param   string|integer  $key            The key that will be used in your SQL query to reference the value. Usually of
+	 *                                          the form ':key', but can also be an integer.
+	 * @param   mixed           &$value         The value that will be bound. The value is passed by reference to support output
+	 *                                          parameters such as those possible with stored procedures.
 	 * @param   integer         $dataType       Constant corresponding to a SQL datatype.
-	 * @param   integer         $length         The length of the variable. Usually required
-	 *                                          for OUTPUT variables.
+	 * @param   integer         $length         The length of the variable. Usually required for OUTPUT parameters.
 	 * @param   array           $driverOptions  Optional driver options to be used.
 	 *
-	 * @return JDatabaseQuery
+	 * @return  JDatabaseQuery
 	 *
-	 * @since  12.1
+	 * @since   12.1
 	 */
-	public function bind($key = null, $value = null, $dataType = PDO::PARAM_STR, $length = 0, $driverOptions = array());
+	public function bind($key = null, &$value = null, $dataType = PDO::PARAM_STR, $length = 0, $driverOptions = array());
 
 	/**
-	 * Retrieves the internal $bounded array when key is null and
-	 * returns it by reference. If a key is provided then that
-	 * item is returned from the $bounded array if available.
+	 * Retrieves the bound parameters array when key is null and returns it by reference. If a key is provided then that item is
+	 * returned.
 	 *
-	 * @param   mixed  $key  The bounded variable key to retrieve
+	 * @param   mixed  $key  The bounded variable key to retrieve.
 	 *
 	 * @return  mixed
 	 *

--- a/libraries/joomla/database/query/sqlite.php
+++ b/libraries/joomla/database/query/sqlite.php
@@ -37,27 +37,22 @@ class JDatabaseQuerySqlite extends JDatabaseQueryPdo implements JDatabaseQueryPr
 	protected $bounded = array();
 
 	/**
-	 * Method to add a variable to an internal $bounded array that
-	 * will later be bound to a prepared SQL statement at the time
-	 * of query execution. Also removes a variable that has been
-	 * bounded from the internal bounded array when the passed in value
-	 * is null.
+	 * Method to add a variable to an internal array that will be bound to a prepared SQL statement before query execution. Also
+	 * removes a variable that has been bounded from the internal bounded array when the passed in value is null.
 	 *
-	 * @param   string|integer  $key            The key that will be used in your SQL
-	 *                                          query to reference the value. Usually
-	 *                                          of the form ':key', but can also be an
-	 *                                          integer.
-	 * @param   mixed           $value          The value that will be bound.
+	 * @param   string|integer  $key            The key that will be used in your SQL query to reference the value. Usually of
+	 *                                          the form ':key', but can also be an integer.
+	 * @param   mixed           &$value         The value that will be bound. The value is passed by reference to support output
+	 *                                          parameters such as those possible with stored procedures.
 	 * @param   integer         $dataType       Constant corresponding to a SQL datatype.
-	 * @param   integer         $length         The length of the variable. Usually required
-	 *                                          for OUTPUT variables.
+	 * @param   integer         $length         The length of the variable. Usually required for OUTPUT parameters.
 	 * @param   array           $driverOptions  Optional driver options to be used.
 	 *
-	 * @return JDatabaseQuery
+	 * @return  JDatabaseQuery
 	 *
-	 * @since 12.1
+	 * @since   12.1
 	 */
-	public function bind($key = null, $value = null, $dataType = PDO::PARAM_STR, $length = 0, $driverOptions = array())
+	public function bind($key = null, &$value = null, $dataType = PDO::PARAM_STR, $length = 0, $driverOptions = array())
 	{
 		// Case 1: Empty Key (reset $bounded array)
 		if (empty($key))
@@ -91,15 +86,14 @@ class JDatabaseQuerySqlite extends JDatabaseQueryPdo implements JDatabaseQueryPr
 	}
 
 	/**
-	 * Retrieves the internal $bounded array when key is null and
-	 * returns it by reference. If a key is provided then that
-	 * item is returned from the $bounded array if available.
+	 * Retrieves the bound parameters array when key is null and returns it by reference. If a key is provided then that item is
+	 * returned.
 	 *
-	 * @param   mixed  $key  The bounded variable key to retrieve
+	 * @param   mixed  $key  The bounded variable key to retrieve.
 	 *
-	 * @return array|stdClass
+	 * @return  mixed
 	 *
-	 * @since 12.1
+	 * @since   12.1
 	 */
 	public function &getBounded($key = null)
 	{


### PR DESCRIPTION
When interacting with stored procedures that use output parameters, JDatabaseQueryPreparable would not update the original passed in parameter as expected with the values output from the stored procedure. To solve this, the value is passed by reference so that when it is bound to the query, it can be updated properly with the new value after query execution.
