### PR TITLE
Allow JApplicationWeb::render() to receive params for a theme

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -310,7 +310,7 @@ class JApplicationWeb extends JApplicationBase
 		$options = array(
 			'template' => $this->get('theme'),
 			'file' => 'index.php',
-			'params' => ''
+			'params' => $this->get('themeParams')
 		);
 
 		if ($this->get('themes.base'))


### PR DESCRIPTION
Similar to `JApplication::render()` and the CMS's application classes, this sets the params for a theme if they are set in the configuration.
