### PR TITLE
Reverting 1201

### DIFF
--- a/libraries/joomla/input/input.php
+++ b/libraries/joomla/input/input.php
@@ -68,12 +68,12 @@ class JInput implements Serializable
 	/**
 	 * Constructor.
 	 *
-	 * @param   array  &$source  Source data (Optional, default is $_REQUEST)
+	 * @param   array  $source   Source data (Optional, default is $_REQUEST)
 	 * @param   array  $options  Array of configuration parameters (Optional)
 	 *
 	 * @since   11.1
 	 */
-	public function __construct(&$source = null, array $options = array())
+	public function __construct($source = null, array $options = array())
 	{
 		if (isset($options['filter']))
 		{
@@ -86,11 +86,11 @@ class JInput implements Serializable
 
 		if (is_null($source))
 		{
-			$this->data = & $_REQUEST;
+			$this->data = &$_REQUEST;
 		}
 		else
 		{
-			$this->data = & $source;
+			$this->data = $source;
 		}
 
 		// Set the options for the class.

--- a/tests/suites/unit/joomla/input/JInputTest.php
+++ b/tests/suites/unit/joomla/input/JInputTest.php
@@ -59,7 +59,7 @@ class JInputTest extends PHPUnit_Framework_TestCase
 	public function test__get()
 	{
 		$_POST['foo'] = 'bar';
-		
+
 		// Test the get method.
 		$this->assertThat(
 			$this->class->post->get('foo'),
@@ -71,7 +71,7 @@ class JInputTest extends PHPUnit_Framework_TestCase
 		$this->class->post->set('foo', 'notbar');
 		$this->assertThat(
 			$_POST['foo'],
-			$this->equalTo('notbar'),
+			$this->equalTo('bar'),
 			'Line: '.__LINE__.'.'
 		);
 


### PR DESCRIPTION
This pull is to revert the changes in 1201.  For some reason it has changed the way internal data persist (made some independent tests fail).  But looking at it, I actually think we should go further and not allow JInput to modify the source input (for example, it should get a copy of $_REQUEST, not a reference so that that input variable can make changes without affecting the rest of the application).
