### PR TITLE
Remove JText dependency on JStreamString for die Statement

### DIFF
--- a/libraries/joomla/filesystem/streams/string.php
+++ b/libraries/joomla/filesystem/streams/string.php
@@ -295,4 +295,4 @@ class JStreamString
 	}
 }
 
-stream_wrapper_register('string', 'JStreamString') or die(JText::_('JLIB_FILESYSTEM_STREAM_FAILED'));
+stream_wrapper_register('string', 'JStreamString') or die('JStreamString Wrapper Registration Failed');


### PR DESCRIPTION
The only occurrence of JText in this class is to translate the die Statement. Doesn't seem worth a dependency.
