### PR TITLE
Added JDatabaseDriver::disconnect() to support disconnecting from the database cleanly.

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -397,6 +397,15 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	abstract public function connected();
 
 	/**
+	 * Disconnects the database.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	abstract public function disconnect();
+
+	/**
 	 * Drops a table from the database.
 	 *
 	 * @param   string   $table     The name of the database table to drop.

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -74,6 +74,19 @@ class JDatabaseDriverMysql extends JDatabaseDriver
 	}
 
 	/**
+	 * Destructor.
+	 *
+	 * @since   12.1
+	 */
+	public function __destruct()
+	{
+		if (is_resource($this->connection))
+		{
+			mysql_close($this->connection);
+		}
+	}
+
+	/**
 	 * Connects to the database if needed.
 	 *
 	 * @return  void  Returns void if the database connected successfully.
@@ -114,16 +127,18 @@ class JDatabaseDriverMysql extends JDatabaseDriver
 	}
 
 	/**
-	 * Destructor.
+	 * Disconnects the database.
+	 *
+	 * @return  void
 	 *
 	 * @since   12.1
 	 */
-	public function __destruct()
+	public function disconnect()
 	{
-		if (is_resource($this->connection))
-		{
-			mysql_close($this->connection);
-		}
+		// Close the connection.
+		mysql_close($this->connection);
+
+		$this->connection = null;
 	}
 
 	/**
@@ -173,7 +188,7 @@ class JDatabaseDriverMysql extends JDatabaseDriver
 	{
 		if (is_resource($this->connection))
 		{
-			return mysql_ping($this->connection);
+			return @mysql_ping($this->connection);
 		}
 
 		return false;

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -50,6 +50,19 @@ class JDatabaseDriverMysqli extends JDatabaseDriverMysql
 	}
 
 	/**
+	 * Destructor.
+	 *
+	 * @since   12.1
+	 */
+	public function __destruct()
+	{
+		if (is_callable($this->connection, 'close'))
+		{
+			mysqli_close($this->connection);
+		}
+	}
+
+	/**
 	 * Connects to the database if needed.
 	 *
 	 * @return  void  Returns void if the database connected successfully.
@@ -121,16 +134,21 @@ class JDatabaseDriverMysqli extends JDatabaseDriverMysql
 	}
 
 	/**
-	 * Destructor.
+	 * Disconnects the database.
+	 *
+	 * @return  void
 	 *
 	 * @since   12.1
 	 */
-	public function __destruct()
+	public function disconnect()
 	{
+		// Close the connection.
 		if (is_callable($this->connection, 'close'))
 		{
 			mysqli_close($this->connection);
 		}
+
+		$this->connection = null;
 	}
 
 	/**

--- a/libraries/joomla/database/driver/oracle.php
+++ b/libraries/joomla/database/driver/oracle.php
@@ -64,6 +64,17 @@ class JDatabaseDriverOracle extends JDatabaseDriverPdo
 	}
 
 	/**
+	 * Destructor.
+	 *
+	 * @since   12.1
+	 */
+	public function __destruct()
+	{
+		$this->freeResult();
+		unset($this->connection);
+	}
+
+	/**
 	 * Connects to the database if needed.
 	 *
 	 * @return  void  Returns void if the database connected successfully.
@@ -84,12 +95,15 @@ class JDatabaseDriverOracle extends JDatabaseDriverPdo
 	}
 
 	/**
-	 * Destructor.
+	 * Disconnects the database.
+	 *
+	 * @return  void
 	 *
 	 * @since   12.1
 	 */
-	public function __destruct()
+	public function disconnect()
 	{
+		// Close the connection.
 		$this->freeResult();
 		unset($this->connection);
 	}

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -84,6 +84,17 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	}
 
 	/**
+	 * Destructor.
+	 *
+	 * @since   12.1
+	 */
+	public function __destruct()
+	{
+		$this->freeResult();
+		unset($this->connection);
+	}
+
+	/**
 	 * Connects to the database if needed.
 	 *
 	 * @return  void  Returns void if the database connected successfully.
@@ -290,11 +301,13 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	}
 
 	/**
-	 * Destructor.
+	 * Disconnects the database.
+	 *
+	 * @return  void
 	 *
 	 * @since   12.1
 	 */
-	public function __destruct()
+	public function disconnect()
 	{
 		$this->freeResult();
 		unset($this->connection);

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -78,6 +78,19 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	}
 
 	/**
+	 * Database object destructor
+	 *
+	 * @since 12.1
+	 */
+	public function __destruct()
+	{
+		if (is_resource($this->connection))
+		{
+			pg_close($this->connection);
+		}
+	}
+
+	/**
 	 * Connects to the database if needed.
 	 *
 	 * @return  void  Returns void if the database connected successfully.
@@ -112,16 +125,21 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	}
 
 	/**
-	 * Database object destructor
+	 * Disconnects the database.
 	 *
-	 * @since 12.1
+	 * @return  void
+	 *
+	 * @since   12.1
 	 */
-	public function __destruct()
+	public function disconnect()
 	{
+		// Close the connection.
 		if (is_resource($this->connection))
 		{
 			pg_close($this->connection);
 		}
+
+		$this->connection = null;
 	}
 
 	/**

--- a/libraries/joomla/database/driver/sqlite.php
+++ b/libraries/joomla/database/driver/sqlite.php
@@ -63,6 +63,19 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 	}
 
 	/**
+	 * Disconnects the database.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function disconnect()
+	{
+		$this->freeResult();
+		unset($this->connection);
+	}
+
+	/**
 	 * Drops a table from the database.
 	 *
 	 * @param   string   $tableName  The name of the database table to drop.

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -86,6 +86,19 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	}
 
 	/**
+	 * Destructor.
+	 *
+	 * @since   12.1
+	 */
+	public function __destruct()
+	{
+		if (is_resource($this->connection))
+		{
+			sqlsrv_close($this->connection);
+		}
+	}
+
+	/**
 	 * Connects to the database if needed.
 	 *
 	 * @return  void  Returns void if the database connected successfully.
@@ -131,16 +144,21 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	}
 
 	/**
-	 * Destructor.
+	 * Disconnects the database.
+	 *
+	 * @return  void
 	 *
 	 * @since   12.1
 	 */
-	public function __destruct()
+	public function disconnect()
 	{
+		// Close the connection.
 		if (is_resource($this->connection))
 		{
 			sqlsrv_close($this->connection);
 		}
+
+		$this->connection = null;
 	}
 
 	/**

--- a/tests/core/mock/database/driver.php
+++ b/tests/core/mock/database/driver.php
@@ -37,6 +37,7 @@ class TestMockDatabaseDriver
 		$methods = array(
 			'connect',
 			'connected',
+			'disconnect',
 			'dropTable',
 			'escape',
 			'execute',

--- a/tests/suites/unit/joomla/database/stubs/nosqldriver.php
+++ b/tests/suites/unit/joomla/database/stubs/nosqldriver.php
@@ -63,29 +63,29 @@ class JDatabaseDriverNosql extends JDatabaseDriver
 		return true;
 	}
 
-
 	/**
-
 	 * Determines if the connection to the server is active.
-
 	 *
-
 	 * @return  boolean  True if connected to the database engine.
-
 	 *
-
 	 * @since   11.4
-
 	 */
-
 	public function connected()
-
 	{
-
 		return true;
-
 	}
 
+	/**
+	 * Disconnects the database.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.1
+	 */
+	public function disconnect()
+	{
+		return;
+	}
 
 	/**
 	 * Drops a table from the database.


### PR DESCRIPTION
This is useful when building applications with JApplicationDaemon because the database resource that gets copied after forking is shared between parent and child and if either of the processes close the connect, it is closed for both. With this, you can use the onFork event to disconnect and reconnect the database to get a new, unshared resource.
