### PR TITLE
Allow JArrayHelper::getColumn process associative array (of arrays/ objects)

### DIFF
--- a/libraries/joomla/utilities/arrayhelper.php
+++ b/libraries/joomla/utilities/arrayhelper.php
@@ -242,12 +242,8 @@ class JArrayHelper
 
 		if (is_array($array))
 		{
-			$n = count($array);
-
-			for ($i = 0; $i < $n; $i++)
+			foreach ($array as $key => &$item)
 			{
-				$item = &$array[$i];
-
 				if (is_array($item) && isset($item[$index]))
 				{
 					$result[] = $item[$index];


### PR DESCRIPTION
At the moment JArrayHelper::getColumn doesn't work on non-associative arrays.
No idea why `for` loop has been used instead of `foreach`..
