### PR TITLE
Use JPATH_THEMES constant to set themes directory in JApplicationWeb::render()

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -320,7 +320,7 @@ class JApplicationWeb extends JApplicationBase
 		// Fall back to constants.
 		else
 		{
-			$options['directory'] = (defined('JPATH_BASE') ? JPATH_BASE : __DIR__) . '/themes';
+			$options['directory'] = defined('JPATH_THEMES') ? JPATH_THEMES : (defined('JPATH_BASE') ? JPATH_BASE : __DIR__) . '/themes';
 		}
 
 		// Parse the document.


### PR DESCRIPTION
The `JPATH_THEMES` constant is set in the CMS, unit tests, and in some of the example apps I've seen to define the path where themes (templates) are located.  Instead of checking for a hard-coded themes folder under `JPATH_BASE`, this allows the themes directory to be set to this constant (which, for example, allows the CMS to continue using the "templates" directory if so desired when the applications are refactored) and retains the current fallback of `__DIR__ . '/themes'`
