### PR TITLE
Changed PostgreSQL's getTableColumns.

### DIFF
--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -327,7 +327,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 					END AS "null",
 					CASE WHEN pg_catalog.pg_get_expr(adef.adbin, adef.adrelid, true) IS NOT NULL
 						THEN pg_catalog.pg_get_expr(adef.adbin, adef.adrelid, true)
-					END as "default",
+					END as "Default",
 					CASE WHEN pg_catalog.col_description(a.attrelid, a.attnum) IS NULL
 					THEN \'\'
 					ELSE pg_catalog.col_description(a.attrelid, a.attnum)
@@ -358,6 +358,15 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 			foreach ($fields as $field)
 			{
 				$result[$field->column_name] = $field;
+			}
+		}
+
+		/* Change Postgresql's NULL::* type with PHP's null one */
+		foreach ($fields as $field)
+		{
+			if (preg_match("/^NULL::*/", $field->Default))
+			{
+				$field->Default = null;
 			}
 		}
 

--- a/tests/suites/database/driver/postgresql/JDatabasePostgresqlTest.php
+++ b/tests/suites/database/driver/postgresql/JDatabasePostgresqlTest.php
@@ -331,28 +331,28 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 		$id->column_name = 'id';
 		$id->type = 'integer';
 		$id->null = 'NO';
-		$id->default = 'nextval(\'jos_dbtest_id_seq\'::regclass)';
+		$id->Default = 'nextval(\'jos_dbtest_id_seq\'::regclass)';
 		$id->comments = '';
 
 		$title = new stdClass;
 		$title->column_name = 'title';
 		$title->type = 'character varying(50)';
 		$title->null = 'NO';
-		$title->default = null;
+		$title->Default = null;
 		$title->comments = '';
 
 		$start_date = new stdClass;
 		$start_date->column_name = 'start_date';
 		$start_date->type = 'timestamp without time zone';
 		$start_date->null = 'NO';
-		$start_date->default = null;
+		$start_date->Default = null;
 		$start_date->comments = '';
 
 		$description = new stdClass;
 		$description->column_name = 'description';
 		$description->type = 'text';
 		$description->null = 'NO';
-		$description->default = null;
+		$description->Default = null;
 		$description->comments = '';
 
 		$this->assertThat(


### PR DESCRIPTION
Now returns object with "Default" property instead of "default", as MySQL and other driver does.
Changed corresponding test.

Added conversion between PostgreSQL's null to PHP's null value, default field containing "NULL::character varying" will be used as string otherwise.
