### PR TITLE
Modified JFactory::getApplication to allow instanciating web or cli applications

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -82,6 +82,7 @@ abstract class JFactory
 	 * Returns the global {@link JApplication} object, only creating it if it doesn't already exist.
 	 *
 	 * @param   mixed   $id      A client identifier or name.
+	 * @param   string  $type    Application type : Web or Cli
 	 * @param   array   $config  An optional associative array of configuration settings.
 	 * @param   string  $prefix  Application prefix
 	 *
@@ -91,7 +92,7 @@ abstract class JFactory
 	 * @since   11.1
 	 * @throws  Exception
 	 */
-	public static function getApplication($id = null, array $config = array(), $prefix = 'J')
+	public static function getApplication($id = null, $type = null, array $config = array(), $prefix = 'J')
 	{
 		if (!self::$application)
 		{
@@ -100,7 +101,26 @@ abstract class JFactory
 				throw new Exception('Application Instantiation Error', 500);
 			}
 
-			self::$application = JApplication::getInstance($id, $config, $prefix);
+			if (!$type)
+			{
+				self::$application = JApplication::getInstance($id, $config, $prefix);
+			}
+
+			else
+			{
+				$type = strtolower($type);
+
+				if ($type === 'web' || $type === 'cli')
+				{
+					$classname = 'JApplication' . ucfirst($type);
+					self::$application = $classname::getInstance($id);
+				}
+
+				else
+				{
+					throw new Exception('Application Instantiation Error : Unknown Application type ' . $type, 500);
+				}
+			}
 		}
 
 		return self::$application;

--- a/tests/suites/unit/joomla/JFactoryTest.php
+++ b/tests/suites/unit/joomla/JFactoryTest.php
@@ -49,20 +49,73 @@ class JFactoryTest extends TestCase
 	}
 
 	/**
-	 * Tests the JFactory::getApplicatiom method.
+	 * Tests the JFactory::getApplication method.
 	 *
 	 * @return  void
 	 *
 	 * @since   12.1
-	 * @covers  JFactory::getApplicatiom
-	 * @todo    Implement testGetApplication().
+	 * @covers  JFactory::getApplication
 	 */
-	function testGetApplication()
+	public function testGetApplication()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete(
-				'This test has not been implemented yet.'
-		);
+		if (empty($_SERVER['HTTP_HOST']))
+		{
+			$_SERVER['HTTP_HOST'] = 'localhost';
+		}
+
+		$temp = JFactory::$application;
+
+		// Test without param
+		JFactory::$application = TestMockApplicationWeb::create($this);
+		$this->assertInstanceOf('JApplicationWeb', JFactory::getApplication());
+
+		// Test the exception with a non specified application
+		JFactory::$application = null;
+		$catched = false;
+		try
+		{
+			JFactory::getApplication();
+		}
+
+		catch (Exception $e)
+		{
+			$catched = true;
+		}
+
+		$this->assertTrue($catched);
+
+		// Test JApplication (CMS only)
+		if (class_exists('JApplication'))
+		{
+			JFactory::$application = null;
+			$this->assertInstanceOf('JApplication', JFactory::getApplication('site'));
+		}
+
+		// Test JApplicationWeb
+		JFactory::$application = null;
+		$this->assertInstanceOf('JApplicationWeb', JFactory::getApplication('test', 'web'));
+
+		// Test JApplicationCli
+		JFactory::$application = null;
+		$this->assertInstanceOf('JApplicationCli', JFactory::getApplication('test', 'cli'));
+
+		// Test the exception with a non existing Application type
+		$catched = false;
+		JFactory::$application = null;
+
+		try
+		{
+			JFactory::getApplication('test', 'nonexisting');
+		}
+
+		catch (Exception $e)
+		{
+			$catched = true;
+		}
+
+		$this->assertTrue($catched);
+
+		JFactory::$application = $temp;
 	}
 
 	/**
@@ -111,7 +164,7 @@ class JFactoryTest extends TestCase
 				'This test has not been implemented completely yet.'
 		);
 	}
-	
+
 	/**
 	 * Tests the JFactory::getDocument method.
 	 *

--- a/tests/suites/unit/joomla/JFactoryTest.php
+++ b/tests/suites/unit/joomla/JFactoryTest.php
@@ -71,7 +71,7 @@ class JFactoryTest extends TestCase
 
 		// Test the exception with a non specified application
 		JFactory::$application = null;
-		$catched = false;
+		$caught = false;
 		try
 		{
 			JFactory::getApplication();
@@ -79,10 +79,10 @@ class JFactoryTest extends TestCase
 
 		catch (Exception $e)
 		{
-			$catched = true;
+			$caught = true;
 		}
 
-		$this->assertTrue($catched);
+		$this->assertTrue($caught);
 
 		// Test JApplication (CMS only)
 		if (class_exists('JApplication'))
@@ -100,7 +100,7 @@ class JFactoryTest extends TestCase
 		$this->assertInstanceOf('JApplicationCli', JFactory::getApplication('test', 'cli'));
 
 		// Test the exception with a non existing Application type
-		$catched = false;
+		$caught = false;
 		JFactory::$application = null;
 
 		try
@@ -110,10 +110,10 @@ class JFactoryTest extends TestCase
 
 		catch (Exception $e)
 		{
-			$catched = true;
+			$caught = true;
 		}
 
-		$this->assertTrue($catched);
+		$this->assertTrue($caught);
 
 		JFactory::$application = $temp;
 	}

--- a/tests/suites/unit/joomla/JFactoryTest.php
+++ b/tests/suites/unit/joomla/JFactoryTest.php
@@ -66,8 +66,8 @@ class JFactoryTest extends TestCase
 		$temp = JFactory::$application;
 
 		// Test without param
-		JFactory::$application = TestMockApplicationWeb::create($this);
-		$this->assertInstanceOf('JApplicationWeb', JFactory::getApplication());
+		JFactory::$application = 'test';
+		$this->assertEquals('test', JFactory::getApplication());
 
 		// Test the exception with a non specified application
 		JFactory::$application = null;
@@ -93,11 +93,13 @@ class JFactoryTest extends TestCase
 
 		// Test JApplicationWeb
 		JFactory::$application = null;
-		$this->assertInstanceOf('JApplicationWeb', JFactory::getApplication('test', 'web'));
+		$this->assertEquals('JApplicationWeb', JFactory::getApplication('test', 'web'));
+		TestReflection::setValue('JApplicationWeb', 'instance', null);
 
 		// Test JApplicationCli
 		JFactory::$application = null;
 		$this->assertInstanceOf('JApplicationCli', JFactory::getApplication('test', 'cli'));
+		TestReflection::setValue('JApplicationCli', 'instance', null);
 
 		// Test the exception with a non existing Application type
 		$caught = false;

--- a/tests/suites/unit/joomla/JFactoryTest.php
+++ b/tests/suites/unit/joomla/JFactoryTest.php
@@ -93,7 +93,7 @@ class JFactoryTest extends TestCase
 
 		// Test JApplicationWeb
 		JFactory::$application = null;
-		$this->assertEquals('JApplicationWeb', JFactory::getApplication('test', 'web'));
+		$this->assertInstanceOf('JApplicationWeb', JFactory::getApplication('test', 'web'));
 		TestReflection::setValue('JApplicationWeb', 'instance', null);
 
 		// Test JApplicationCli


### PR DESCRIPTION
We could now use :

JFactory::getApplication('MyWebApp', 'web')
JFactory::getApplication('MyCliApp', 'cli')

to load the Application object in the Factory, instead of 
JFactory::$application = JApplicationWeb::getInstance('MyWebApp');
