### PR TITLE
Fixing defined syntax error - missing quotes

### DIFF
--- a/tests/suites/unit/joomla/http/JHttpTransportTest.php
+++ b/tests/suites/unit/joomla/http/JHttpTransportTest.php
@@ -36,7 +36,7 @@ class JHttpTransportTest extends PHPUnit_Framework_TestCase
 		}
 		else
 		{
-			$this->stubUrl = defined(JTEST_HTTP_STUB) ? JTEST_HTTP_STUB : getenv('JTEST_HTTP_STUB');
+			$this->stubUrl = defined('JTEST_HTTP_STUB') ? JTEST_HTTP_STUB : getenv('JTEST_HTTP_STUB');
 		}
 	}
 


### PR DESCRIPTION
defined expects the constant name to be a string and not the evaluated value of the constant.
