### PR TITLE
Running test on php 5.4

### DIFF
--- a/libraries/joomla/log/logger.php
+++ b/libraries/joomla/log/logger.php
@@ -75,7 +75,7 @@ abstract class JLogLogger
  * @since       11.1
  * @deprecated  13.3
  */
-class JLogger extends JLogLogger
+abstract class JLogger extends JLogLogger
 {
 	/**
 	 * Constructor.

--- a/tests/bootstrap.legacy.php
+++ b/tests/bootstrap.legacy.php
@@ -19,7 +19,7 @@ define('_JEXEC', 1);
 
 // Maximise error reporting.
 @ini_set('zend.ze1_compatibility_mode', '0');
-error_reporting(E_ALL);
+error_reporting(E_ALL & ~E_STRICT);
 ini_set('display_errors', 1);
 
 /*

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,7 +19,7 @@ define('_JEXEC', 1);
 
 // Maximise error reporting.
 @ini_set('zend.ze1_compatibility_mode', '0');
-error_reporting(E_ALL);
+error_reporting(E_ALL & ~E_STRICT);
 ini_set('display_errors', 1);
 
 /*

--- a/tests/suites/unit/joomla/application/JApplicationCliTest.php
+++ b/tests/suites/unit/joomla/application/JApplicationCliTest.php
@@ -95,7 +95,7 @@ class JApplicationCliTest extends TestCase
 				$this->returnValue('ok')
 			);
 
-		$mockConfig = $this->getMock('JRegistry', array('test'), array(), '', false);
+		$mockConfig = $this->getMock('JRegistry', array('test'), array(null), '', true);
 		$mockConfig
 			->expects($this->any())
 			->method('test')

--- a/tests/suites/unit/joomla/application/JApplicationWebTest.php
+++ b/tests/suites/unit/joomla/application/JApplicationWebTest.php
@@ -198,7 +198,7 @@ class JApplicationWebTest extends TestCase
 				$this->returnValue('ok')
 			);
 
-		$mockConfig = $this->getMock('JRegistry', array('test'), array(), '', false);
+		$mockConfig = $this->getMock('JRegistry', array('test'), array(null), '', true);
 		$mockConfig
 			->expects($this->any())
 			->method('test')
@@ -285,12 +285,12 @@ class JApplicationWebTest extends TestCase
 			'Checks the body array has been appended.'
 		);
 
-		$this->class->appendBody(array('goo'));
+		$this->class->appendBody(true);
 
 		$this->assertThat(
 			TestReflection::getValue($this->class, 'response')->body,
 			$this->equalTo(
-				array('foo', 'bar', 'Array')
+				array('foo', 'bar', '1')
 			),
 			'Checks that non-strings are converted to strings.'
 		);
@@ -1372,12 +1372,12 @@ class JApplicationWebTest extends TestCase
 			'Checks the body array has been prepended.'
 		);
 
-		$this->class->prependBody(array('goo'));
+		$this->class->prependBody(true);
 
 		$this->assertThat(
 			TestReflection::getValue($this->class, 'response')->body,
 			$this->equalTo(
-				array('Array', 'bar', 'foo')
+				array('1', 'bar', 'foo')
 			),
 			'Checks that non-strings are converted to strings.'
 		);
@@ -1738,12 +1738,12 @@ class JApplicationWebTest extends TestCase
 			'Checks the body array has been reset.'
 		);
 
-		$this->class->setBody(array('goo'));
+		$this->class->setBody(true);
 
 		$this->assertThat(
 			TestReflection::getValue($this->class, 'response')->body,
 			$this->equalTo(
-				array('Array')
+				array('1')
 			),
 			'Checks reset and that non-strings are converted to strings.'
 		);

--- a/tests/suites/unit/joomla/log/loggers/JLogLoggerDatabaseTest.php
+++ b/tests/suites/unit/joomla/log/loggers/JLogLoggerDatabaseTest.php
@@ -7,7 +7,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
-require_once JPATH_PLATFORM.'/joomla/log/loggers/database.php';
 require_once __DIR__.'/stubs/database/inspector.php';
 
 /**

--- a/tests/suites/unit/joomla/log/loggers/JLogLoggerEchoTest.php
+++ b/tests/suites/unit/joomla/log/loggers/JLogLoggerEchoTest.php
@@ -7,8 +7,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
-require_once JPATH_PLATFORM.'/joomla/log/loggers/echo.php';
-
 /**
  * Test class for JLogLoggerEcho.
  */

--- a/tests/suites/unit/joomla/log/loggers/JLogLoggerFormattedTextTest.php
+++ b/tests/suites/unit/joomla/log/loggers/JLogLoggerFormattedTextTest.php
@@ -7,7 +7,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
-require_once JPATH_PLATFORM.'/joomla/log/loggers/formattedtext.php';
 require_once __DIR__.'/stubs/formattedtext/inspector.php';
 
 /**

--- a/tests/suites/unit/joomla/log/loggers/JLogLoggerMessageQueueTest.php
+++ b/tests/suites/unit/joomla/log/loggers/JLogLoggerMessageQueueTest.php
@@ -7,7 +7,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
-require_once JPATH_PLATFORM.'/joomla/log/loggers/messagequeue.php';
 require_once __DIR__.'/stubs/messagequeue/mock.application.php';
 
 /**
@@ -51,7 +50,7 @@ class JLogLoggerMessageQueueTest extends PHPUnit_Framework_TestCase
 		$config = array();
 
 		// Get an instance of the logger.
-		$logger = new JLogLoggerMessageQueue($config);
+		$logger = new JLogLoggerMessagequeue($config);
 
 		// Add a basic error message, it ignores the category.
 		$logger->addEntry(new JLogEntry('TESTING', JLog::ERROR, 'DePrEcAtEd'));

--- a/tests/suites/unit/joomla/log/loggers/JLogLoggerSyslogTest.php
+++ b/tests/suites/unit/joomla/log/loggers/JLogLoggerSyslogTest.php
@@ -7,8 +7,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
-require_once JPATH_PLATFORM.'/joomla/log/loggers/syslog.php';
-
 /**
  * Test class for JLogLoggerSysLog.
  */

--- a/tests/suites/unit/joomla/log/loggers/JLogLoggerW3CTest.php
+++ b/tests/suites/unit/joomla/log/loggers/JLogLoggerW3CTest.php
@@ -7,7 +7,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
-require_once JPATH_PLATFORM.'/joomla/log/loggers/w3c.php';
 require_once __DIR__.'/stubs/w3c/inspector.php';
 
 /**

--- a/tests/suites/unit/joomla/log/loggers/stubs/formattedtext/inspector.php
+++ b/tests/suites/unit/joomla/log/loggers/stubs/formattedtext/inspector.php
@@ -15,7 +15,7 @@
  * @package		Joomla.UnitTest
  * @subpackage  Log
  */
-class JLogLoggerFormattedTextInspector extends JLogLoggerFormattedText
+class JLogLoggerFormattedTextInspector extends JLogLoggerFormattedtext
 {
 	public $file;
 	public $format = '{DATETIME}	{PRIORITY}	{CATEGORY}	{MESSAGE}';

--- a/tests/suites/unit/joomla/log/loggers/stubs/w3c/inspector.php
+++ b/tests/suites/unit/joomla/log/loggers/stubs/w3c/inspector.php
@@ -15,7 +15,7 @@
  * @package		Joomla.UnitTest
  * @subpackage  Log
  */
-class JLogLoggerW3CInspector extends JLogLoggerW3C
+class JLogLoggerW3CInspector extends JLogLoggerW3c
 {
 	public $file;
 	public $format = '{DATE}	{TIME}	{PRIORITY}	{CLIENTIP}	{CATEGORY}	{MESSAGE}';


### PR DESCRIPTION
PHP 5.4 is not running test successfully:
- E_STRICT became part of E_ALL (in PHP 5.4)
- converting an array to a string now generates a notice
- a class containing an abstract method must be abstract

and some others issues
