### PR TITLE
Curl request() encodes $data regardless the Content-type header.

### DIFF
--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -74,7 +74,7 @@ class JHttpTransportCurl implements JHttpTransport
 		if (isset($data))
 		{
 			// If the data is a scalar value simply add it to the cURL post fields.
-			if (is_scalar($data) || (isset($headers['Content-type']) && $headers['Content-type'] == 'multipart/form-data'))
+			if (is_scalar($data) || (isset($headers['Content-type']) && strpos($headers['Content-type'], 'multipart/form-data') === 0))
 			{
 				$options[CURLOPT_POSTFIELDS] = $data;
 			}

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -74,7 +74,7 @@ class JHttpTransportCurl implements JHttpTransport
 		if (isset($data))
 		{
 			// If the data is a scalar value simply add it to the cURL post fields.
-			if (is_scalar($data) || (!isset($headers['Content-type']) && $headers['Content-type'] == 'multipart/form-data'))
+			if (is_scalar($data) || (isset($headers['Content-type']) && $headers['Content-type'] == 'multipart/form-data'))
 			{
 				$options[CURLOPT_POSTFIELDS] = $data;
 			}

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -74,7 +74,7 @@ class JHttpTransportCurl implements JHttpTransport
 		if (isset($data))
 		{
 			// If the data is a scalar value simply add it to the cURL post fields.
-			if (is_scalar($data))
+			if (is_scalar($data) || (!isset($headers['Content-type']) && $headers['Content-type'] == 'multipart/form-data'))
 			{
 				$options[CURLOPT_POSTFIELDS] = $data;
 			}
@@ -89,7 +89,10 @@ class JHttpTransportCurl implements JHttpTransport
 				$headers['Content-type'] = 'application/x-www-form-urlencoded';
 			}
 
-			$headers['Content-length'] = strlen($options[CURLOPT_POSTFIELDS]);
+			if (is_scalar($options[CURLOPT_POSTFIELDS]))
+			{
+				$headers['Content-length'] = strlen($options[CURLOPT_POSTFIELDS]);
+			}
 		}
 
 		// Build the headers string for the request.


### PR DESCRIPTION
To post a file using curl the '@' prefix must be used with the file's full path. As of PHP 5.2.0, the CURLOPT_POSTFIELDS option must be an array if this prefix is used. That means the $data parameter of the request() method must not be encoded if the Content-type header is multipart/form-data.
