### PR TITLE
Set the CSS class for JForm field label

### DIFF
--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -380,8 +380,8 @@ abstract class JFormField
 		// Set the field default value.
 		$this->value = $value;
 
-        // Set the CSS class of field label
-        $this->labelClass = (string) $element['labelclass'];
+		// Set the CSS class of field label
+		$this->labelClass = (string) $element['labelclass'];
 
 		return true;
 	}
@@ -495,7 +495,7 @@ abstract class JFormField
 		// Build the class for the label.
 		$class = !empty($this->description) ? 'hasTip' : '';
 		$class = $this->required == true ? $class . ' required' : $class;
-        $class = !empty($this->labelClass) ? $class . ' ' . $this->labelClass : $class;
+		$class = !empty($this->labelClass) ? $class . ' ' . $this->labelClass : $class;
 
 		// Add the opening label tag and main attributes attributes.
 		$label .= '<label id="' . $this->id . '-lbl" for="' . $this->id . '" class="' . $class . '"';

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -166,6 +166,14 @@ abstract class JFormField
 	protected $value;
 
 	/**
+	 * The label's CSS class of the form field
+	 *
+	 * @var    mixed
+	 * @since  11.1
+	 */
+	protected $labelClass;
+
+	/**
 	 * The count value for generated name field
 	 *
 	 * @var    integer
@@ -236,6 +244,7 @@ abstract class JFormField
 			case 'type':
 			case 'validate':
 			case 'value':
+			case 'labelClass':
 			case 'fieldname':
 			case 'group':
 				return $this->$name;
@@ -371,6 +380,9 @@ abstract class JFormField
 		// Set the field default value.
 		$this->value = $value;
 
+        // Set the CSS class of field label
+        $this->labelClass = (string) $element['labelclass'];
+
 		return true;
 	}
 
@@ -483,6 +495,7 @@ abstract class JFormField
 		// Build the class for the label.
 		$class = !empty($this->description) ? 'hasTip' : '';
 		$class = $this->required == true ? $class . ' required' : $class;
+        $class = !empty($this->labelClass) ? $class . ' ' . $this->labelClass : $class;
 
 		// Add the opening label tag and main attributes attributes.
 		$label .= '<label id="' . $this->id . '-lbl" for="' . $this->id . '" class="' . $class . '"';


### PR DESCRIPTION
This pull is intended to allow developer to set CSS class for form field's label. It can be useful for styling purpose. 

For example Twitter Bootstrap requires class="control-label" for form field label tag.

Usage: add labelclass="your-css-class" in your form xml manifest

<......description="" required="true" labelclass="control-label" />
