### PR TITLE
Use the PHP 5.3 const syntax where possible.

### DIFF
--- a/libraries/joomla/application/router.php
+++ b/libraries/joomla/application/router.php
@@ -12,8 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Set the available masks for the routing mode
  */
-define('JROUTER_MODE_RAW', 0);
-define('JROUTER_MODE_SEF', 1);
+const JROUTER_MODE_RAW = 0;
+const JROUTER_MODE_SEF = 1;
 
 /**
  * Class to create and parse routes

--- a/libraries/legacy/error/error.php
+++ b/libraries/legacy/error/error.php
@@ -10,13 +10,13 @@
 defined('JPATH_PLATFORM') or die;
 
 // Error Definition: Illegal Options
-define('JERROR_ILLEGAL_OPTIONS', 1);
+const JERROR_ILLEGAL_OPTIONS = 1;
 
 // Error Definition: Callback does not exist
-define('JERROR_CALLBACK_NOT_CALLABLE', 2);
+const JERROR_CALLBACK_NOT_CALLABLE = 2;
 
 // Error Definition: Illegal Handler
-define('JERROR_ILLEGAL_MODE', 3);
+const JERROR_ILLEGAL_MODE = 3
 
 /**
  * Error Handling Class

--- a/libraries/legacy/request/request.php
+++ b/libraries/legacy/request/request.php
@@ -17,9 +17,9 @@ $GLOBALS['_JREQUEST'] = array();
 /**
  * Set the available masks for cleaning variables
  */
-define('JREQUEST_NOTRIM', 1);
-define('JREQUEST_ALLOWRAW', 2);
-define('JREQUEST_ALLOWHTML', 4);
+const JREQUEST_NOTRIM    = 1;
+const JREQUEST_ALLOWRAW  = 2;
+const JREQUEST_ALLOWHTML = 4;
 
 JLog::add('JRequest is deprecated.', JLog::WARNING, 'deprecated');
 


### PR DESCRIPTION
This is mainly for consistency with class constants. Note that this only works for constants that are not conditional and that they take only a simple value and not the result of an expression. Since they are compile time instead of runtime based they get cached a bit more efficient with an opcode cache (negligible improvement thou)
