### PR TITLE
Fix PHP error: Access to undeclared static property

### DIFF
--- a/libraries/legacy/component/helper.php
+++ b/libraries/legacy/component/helper.php
@@ -24,7 +24,7 @@ class JComponentHelper
 	 * @var    array
 	 * @since  11.1
 	 */
-	protected static $_components = array();
+	protected static $components = array();
 
 	/**
 	 * Get the component information.
@@ -365,7 +365,7 @@ class JComponentHelper
 	}
 
 	/**
-	 * Load the installed components into the _components property.
+	 * Load the installed components into the components property.
 	 *
 	 * @param   string  $option  The element value for the extension
 	 *


### PR DESCRIPTION
With the current Platform, JComponentHelper is unusable due to the `$_components` property being declared with the underscore, but all uses within the class do not use the underscore.  This makes it usable again.
