### PR TITLE
Remove deprecated methods in JLog + additional fixes

### DIFF
--- a/libraries/joomla/database/database.php
+++ b/libraries/joomla/database/database.php
@@ -29,7 +29,7 @@ abstract class JDatabase
 	 */
 	public function query()
 	{
-		JLog::add('JDatabase::query() is deprecated, use JDatabaseDriver::execute() instead.', JLog::NOTICE, 'deprecated');
+		JLog::add('JDatabase::query() is deprecated, use JDatabaseDriver::execute() instead.', JLog::WARNING, 'deprecated');
 
 		return $this->execute();
 	}
@@ -46,7 +46,7 @@ abstract class JDatabase
 	 */
 	public static function getConnectors()
 	{
-		JLog::add('JDatabase::getConnectors() is deprecated, use JDatabaseDriver::getConnectors() instead.', JLog::NOTICE, 'deprecated');
+		JLog::add('JDatabase::getConnectors() is deprecated, use JDatabaseDriver::getConnectors() instead.', JLog::WARNING, 'deprecated');
 
 		return JDatabaseDriver::getConnectors();
 	}
@@ -109,7 +109,7 @@ abstract class JDatabase
 	 */
 	public static function getInstance($options = array())
 	{
-		JLog::add('JDatabase::getInstance() is deprecated, use JDatabaseDriver::getInstance() instead.', JLog::NOTICE, 'deprecated');
+		JLog::add('JDatabase::getInstance() is deprecated, use JDatabaseDriver::getInstance() instead.', JLog::WARNING, 'deprecated');
 
 		return JDatabaseDriver::getInstance($options);
 	}
@@ -126,7 +126,7 @@ abstract class JDatabase
 	 */
 	public static function splitSql($sql)
 	{
-		JLog::add('JDatabase::splitSql() is deprecated, use JDatabaseDriver::splitSql() instead.', JLog::NOTICE, 'deprecated');
+		JLog::add('JDatabase::splitSql() is deprecated, use JDatabaseDriver::splitSql() instead.', JLog::WARNING, 'deprecated');
 
 		return JDatabaseDriver::splitSql($sql);
 	}

--- a/libraries/joomla/database/database.php
+++ b/libraries/joomla/database/database.php
@@ -46,7 +46,6 @@ abstract class JDatabase
 	 */
 	public static function getConnectors()
 	{
-		// Deprecation warning.
 		JLog::add('JDatabase::getConnectors() is deprecated, use JDatabaseDriver::getConnectors() instead.', JLog::NOTICE, 'deprecated');
 
 		return JDatabaseDriver::getConnectors();

--- a/libraries/joomla/database/database/mysql.php
+++ b/libraries/joomla/database/database/mysql.php
@@ -9,7 +9,6 @@
 
 defined('JPATH_PLATFORM') or die;
 
-// Deprecation warning.
 JLog::add('JDatabaseMysql is deprecated, use JDatabaseDriverMysql instead.', JLog::NOTICE, 'deprecated');
 
 /**

--- a/libraries/joomla/database/database/mysql.php
+++ b/libraries/joomla/database/database/mysql.php
@@ -9,7 +9,7 @@
 
 defined('JPATH_PLATFORM') or die;
 
-JLog::add('JDatabaseMysql is deprecated, use JDatabaseDriverMysql instead.', JLog::NOTICE, 'deprecated');
+JLog::add('JDatabaseMysql is deprecated, use JDatabaseDriverMysql instead.', JLog::WARNING, 'deprecated');
 
 /**
  * MySQL database driver

--- a/libraries/joomla/database/database/mysqlexporter.php
+++ b/libraries/joomla/database/database/mysqlexporter.php
@@ -9,4 +9,4 @@
 
 defined('JPATH_PLATFORM') or die;
 
-JLog::add('JDatabaseExporterMysql has moved to the database/exporter directory.', JLog::NOTICE, 'deprecated');
+JLog::add('JDatabaseExporterMysql has moved to the database/exporter directory.', JLog::WARNING, 'deprecated');

--- a/libraries/joomla/database/database/mysqlexporter.php
+++ b/libraries/joomla/database/database/mysqlexporter.php
@@ -9,5 +9,4 @@
 
 defined('JPATH_PLATFORM') or die;
 
-// Deprecation warning.
 JLog::add('JDatabaseExporterMysql has moved to the database/exporter directory.', JLog::NOTICE, 'deprecated');

--- a/libraries/joomla/database/database/mysqli.php
+++ b/libraries/joomla/database/database/mysqli.php
@@ -9,7 +9,6 @@
 
 defined('JPATH_PLATFORM') or die;
 
-// Deprecation warning.
 JLog::add('JDatabaseMysqli is deprecated, use JDatabaseDriverMysqli instead.', JLog::NOTICE, 'deprecated');
 
 /**

--- a/libraries/joomla/database/database/mysqli.php
+++ b/libraries/joomla/database/database/mysqli.php
@@ -9,7 +9,7 @@
 
 defined('JPATH_PLATFORM') or die;
 
-JLog::add('JDatabaseMysqli is deprecated, use JDatabaseDriverMysqli instead.', JLog::NOTICE, 'deprecated');
+JLog::add('JDatabaseMysqli is deprecated, use JDatabaseDriverMysqli instead.', JLog::WARNING, 'deprecated');
 
 /**
  * MySQLi database driver

--- a/libraries/joomla/database/database/mysqliexporter.php
+++ b/libraries/joomla/database/database/mysqliexporter.php
@@ -9,4 +9,4 @@
 
 defined('JPATH_PLATFORM') or die;
 
-JLog::add('JDatabaseExporterMysqli has moved to the database/exporter directory.', JLog::NOTICE, 'deprecated');
+JLog::add('JDatabaseExporterMysqli has moved to the database/exporter directory.', JLog::WARNING, 'deprecated');

--- a/libraries/joomla/database/database/mysqliexporter.php
+++ b/libraries/joomla/database/database/mysqliexporter.php
@@ -9,5 +9,4 @@
 
 defined('JPATH_PLATFORM') or die;
 
-// Deprecation warning.
 JLog::add('JDatabaseExporterMysqli has moved to the database/exporter directory.', JLog::NOTICE, 'deprecated');

--- a/libraries/joomla/database/database/mysqliimporter.php
+++ b/libraries/joomla/database/database/mysqliimporter.php
@@ -9,5 +9,4 @@
 
 defined('JPATH_PLATFORM') or die;
 
-// Deprecation warning.
 JLog::add('JDatabaseImporterMysqli has moved to the database/importer directory.', JLog::NOTICE, 'deprecated');

--- a/libraries/joomla/database/database/mysqliimporter.php
+++ b/libraries/joomla/database/database/mysqliimporter.php
@@ -9,4 +9,4 @@
 
 defined('JPATH_PLATFORM') or die;
 
-JLog::add('JDatabaseImporterMysqli has moved to the database/importer directory.', JLog::NOTICE, 'deprecated');
+JLog::add('JDatabaseImporterMysqli has moved to the database/importer directory.', JLog::WARNING, 'deprecated');

--- a/libraries/joomla/database/database/mysqlimporter.php
+++ b/libraries/joomla/database/database/mysqlimporter.php
@@ -9,4 +9,4 @@
 
 defined('JPATH_PLATFORM') or die;
 
-JLog::add('JDatabaseImporterMysql has moved to the database/importer directory.', JLog::NOTICE, 'deprecated');
+JLog::add('JDatabaseImporterMysql has moved to the database/importer directory.', JLog::WARNING, 'deprecated');

--- a/libraries/joomla/database/database/mysqlimporter.php
+++ b/libraries/joomla/database/database/mysqlimporter.php
@@ -9,5 +9,4 @@
 
 defined('JPATH_PLATFORM') or die;
 
-// Deprecation warning.
 JLog::add('JDatabaseImporterMysql has moved to the database/importer directory.', JLog::NOTICE, 'deprecated');

--- a/libraries/joomla/database/database/mysqliquery.php
+++ b/libraries/joomla/database/database/mysqliquery.php
@@ -9,5 +9,4 @@
 
 defined('JPATH_PLATFORM') or die;
 
-// Deprecation warning.
 JLog::add('JDatabaseQueryMysqli has moved to the database/query directory.', JLog::NOTICE, 'deprecated');

--- a/libraries/joomla/database/database/mysqliquery.php
+++ b/libraries/joomla/database/database/mysqliquery.php
@@ -9,4 +9,4 @@
 
 defined('JPATH_PLATFORM') or die;
 
-JLog::add('JDatabaseQueryMysqli has moved to the database/query directory.', JLog::NOTICE, 'deprecated');
+JLog::add('JDatabaseQueryMysqli has moved to the database/query directory.', JLog::WARNING, 'deprecated');

--- a/libraries/joomla/database/database/mysqlquery.php
+++ b/libraries/joomla/database/database/mysqlquery.php
@@ -9,5 +9,4 @@
 
 defined('JPATH_PLATFORM') or die;
 
-// Deprecation warning.
 JLog::add('JDatabaseQueryMysql has moved to the database/query directory.', JLog::NOTICE, 'deprecated');

--- a/libraries/joomla/database/database/mysqlquery.php
+++ b/libraries/joomla/database/database/mysqlquery.php
@@ -9,4 +9,4 @@
 
 defined('JPATH_PLATFORM') or die;
 
-JLog::add('JDatabaseQueryMysql has moved to the database/query directory.', JLog::NOTICE, 'deprecated');
+JLog::add('JDatabaseQueryMysql has moved to the database/query directory.', JLog::WARNING, 'deprecated');

--- a/libraries/joomla/database/database/sqlazure.php
+++ b/libraries/joomla/database/database/sqlazure.php
@@ -9,7 +9,6 @@
 
 defined('JPATH_PLATFORM') or die;
 
-// Deprecation warning.
 JLog::add('JDatabaseSqlazure is deprecated, use JDatabaseDriverSqlazure instead.', JLog::NOTICE, 'deprecated');
 
 /**

--- a/libraries/joomla/database/database/sqlazure.php
+++ b/libraries/joomla/database/database/sqlazure.php
@@ -9,7 +9,7 @@
 
 defined('JPATH_PLATFORM') or die;
 
-JLog::add('JDatabaseSqlazure is deprecated, use JDatabaseDriverSqlazure instead.', JLog::NOTICE, 'deprecated');
+JLog::add('JDatabaseSqlazure is deprecated, use JDatabaseDriverSqlazure instead.', JLog::WARNING, 'deprecated');
 
 /**
  * SQL Server database driver

--- a/libraries/joomla/database/database/sqlazurequery.php
+++ b/libraries/joomla/database/database/sqlazurequery.php
@@ -9,5 +9,4 @@
 
 defined('JPATH_PLATFORM') or die;
 
-// Deprecation warning.
 JLog::add('JDatabaseQuerySqlazure has moved to the database/query directory.', JLog::NOTICE, 'deprecated');

--- a/libraries/joomla/database/database/sqlazurequery.php
+++ b/libraries/joomla/database/database/sqlazurequery.php
@@ -9,4 +9,4 @@
 
 defined('JPATH_PLATFORM') or die;
 
-JLog::add('JDatabaseQuerySqlazure has moved to the database/query directory.', JLog::NOTICE, 'deprecated');
+JLog::add('JDatabaseQuerySqlazure has moved to the database/query directory.', JLog::WARNING, 'deprecated');

--- a/libraries/joomla/database/database/sqlsrv.php
+++ b/libraries/joomla/database/database/sqlsrv.php
@@ -9,7 +9,6 @@
 
 defined('JPATH_PLATFORM') or die;
 
-// Deprecation warning.
 JLog::add('JDatabaseSqlsrv is deprecated, use JDatabaseDriverSqlsrv instead.', JLog::NOTICE, 'deprecated');
 JLoader::register('JDatabaseQuerySQLSrv', __DIR__ . '/sqlsrvquery.php');
 

--- a/libraries/joomla/database/database/sqlsrv.php
+++ b/libraries/joomla/database/database/sqlsrv.php
@@ -9,7 +9,7 @@
 
 defined('JPATH_PLATFORM') or die;
 
-JLog::add('JDatabaseSqlsrv is deprecated, use JDatabaseDriverSqlsrv instead.', JLog::NOTICE, 'deprecated');
+JLog::add('JDatabaseSqlsrv is deprecated, use JDatabaseDriverSqlsrv instead.', JLog::WARNING, 'deprecated');
 JLoader::register('JDatabaseQuerySQLSrv', __DIR__ . '/sqlsrvquery.php');
 
 /**

--- a/libraries/joomla/database/database/sqlsrvquery.php
+++ b/libraries/joomla/database/database/sqlsrvquery.php
@@ -9,4 +9,4 @@
 
 defined('JPATH_PLATFORM') or die;
 
-JLog::add('JDatabaseQuerySqlsrv has moved to the database/query directory.', JLog::NOTICE, 'deprecated');
+JLog::add('JDatabaseQuerySqlsrv has moved to the database/query directory.', JLog::WARNING, 'deprecated');

--- a/libraries/joomla/database/database/sqlsrvquery.php
+++ b/libraries/joomla/database/database/sqlsrvquery.php
@@ -9,5 +9,4 @@
 
 defined('JPATH_PLATFORM') or die;
 
-// Deprecation warning.
 JLog::add('JDatabaseQuerySqlsrv has moved to the database/query directory.', JLog::NOTICE, 'deprecated');

--- a/libraries/joomla/html/html/select.php
+++ b/libraries/joomla/html/html/select.php
@@ -328,7 +328,6 @@ abstract class JHtmlSelect
 	 */
 	public static function optgroup($text, $optKey = 'value', $optText = 'text')
 	{
-		// Deprecation warning.
 		JLog::add('JSelect::optgroup is deprecated.', JLog::WARNING, 'deprecated');
 
 		// Set initial state

--- a/libraries/joomla/log/log.php
+++ b/libraries/joomla/log/log.php
@@ -207,65 +207,6 @@ class JLog
 	}
 
 	/**
-	 * Returns a JLog object for a given log file/configuration, only creating it if it doesn't already exist.
-	 *
-	 * This method must be invoked as:
-	 * <code>$log = JLog::getInstance($file, $options, $path);</code>
-	 *
-	 * @param   string  $file     The filename of the log file.
-	 * @param   array   $options  The object configuration array.
-	 * @param   string  $path     The base path for the log file.
-	 *
-	 * @return  JLog
-	 *
-	 * @since   11.1
-	 *
-	 * @deprecated  12.1
-	 */
-	public static function getInstance($file = 'error.php', $options = null, $path = null)
-	{
-		self::add('JLog::getInstance() is deprecated.  See JLog::addLogger().', self::WARNING, 'deprecated');
-
-		// Get the system configuration object.
-		$config = JFactory::getConfig();
-
-		// Set default path if not set and sanitize it.
-		if (!$path)
-		{
-			$path = $config->get('log_path');
-		}
-
-		// If no options were explicitly set use the default from configuration.
-		if (empty($options))
-		{
-			$options = (array) $config->get('log_options');
-		}
-
-		// Fix up the options so that we use the w3c format.
-		$options['text_entry_format'] = empty($options['format']) ? null : $options['format'];
-		$options['text_file'] = $file;
-		$options['text_file_path'] = $path;
-		$options['logger'] = 'w3c';
-
-		// Generate a unique signature for the JLog instance based on its options.
-		$signature = md5(serialize($options));
-
-		// Only create the object if not already created.
-		if (empty(self::$legacy[$signature]))
-		{
-			self::$legacy[$signature] = new JLog;
-
-			// Register the configuration.
-			self::$legacy[$signature]->configurations[$signature] = $options;
-
-			// Setup the lookup to catch all.
-			self::$legacy[$signature]->lookup[$signature] = (object) array('priorities' => self::ALL, 'categories' => array());
-		}
-
-		return self::$legacy[$signature];
-	}
-
-	/**
 	 * Returns a reference to the a JLog object, only creating it if it doesn't already exist.
 	 * Note: This is principally made available for testing and internal purposes.
 	 *
@@ -281,61 +222,6 @@ class JLog
 		{
 			self::$instance = & $instance;
 		}
-	}
-
-	/**
-	 * Method to add an entry to the log file.
-	 *
-	 * @param   array  $entry  Array of values to map to the format string for the log file.
-	 *
-	 * @return  mixed  null|boolean
-	 *
-	 * @since         11.1
-	 *
-	 * @deprecated    12.1  Use JLog::add() instead.
-	 */
-	public function addEntry($entry)
-	{
-		self::add('JLog::addEntry() is deprecated, use JLog::add() instead.', self::WARNING, 'deprecated');
-
-		// Easiest case is we already have a JLogEntry object to add.
-		if ($entry instanceof JLogEntry)
-		{
-			return $this->addLogEntry($entry);
-		}
-		// We have either an object or array that needs to be converted to a JLogEntry.
-		elseif (is_array($entry) || is_object($entry))
-		{
-			$tmp = new JLogEntry('');
-			foreach ((array) $entry as $k => $v)
-			{
-				switch ($k)
-				{
-					case 'c-ip':
-						$tmp->clientIP = $v;
-						break;
-					case 'status':
-						$tmp->category = $v;
-						break;
-					case 'level':
-						$tmp->priority = $v;
-						break;
-					case 'comment':
-						$tmp->message = $v;
-						break;
-					default:
-						$tmp->$k = $v;
-						break;
-				}
-			}
-		}
-		// Unrecognized type.
-		else
-		{
-			return false;
-		}
-
-		return $this->addLogEntry($tmp);
 	}
 
 	/**

--- a/libraries/joomla/log/log.php
+++ b/libraries/joomla/log/log.php
@@ -296,7 +296,6 @@ class JLog
 	 */
 	public function addEntry($entry)
 	{
-		// Deprecation warning.
 		self::add('JLog::addEntry() is deprecated, use JLog::add() instead.', self::WARNING, 'deprecated');
 
 		// Easiest case is we already have a JLogEntry object to add.

--- a/libraries/joomla/log/log.php
+++ b/libraries/joomla/log/log.php
@@ -13,9 +13,6 @@ jimport('joomla.log.logger');
 
 JLoader::discover('JLogger', __DIR__ . '/loggers');
 
-// @deprecated  12.1
-jimport('joomla.filesystem.path');
-
 /**
  * Joomla! Log Class
  *

--- a/libraries/joomla/plugin/helper.php
+++ b/libraries/joomla/plugin/helper.php
@@ -156,16 +156,12 @@ abstract class JPluginHelper
 		$plugin->type = preg_replace('/[^A-Z0-9_\.-]/i', '', $plugin->type);
 		$plugin->name = preg_replace('/[^A-Z0-9_\.-]/i', '', $plugin->name);
 
-		$legacypath = JPATH_PLUGINS . '/' . $plugin->type . '/' . $plugin->name . '.php';
 		$path = JPATH_PLUGINS . '/' . $plugin->type . '/' . $plugin->name . '/' . $plugin->name . '.php';
 
-		if (!isset($paths[$path]) || !isset($paths[$legacypath]))
+		if (!isset($paths[$path]))
 		{
-			$pathExists = file_exists($path);
-			if ($pathExists || file_exists($legacypath))
+			if (file_exists($path))
 			{
-				$path = $pathExists ? $path : $legacypath;
-
 				if (!isset($paths[$path]))
 				{
 					require_once $path;

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -446,7 +446,6 @@ class JUser extends JObject
 	public function getParameters($loadsetupfile = false, $path = null)
 	{
 		// @codeCoverageIgnoreStart
-		// Deprecation warning.
 		JLog::add('JUser::getParameters() is deprecated.', JLog::WARNING, 'deprecated');
 
 		return $this->_params;

--- a/libraries/joomla/utilities/xmlelement.php
+++ b/libraries/joomla/utilities/xmlelement.php
@@ -29,7 +29,7 @@ class JXMLElement extends SimpleXMLElement
 	 */
 	public function name()
 	{
-		JLog::add('JXMLElement::name() is deprecated, use SimpleXMLElement::getName() instead.', self::WARNING, 'deprecated');
+		JLog::add('JXMLElement::name() is deprecated, use SimpleXMLElement::getName() instead.', JLog::WARNING, 'deprecated');
 		return (string) $this->getName();
 	}
 
@@ -47,7 +47,7 @@ class JXMLElement extends SimpleXMLElement
 	 */
 	public function asFormattedXML($compressed = false, $indent = "\t", $level = 0)
 	{
-		JLog::add('JXMLElement::asFormattedXML() is deprecated, use SimpleXMLElement::asXML() instead.', self::WARNING, 'deprecated');
+		JLog::add('JXMLElement::asFormattedXML() is deprecated, use SimpleXMLElement::asXML() instead.', JLog::WARNING, 'deprecated');
 		$out = '';
 
 		// Start a new line, indent by the number indicated in $level

--- a/libraries/legacy/base/node.php
+++ b/libraries/legacy/base/node.php
@@ -43,7 +43,6 @@ class JNode extends JObject
 	 */
 	public function __construct()
 	{
-		// Deprecation warning.
 		JLog::add('JNode::__construct() is deprecated.', JLog::WARNING, 'deprecated');
 
 		return true;
@@ -62,7 +61,6 @@ class JNode extends JObject
 	 */
 	public function addChild(&$child)
 	{
-		// Deprecation warning.
 		JLog::add('JNode::addChild() is deprecated.', JLog::WARNING, 'deprecated');
 
 		if ($child instanceof Jnode)
@@ -84,7 +82,6 @@ class JNode extends JObject
 	 */
 	public function setParent(&$parent)
 	{
-		// Deprecation warning.
 		JLog::add('JNode::setParent() is deprecated.', JLog::WARNING, 'deprecated');
 
 		if ($parent instanceof JNode || is_null($parent))
@@ -111,7 +108,6 @@ class JNode extends JObject
 	 */
 	public function &getChildren()
 	{
-		// Deprecation warning.
 		JLog::add('JNode::getChildren() is deprecated.', JLog::WARNING, 'deprecated');
 
 		return $this->_children;
@@ -126,7 +122,6 @@ class JNode extends JObject
 	 */
 	public function &getParent()
 	{
-		// Deprecation warning.
 		JLog::add('JNode::getParent() is deprecated.', JLog::WARNING, 'deprecated');
 
 		return $this->_parent;
@@ -141,7 +136,6 @@ class JNode extends JObject
 	 */
 	public function hasChildren()
 	{
-		// Deprecation warning.
 		JLog::add('JNode::hasChildren() is deprecated.', JLog::WARNING, 'deprecated');
 
 		return (bool) count($this->_children);
@@ -156,7 +150,6 @@ class JNode extends JObject
 	 */
 	public function hasParent()
 	{
-		// Deprecation warning.
 		JLog::add('JNode::hasParent() is deprecated.', JLog::WARNING, 'deprecated');
 
 		return $this->getParent() != null;

--- a/libraries/legacy/base/tree.php
+++ b/libraries/legacy/base/tree.php
@@ -43,7 +43,6 @@ class JTree extends JObject
 	 */
 	public function __construct()
 	{
-		// Deprecation warning.
 		JLog::add('JTree::__construct() is deprecated.', JLog::WARNING, 'deprecated');
 
 		$this->_root = new JNode('ROOT');
@@ -62,7 +61,6 @@ class JTree extends JObject
 	 */
 	public function addChild(&$node, $setCurrent = false)
 	{
-		// Deprecation warning.
 		JLog::add('JTree::addChild() is deprecated.', JLog::WARNING, 'deprecated');
 
 		$this->_current->addChild($node);
@@ -81,7 +79,6 @@ class JTree extends JObject
 	 */
 	public function getParent()
 	{
-		// Deprecation warning.
 		JLog::add('JTree::getParent() is deprecated.', JLog::WARNING, 'deprecated');
 
 		$this->_current = &$this->_current->getParent();
@@ -96,7 +93,6 @@ class JTree extends JObject
 	 */
 	public function reset()
 	{
-		// Deprecation warning.
 		JLog::add('JTree::reset() is deprecated.', JLog::WARNING, 'deprecated');
 
 		$this->_current = &$this->_root;

--- a/libraries/legacy/controller/controller.php
+++ b/libraries/legacy/controller/controller.php
@@ -316,6 +316,11 @@ class JController extends JObject
 		$this->redirect = null;
 		$this->taskMap = array();
 
+		if (JDEBUG)
+		{
+			JLog::addLogger(array('text_file' => 'jcontroller.log.php'), JLog::ALL, array('controller'));
+		}
+
 		// Determine the methods to exclude from the base class.
 		$xMethods = get_class_methods('JController');
 
@@ -502,17 +507,13 @@ class JController extends JObject
 
 			if (JDEBUG)
 			{
-				JLog::getInstance('jcontroller.log.php')->addEntry(
-					array(
-						'comment' => sprintf(
-							'Checking edit ID %s.%s: %d %s',
-							$context,
-							$id,
-							(int) $result,
-							str_replace("\n", ' ', print_r($values, 1))
-						)
-					)
-				);
+				JLog::add(sprintf(
+					'Checking edit ID %s.%s: %d %s',
+					$context,
+					$id,
+					(int) $result,
+					str_replace("\n", ' ', print_r($values, 1))
+				), JLog::INFO, 'controller');
 			}
 
 			return $result;
@@ -872,11 +873,12 @@ class JController extends JObject
 
 			if (JDEBUG)
 			{
-				JLog::getInstance('jcontroller.log.php')->addEntry(
-					array(
-						'comment' => sprintf('Holding edit ID %s.%s %s', $context, $id, str_replace("\n", ' ', print_r($values, 1)))
-					)
-				);
+				JLog::add(sprintf(
+					'Holding edit ID %s.%s %s',
+					$context,
+					$id,
+					str_replace("\n", ' ', print_r($values, 1))
+				), JLog::INFO, 'controller');
 			}
 		}
 	}
@@ -976,11 +978,12 @@ class JController extends JObject
 
 			if (JDEBUG)
 			{
-				JLog::getInstance('jcontroller.log.php')->addEntry(
-					array(
-						'comment' => sprintf('Releasing edit ID %s.%s %s', $context, $id, str_replace("\n", ' ', print_r($values, 1)))
-					)
-				);
+				JLog::add(sprintf(
+					'Releasing edit ID %s.%s %s',
+					$context,
+					$id,
+					str_replace("\n", ' ', print_r($values, 1))
+				), JLog::INFO, 'controller');
 			}
 		}
 	}

--- a/libraries/legacy/database/exception.php
+++ b/libraries/legacy/database/exception.php
@@ -9,8 +9,7 @@
 
 defined('JPATH_PLATFORM') or die;
 
-// Deprecation warning.
-JLog::add('JDatabaseException is deprecated, use SPL Exceptions instead.', JLog::NOTICE, 'deprecated');
+JLog::add('JDatabaseException is deprecated, use SPL Exceptions instead.', JLog::WARNING, 'deprecated');
 
 /**
  * Exception class definition for the Database subpackage.

--- a/libraries/legacy/error/error.php
+++ b/libraries/legacy/error/error.php
@@ -73,7 +73,6 @@ abstract class JError
 	 */
 	public static function getError($unset = false)
 	{
-		// Deprecation warning.
 		JLog::add('JError::getError() is deprecated.', JLog::WARNING, 'deprecated');
 
 		if (!isset(self::$stack[0]))
@@ -102,7 +101,6 @@ abstract class JError
 	 */
 	public static function getErrors()
 	{
-		// Deprecation warning.
 		JLog::add('JError::getErrors() is deprecated.', JLog::WARNING, 'deprecated');
 
 		return self::$stack;
@@ -120,7 +118,6 @@ abstract class JError
 	 */
 	public static function addToStack(JException &$e)
 	{
-		// Deprecation warning.
 		JLog::add('JError::addToStack() is deprecated.', JLog::WARNING, 'deprecated');
 
 		self::$stack[] = &$e;
@@ -147,7 +144,6 @@ abstract class JError
 	 */
 	public static function raise($level, $code, $msg, $info = null, $backtrace = false)
 	{
-		// Deprecation warning.
 		JLog::add('JError::raise() is deprecated.', JLog::WARNING, 'deprecated');
 
 		// Build error object
@@ -168,7 +164,6 @@ abstract class JError
 	 */
 	public static function throwError(&$exception)
 	{
-		// Deprecation warning.
 		JLog::add('JError::throwError() is deprecated.', JLog::WARNING, 'deprecated');
 
 		static $thrown = false;
@@ -225,7 +220,6 @@ abstract class JError
 	 */
 	public static function raiseError($code, $msg, $info = null)
 	{
-		// Deprecation warning.
 		JLog::add('JError::raiseError() is deprecated.', JLog::WARNING, 'deprecated');
 
 		return self::raise(E_ERROR, $code, $msg, $info, true);
@@ -250,7 +244,6 @@ abstract class JError
 	 */
 	public static function raiseWarning($code, $msg, $info = null)
 	{
-		// Deprecation warning.
 		JLog::add('JError::raiseWarning() is deprecated.', JLog::WARNING, 'deprecated');
 
 		return self::raise(E_WARNING, $code, $msg, $info);
@@ -274,7 +267,6 @@ abstract class JError
 	 */
 	public static function raiseNotice($code, $msg, $info = null)
 	{
-		// Deprecation warning.
 		JLog::add('JError::raiseNotice() is deprecated.', JLog::WARNING, 'deprecated');
 
 		return self::raise(E_NOTICE, $code, $msg, $info);
@@ -293,7 +285,6 @@ abstract class JError
 	 */
 	public static function getErrorHandling($level)
 	{
-		// Deprecation warning.
 		JLog::add('JError::getErrorHandling() is deprecated.', JLog::WARNING, 'deprecated');
 
 		return self::$handlers[$level];
@@ -328,7 +319,6 @@ abstract class JError
 	 */
 	public static function setErrorHandling($level, $mode, $options = null)
 	{
-		// Deprecation warning.
 		JLog::add('JError::setErrorHandling() is deprecated.', JLog::WARNING, 'deprecated');
 
 		$levels = self::$levels;
@@ -399,7 +389,6 @@ abstract class JError
 	 */
 	public static function attachHandler()
 	{
-		// Deprecation warning.
 		JLog::add('JError::getErrorHandling() is deprecated.', JLog::WARNING, 'deprecated');
 
 		set_error_handler(array('JError', 'customErrorHandler'));
@@ -416,7 +405,6 @@ abstract class JError
 	 */
 	public static function detachHandler()
 	{
-		// Deprecation warning.
 		JLog::add('JError::detachHandler() is deprecated.', JLog::WARNING, 'deprecated');
 
 		restore_error_handler();
@@ -441,7 +429,6 @@ abstract class JError
 	 */
 	public static function registerErrorLevel($level, $name, $handler = 'ignore')
 	{
-		// Deprecation warning.
 		JLog::add('JError::registerErrorLevel() is deprecated.', JLog::WARNING, 'deprecated');
 
 		if (isset(self::$levels[$level]))
@@ -469,7 +456,6 @@ abstract class JError
 
 	public static function translateErrorLevel($level)
 	{
-		// Deprecation warning.
 		JLog::add('JError::translateErrorLevel() is deprecated.', JLog::WARNING, 'deprecated');
 
 		if (isset(self::$levels[$level]))
@@ -495,7 +481,6 @@ abstract class JError
 	 */
 	public static function handleIgnore(&$error, $options)
 	{
-		// Deprecation warning.
 		JLog::add('JError::handleIgnore() is deprecated.', JLog::WARNING, 'deprecated');
 
 		return $error;
@@ -516,7 +501,6 @@ abstract class JError
 	 */
 	public static function handleEcho(&$error, $options)
 	{
-		// Deprecation warning.
 		JLog::add('JError::handleEcho() is deprecated.', JLog::WARNING, 'deprecated');
 
 		$level_human = self::translateErrorLevel($error->get('level'));
@@ -590,7 +574,6 @@ abstract class JError
 	 */
 	public static function handleVerbose(&$error, $options)
 	{
-		// Deprecation warning.
 		JLog::add('JError::handleVerbose() is deprecated.', JLog::WARNING, 'deprecated');
 
 		$level_human = self::translateErrorLevel($error->get('level'));
@@ -637,7 +620,6 @@ abstract class JError
 	 */
 	public static function handleDie(&$error, $options)
 	{
-		// Deprecation warning.
 		JLog::add('JError::handleDie() is deprecated.', JLog::WARNING, 'deprecated');
 
 		$level_human = self::translateErrorLevel($error->get('level'));
@@ -679,7 +661,6 @@ abstract class JError
 	 */
 	public static function handleMessage(&$error, $options)
 	{
-		// Deprecation warning.
 		JLog::add('JError::hanleMessage() is deprecated.', JLog::WARNING, 'deprecated');
 
 		$appl = JFactory::getApplication();
@@ -704,7 +685,6 @@ abstract class JError
 	 */
 	public static function handleLog(&$error, $options)
 	{
-		// Deprecation warning.
 		JLog::add('JError::handleLog() is deprecated.', JLog::WARNING, 'deprecated');
 
 		static $log;
@@ -742,7 +722,6 @@ abstract class JError
 	 */
 	public static function handleCallback(&$error, $options)
 	{
-		// Deprecation warning.
 		JLog::add('JError::handleCallback() is deprecated.', JLog::WARNING, 'deprecated');
 
 		return call_user_func($options, $error);
@@ -760,7 +739,6 @@ abstract class JError
 	 */
 	public static function customErrorPage(&$error)
 	{
-		// Deprecation warning.
 		JLog::add('JError::customErrorPage() is deprecated.', JLog::WARNING, 'deprecated');
 
 		// Initialise variables.
@@ -818,7 +796,6 @@ abstract class JError
 	 */
 	public static function customErrorHandler($level, $msg)
 	{
-		// Deprecation warning.
 		JLog::add('JError::customErrorHandler() is deprecated.', JLog::WARNING, 'deprecated');
 
 		self::raise($level, '', $msg);
@@ -836,7 +813,6 @@ abstract class JError
 	 */
 	public static function renderBacktrace($error)
 	{
-		// Deprecation warning.
 		JLog::add('JError::renderBacktrace() is deprecated.', JLog::WARNING, 'deprecated');
 
 		$contents = null;

--- a/libraries/legacy/error/error.php
+++ b/libraries/legacy/error/error.php
@@ -711,15 +711,18 @@ abstract class JError
 
 		if ($log == null)
 		{
-			$fileName = date('Y-m-d') . '.error.log';
+			$options['text_file'] = date('Y-m-d') . '.error.log';
 			$options['format'] = "{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}";
-			$log = JLog::getInstance($fileName, $options);
+			JLog::addLogger($options, JLog::ALL, array('error'));
 		}
 
-		$entry['level'] = $error->get('level');
-		$entry['code'] = $error->get('code');
-		$entry['message'] = str_replace(array("\r", "\n"), array('', '\\n'), $error->get('message'));
-		$log->addEntry($entry);
+		$entry = new JLogEntry(
+			str_replace(array("\r", "\n"), array('', '\\n'), $error->get('message')),
+			$error->get('level'),
+			'error'
+		);
+		$entry->code = $error->get('code');
+		JLog::add($entry);
 
 		return $error;
 	}

--- a/libraries/legacy/exception/exception.php
+++ b/libraries/legacy/exception/exception.php
@@ -114,7 +114,6 @@ class JException extends Exception
 	 */
 	public function __construct($msg, $code = 0, $level = null, $info = null, $backtrace = false)
 	{
-		// Deprecation warning.
 		JLog::add('JException is deprecated.', JLog::WARNING, 'deprecated');
 
 		$this->level = $level;
@@ -258,7 +257,6 @@ class JException extends Exception
 	 */
 	public function getError($i = null, $toString = true)
 	{
-		// Deprecation warning.
 		JLog::add('JException::getError is deprecated.', JLog::WARNING, 'deprecated');
 
 		// Find the error
@@ -297,7 +295,6 @@ class JException extends Exception
 	 */
 	public function getErrors()
 	{
-		// Deprecation warning.
 		JLog::add('JException::getErrors is deprecated.', JLog::WARNING, 'deprecated');
 
 		return $this->_errors;
@@ -317,7 +314,6 @@ class JException extends Exception
 	 */
 	public function set($property, $value = null)
 	{
-		// Deprecation warning.
 		JLog::add('JException::set is deprecated.', JLog::WARNING, 'deprecated');
 
 		$previous = isset($this->$property) ? $this->$property : null;
@@ -338,7 +334,6 @@ class JException extends Exception
 	 */
 	public function setProperties($properties)
 	{
-		// Deprecation warning.
 		JLog::add('JException::setProperties is deprecated.', JLog::WARNING, 'deprecated');
 
 		// Cast to an array
@@ -370,7 +365,6 @@ class JException extends Exception
 	 */
 	public function setError($error)
 	{
-		// Deprecation warning.
 		JLog::add('JException::setErrors is deprecated.', JLog::WARNING, 'deprecated');
 
 		array_push($this->_errors, $error);

--- a/libraries/legacy/exception/exception.php
+++ b/libraries/legacy/exception/exception.php
@@ -179,6 +179,8 @@ class JException extends Exception
 	 */
 	public function __toString()
 	{
+		JLog::add('JException::__toString is deprecated.', JLog::WARNING, 'deprecated');
+
 		return $this->message;
 	}
 
@@ -192,6 +194,8 @@ class JException extends Exception
 	 */
 	public function toString()
 	{
+		JLog::add('JException::toString is deprecated.', JLog::WARNING, 'deprecated');
+
 		return (string) $this;
 	}
 
@@ -209,6 +213,8 @@ class JException extends Exception
 	 */
 	public function get($property, $default = null)
 	{
+		JLog::add('JException::get is deprecated.', JLog::WARNING, 'deprecated');
+
 		if (isset($this->$property))
 		{
 			return $this->$property;
@@ -229,6 +235,8 @@ class JException extends Exception
 	 */
 	public function getProperties($public = true)
 	{
+		JLog::add('JException::getProperties is deprecated.', JLog::WARNING, 'deprecated');
+
 		$vars = get_object_vars($this);
 		if ($public)
 		{

--- a/libraries/legacy/log/logexception.php
+++ b/libraries/legacy/log/logexception.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+JLog::add('LogException is deprecated, use SPL Exceptions instead.', JLog::WARNING, 'deprecated');
+
 /**
  * Exception class definition for the Log subpackage.
  *
@@ -17,6 +19,6 @@ defined('JPATH_PLATFORM') or die;
  * @since       11.1
  * @deprecated  12.3 Use semantic exceptions instead
  */
-class LogException extends Exception
+class LogException extends RuntimeException
 {
 }

--- a/libraries/legacy/module/helper.php
+++ b/libraries/legacy/module/helper.php
@@ -384,6 +384,8 @@ abstract class JModuleHelper
 	 * Caching modes:
 	 * To be set in XML:
 	 * 'static'      One cache file for all pages with the same module parameters
+	 * 'oldstatic'   1.5 definition of module caching, one cache file for all pages
+	 *               with the same module id and user aid,
 	 * 'itemid'      Changes on itemid change, to be called from inside the module:
 	 * 'safeuri'     Id created from $cacheparams->modeparams array,
 	 * 'id'          Module sets own cache id's
@@ -472,6 +474,16 @@ abstract class JModuleHelper
 						$cacheparams->method),
 					$cacheparams->methodparams,
 					$module->module . md5(serialize($cacheparams->methodparams)),
+					$wrkarounds,
+					$wrkaroundoptions
+				);
+				break;
+
+			case 'oldstatic': // provided for backward compatibility, not really usefull
+				$ret = $cache->get(
+					array($cacheparams->class, $cacheparams->method),
+					$cacheparams->methodparams,
+					$module->id . $view_levels,
 					$wrkarounds,
 					$wrkaroundoptions
 				);

--- a/libraries/legacy/simplecrypt/simplecrypt.php
+++ b/libraries/legacy/simplecrypt/simplecrypt.php
@@ -37,6 +37,8 @@ class JSimplecrypt
 	 */
 	public function __construct($privateKey = null)
 	{
+		JLog::add('JSimpleCrypt is deprecated.  Use JCrypt instead.', JLog::WARNING, 'deprecated');
+
 		if (empty($privateKey))
 		{
 			$privateKey = md5(JFactory::getConfig()->get('secret'));
@@ -47,8 +49,6 @@ class JSimplecrypt
 
 		// Setup the JCrypt object.
 		$this->_crypt = new JCrypt(new JCryptCipherSimple, $key);
-
-		JLog::add('JSimpleCrypt is deprecated.  Use JCrypt instead.', JLog::WARNING, 'deprecated');
 	}
 
 	/**

--- a/libraries/legacy/simplecrypt/simplecrypt.php
+++ b/libraries/legacy/simplecrypt/simplecrypt.php
@@ -48,7 +48,6 @@ class JSimplecrypt
 		// Setup the JCrypt object.
 		$this->_crypt = new JCrypt(new JCryptCipherSimple, $key);
 
-		// Deprecation warning.
 		JLog::add('JSimpleCrypt is deprecated.  Use JCrypt instead.', JLog::WARNING, 'deprecated');
 	}
 

--- a/tests/suites/unit/joomla/log/JLogTest.php
+++ b/tests/suites/unit/joomla/log/JLogTest.php
@@ -39,74 +39,6 @@ class JLogTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test the JLog::addEntry method to make sure if we give it invalid scalar input it will return false
-	 * just as in Joomla! CMS 1.5.  This method is deprecated and will be removed in 11.2.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.1
-	 */
-	public function testAddEntryWithInvalidScalarInput()
-	{
-		$log = new JLogInspector;
-
-		$this->assertFalse($log->addEntry(123), 'Line: '.__LINE__);
-		$this->assertFalse($log->addEntry('foobar'), 'Line: '.__LINE__);
-		$this->assertFalse($log->addEntry(3.14), 'Line: '.__LINE__);
-	}
-
-	/**
-	 * Test the JLog::addEntry method to make sure if we give it valid array input as in Joomla! CMS 1.5 then
-	 * it will in fact add a log entry and transform it correctly.  This method is deprecated and will be
-	 * removed in 11.2.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.1
-	 */
-	public function testAddEntryWithValidArrayInput()
-	{
-		$log = new JLogInspector;
-
-		// Create an array similar to expected input array from Joomla! CMS 1.5
-		$entry = array(
-			'c-ip' => '127.0.0.1',
-			'status' => 'deprecated',
-			'level' => JLog::DEBUG,
-			'comment' => 'Test Entry',
-			'foo' => 'bar'
-		);
-
-		$log->addEntry($entry);
-
-		// Verify all of the JLogEntry values.
-		$this->assertEquals($log->queue[0]->category, 'deprecated', 'Line: '.__LINE__);
-		$this->assertEquals($log->queue[0]->priority, JLog::DEBUG, 'Line: '.__LINE__);
-		$this->assertEquals($log->queue[0]->message, 'Test Entry', 'Line: '.__LINE__);
-		$this->assertEquals($log->queue[0]->foo, 'bar', 'Line: '.__LINE__);
-		$this->assertEquals($log->queue[0]->clientIP, '127.0.0.1', 'Line: '.__LINE__);
-	}
-
-	/**
-	 * Test the JLog::addEntry method to make sure if we give it a valid JLogEntry object as input it will
-	 * correctly accept and add the entry.  This method is deprecated and will be removed in 11.2.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.1
-	 */
-	public function testAddEntryWithValidJLogEntry()
-	{
-		$log = new JLogInspector;
-
-		$entry = new JLogEntry('TESTING', JLog::DEBUG);
-
-		$log->addEntry($entry);
-
-		$this->assertEquals($log->queue[0], $entry, 'Line: '.__LINE__);
-	}
-
-	/**
 	 * Test the JLog::addLogEntry method to verify that if called directly it will route the entry to the
 	 * appropriate loggers.  We use the echo logger here for easy testing using the PHP output buffer.
 	 *
@@ -374,26 +306,6 @@ class JLogTest extends PHPUnit_Framework_TestCase
 				)),
 			'Line: '.__LINE__.'.'
 		);
-	}
-
-	/**
-	 * Test the JLog::getInstance method to make sure we are getting a valid JLog instance from it.  This
-	 * method is deprecated and will be removed in 11.2.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.1
-	 */
-	public function testGetInstance()
-	{
-		// Make sure we are working with a clean instance.
-		JLog::setInstance(null);
-
-		// Get an instance of the JLog class.
-		$log = JLog::getInstance();
-
-		// Verify that it is a JLog.
-		$this->assertTrue(($log instanceof JLog), 'Line: '.__LINE__);
 	}
 
 	/**


### PR DESCRIPTION
Most significant changes:
-oldstatic is reintroduced as a module cache option
-the support for legacy paths for plugins is removed
