### PR TITLE
Add JLogTest::testAdd()

### DIFF
--- a/tests/suites/unit/joomla/log/JLogTest.php
+++ b/tests/suites/unit/joomla/log/JLogTest.php
@@ -128,6 +128,27 @@ class JLogTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Test the JLog::add method to verify that if called directly it will route the entry to the
+	 * appropriate loggers.  We use the echo logger here for easy testing using the PHP output buffer.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.1
+	 */
+	public function testAdd()
+	{
+		// First let's test a set of priorities.
+		$log = new JLogInspector;
+		JLog::setInstance($log);
+
+		// Add a loggers to the JLog object.
+		JLog::addLogger(array('logger' => 'echo', 'line_separator' => '<br />'), 128, array('dogs','cats'));
+
+		$this->expectOutputString("DEBUG: TESTING [cats]<br />");
+		$log->add('TESTING', 128, 'cats');
+	}
+
+	/**
 	 * Test that if JLog::addLogger is called and no JLog instance has been instantiated yet, that one will
 	 * be instantiated automatically and the logger will work accordingly.  We use the echo logger here for
 	 * easy testing using the PHP output buffer.


### PR DESCRIPTION
I added a test to JLog for the new separator option -- and to test using the add method. (Existing tests send in the JLogEntry so this tests sending in a message, only.) 

Earlier this week, I thought I found a logic error for logs with one priority. The purpose of this testing was to try to see if such an error existed. I found a problem with my code, not JLog, but this test covers ground not already covered so I thought I'd share it if it is desired.  
