### PR TITLE
Passing input array by reference

### DIFF
--- a/libraries/joomla/input/input.php
+++ b/libraries/joomla/input/input.php
@@ -68,7 +68,7 @@ class JInput implements Serializable
 	/**
 	 * Constructor.
 	 *
-	 * @param   array  $source   Source data (Optional, default is $_REQUEST)
+	 * @param   array  &$source  Source data (Optional, default is $_REQUEST)
 	 * @param   array  $options  Array of configuration parameters (Optional)
 	 *
 	 * @since   11.1

--- a/libraries/joomla/input/input.php
+++ b/libraries/joomla/input/input.php
@@ -73,7 +73,7 @@ class JInput implements Serializable
 	 *
 	 * @since   11.1
 	 */
-	public function __construct($source = null, array $options = array())
+	public function __construct(&$source = null, array $options = array())
 	{
 		if (isset($options['filter']))
 		{

--- a/tests/suites/unit/joomla/input/JInputTest.php
+++ b/tests/suites/unit/joomla/input/JInputTest.php
@@ -58,6 +58,23 @@ class JInputTest extends PHPUnit_Framework_TestCase
 	 */
 	public function test__get()
 	{
+		$_POST['foo'] = 'bar';
+		
+		// Test the get method.
+		$this->assertThat(
+			$this->class->post->get('foo'),
+			$this->equalTo('bar'),
+			'Line: '.__LINE__.'.'
+		);
+
+		// Test the set method.
+		$this->class->post->set('foo', 'notbar');
+		$this->assertThat(
+			$_POST['foo'],
+			$this->equalTo('notbar'),
+			'Line: '.__LINE__.'.'
+		);
+
 		$this->markTestIncomplete();
 	}
 
@@ -155,12 +172,13 @@ class JInputTest extends PHPUnit_Framework_TestCase
 	{
 		$filterMock = new JFilterInputMockTracker();
 
+		$array = array(
+			'var1' => 'value1',
+			'var2' => 34,
+			'var3' => array('test')
+		);
 		$input = new JInput(
-			array(
-				'var1' => 'value1',
-				'var2' => 34,
-				'var3' => array('test')
-			),
+			$array,
 			array('filter' => $filterMock)
 		);
 
@@ -202,12 +220,13 @@ class JInputTest extends PHPUnit_Framework_TestCase
 	{
 		$filterMock = new JFilterInputMockTracker();
 
+		$array = array(
+			'var2' => 34,
+			'var3' => array('var2' => 'test'),
+			'var4' => array('var1' => array('var2' => 'test'))
+		);
 		$input = new JInput(
-			array(
-				'var2' => 34,
-				'var3' => array('var2' => 'test'),
-				'var4' => array('var1' => array('var2' => 'test'))
-			),
+			$array,
 			array('filter' => $filterMock)
 		);
 
@@ -343,6 +362,7 @@ class JInputTest extends PHPUnit_Framework_TestCase
 		include_once __DIR__ . '/stubs/JFilterInputMock.php';
 		include_once __DIR__ . '/stubs/JFilterInputMockTracker.php';
 
-		$this->class = new JInputInspector(null, array('filter' => new JFilterInputMock()));
+		$array = null;
+		$this->class = new JInputInspector($array, array('filter' => new JFilterInputMock()));
 	}
 }


### PR DESCRIPTION
The JInput constructor is not receiving its argument by reference. This is causing unexpected behevior:

```
JFactory::getApplication()->input->set('foo', 'bar');
```

This will set $_REQUEST['foo'] equal to 'bar' (because of https://github.com/joomla/joomla-platform/blob/staging/libraries/joomla/input/input.php#L89: var is set by ref)

```
JFactory::getApplication()->input->post->set('foo', 'bar');
```

This will _not_ set $_POST['foo'] equal to 'bar' (because of https://github.com/joomla/joomla-platform/blob/staging/libraries/joomla/input/input.php#L76, arg is not received by ref)
