### PR TITLE
JSession still uses JRequest

### DIFF
--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -530,7 +530,9 @@ class JSession extends JObject
 			
 			if (is_null($cookie->get($session_name)))
 			{
-				if ($session_clean = $input->get($session_name, false, 'string'))
+				$session_clean = $input->get($session_name, false, 'string');
+				
+				if ($session_clean)
 				{
 					session_id($session_clean);
 					$cookie->set($session_name, '', time() - 3600);

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -528,9 +528,9 @@ class JSession extends JObject
 			// Get the JInputCookie object
 			$cookie = $input->cookie;
 			
-			if(is_null($cookie->get($session_name)))
+			if (is_null($cookie->get($session_name)))
 			{
-				if($session_clean = $input->get($session_name, false, 'string'))
+				if ($session_clean = $input->get($session_name, false, 'string'))
 				{
 					session_id($session_clean);
 					$cookie->set($session_name, '', time() - 3600);

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -521,17 +521,17 @@ class JSession extends JObject
 		else
 		{
 			$session_name = session_name();
-			
+
 			// Get the JInput object
 			$input = JFactory::getApplication()->input;
-			
+
 			// Get the JInputCookie object
 			$cookie = $input->cookie;
-			
+
 			if (is_null($cookie->get($session_name)))
 			{
 				$session_clean = $input->get($session_name, false, 'string');
-				
+
 				if ($session_clean)
 				{
 					session_id($session_clean);

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -9,8 +9,6 @@
 
 defined('JPATH_PLATFORM') or die;
 
-jimport('joomla.environment.request');
-
 /**
  * Class for managing HTTP sessions
  *
@@ -523,12 +521,19 @@ class JSession extends JObject
 		else
 		{
 			$session_name = session_name();
-			if (!JRequest::getVar($session_name, false, 'COOKIE'))
+			
+			// Get the JInput object
+			$input = JFactory::getApplication()->input;
+			
+			// Get the JInputCookie object
+			$cookie = $input->cookie;
+			
+			if(is_null($cookie->get($session_name)))
 			{
-				if (JRequest::getVar($session_name))
+				if($session_clean = $input->get($session_name, false, 'string'))
 				{
-					session_id(JRequest::getVar($session_name));
-					setcookie($session_name, '', time() - 3600);
+					session_id($session_clean);
+					$cookie->set($session_name, '', time() - 3600);
 				}
 			}
 		}


### PR DESCRIPTION
It causes a fatal error when instanciating JSession because _start() still uses JRequest. I don't know if you want to use this construction
