### PR TITLE
Fixing false logic in check for JTEST_HTTP_STUB

### DIFF
--- a/tests/suites/unit/joomla/http/JHttpTransportTest.php
+++ b/tests/suites/unit/joomla/http/JHttpTransportTest.php
@@ -30,7 +30,7 @@ class JHttpTransportTest extends PHPUnit_Framework_TestCase
 	{
 		$this->options = $this->getMock('JRegistry', array('get', 'set'));
 
-		if (!defined('JTEST_HTTP_STUB') || getenv('JTEST_HTTP_STUB') == '')
+		if (!defined('JTEST_HTTP_STUB') && getenv('JTEST_HTTP_STUB') == '')
 		{
 			$this->markTestSkipped('The JHttpTransport test stub has not been configured');
 		}


### PR DESCRIPTION
It is currently impossible to set this value using an environment variable because the logical or short circuits.
