### PR TITLE
Let JFactory::getXML() opt to receive a SimpleXMLElement.

### DIFF
--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -496,7 +496,7 @@ class JAccess
 		else
 		{
 			// Else return the actions from the xml.
-			return self::getActionsFromData(JFactory::getXML($file, true), $xpath);
+			return self::getActionsFromData(JFactory::getXML($file, true, false), $xpath);
 		}
 	}
 
@@ -521,7 +521,7 @@ class JAccess
 		// Attempt to load the XML if a string.
 		if (is_string($data))
 		{
-			$data = JFactory::getXML($data, false);
+			$data = JFactory::getXML($data, false, false);
 
 			// Make sure the XML loaded correctly.
 			if (!$data)

--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -372,19 +372,28 @@ abstract class JFactory
 	/**
 	 * Reads a XML file.
 	 *
-	 * @param   string   $data    Full path and file name.
-	 * @param   boolean  $isFile  true to load a file or false to load a string.
+	 * @param   string   $data       Full path and file name.
+	 * @param   boolean  $isFile     true to load a file or false to load a string.
+	 * @param   boolean  $jxmlement  true to load a JXMLElement otherwise loads as SimpleXMLElement.
 	 *
-	 * @return  mixed    JXMLElement on success or false on error.
+	 * @return  mixed    JXMLElement or SimpleXMLElement on success or false on error.
 	 *
 	 * @see     JXMLElement
 	 * @since   11.1
 	 * @note    This method will return SimpleXMLElement object in the future. Do not rely on JXMLElement's methods.
 	 * @todo    This may go in a separate class - error reporting may be improved.
 	 */
-	public static function getXML($data, $isFile = true)
+	public static function getXML($data, $isFile = true, $jxmlement = true)
 	{
-		jimport('joomla.utilities.xmlelement');
+		if ($jxmlement)
+		{
+			jimport('joomla.utilities.xmlelement');
+			$class = 'JXMLElement';
+		}
+		else
+		{
+			$class = 'SimpleXMLElement';
+		}
 
 		// Disable libxml errors and allow to fetch error information as needed
 		libxml_use_internal_errors(true);
@@ -392,12 +401,12 @@ abstract class JFactory
 		if ($isFile)
 		{
 			// Try to load the XML file
-			$xml = simplexml_load_file($data, 'JXMLElement');
+			$xml = simplexml_load_file($data, $class);
 		}
 		else
 		{
 			// Try to load the XML string
-			$xml = simplexml_load_string($data, 'JXMLElement');
+			$xml = simplexml_load_string($data, $class);
 		}
 
 		if (empty($xml))
@@ -415,6 +424,7 @@ abstract class JFactory
 			}
 		}
 
+		libxml_clear_errors();
 		return $xml;
 	}
 

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -1305,7 +1305,7 @@ class JLanguage extends JObject
 	public static function parseXMLLanguageFile($path)
 	{
 		// Try to load the file
-		if (!$xml = JFactory::getXML($path))
+		if (!$xml = JFactory::getXML($path, true, false))
 		{
 			return null;
 		}

--- a/libraries/joomla/utilities/xmlelement.php
+++ b/libraries/joomla/utilities/xmlelement.php
@@ -29,7 +29,7 @@ class JXMLElement extends SimpleXMLElement
 	 */
 	public function name()
 	{
-		JLog::add('JXMLElement::name() is deprecated, use SimpleXMLElement::getName() instead.', JLog::WARNING, 'deprecated');
+		JLog::add('JXMLElement::name() is deprecated. Use SimpleXMLElement::getName() instead.', JLog::WARNING, 'deprecated');
 		return (string) $this->getName();
 	}
 
@@ -47,7 +47,7 @@ class JXMLElement extends SimpleXMLElement
 	 */
 	public function asFormattedXML($compressed = false, $indent = "\t", $level = 0)
 	{
-		JLog::add('JXMLElement::asFormattedXML() is deprecated, use SimpleXMLElement::asXML() instead.', JLog::WARNING, 'deprecated');
+		JLog::add('JXMLElement::asFormattedXML() is deprecated. Use SimpleXMLElement::asXML() instead.', JLog::WARNING, 'deprecated');
 		$out = '';
 
 		// Start a new line, indent by the number indicated in $level

--- a/libraries/legacy/application/helper.php
+++ b/libraries/legacy/application/helper.php
@@ -187,7 +187,7 @@ class JApplicationHelper
 	public static function parseXMLLangMetaFile($path)
 	{
 		// Read the file to see if it's a valid component XML file
-		$xml = JFactory::getXML($path);
+		$xml = JFactory::getXML($path, true, false);
 
 		if (!$xml)
 		{

--- a/libraries/legacy/help/help.php
+++ b/libraries/legacy/help/help.php
@@ -181,7 +181,7 @@ class JHelp
 
 		if (!empty($pathToXml))
 		{
-			$xml = JFactory::getXML($pathToXml);
+			$xml = JFactory::getXML($pathToXml, true, false);
 		}
 
 		if (!$xml)


### PR DESCRIPTION
This adds a deprecated log message to the constructor of JXMLElement and to reduce the number of times this is actually output prevents loading it all the time. I'm not sure whether we shouldn't default to load SimpleXMLElement instead of JXMLElement. For now I opted for the safer option but I'd like to hear what others think.
