### PR TITLE
Correct response code for creating forks

### DIFF
--- a/libraries/joomla/github/forks.php
+++ b/libraries/joomla/github/forks.php
@@ -10,7 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 /**
- * GitHub API References class for the Joomla Platform.
+ * GitHub API Forks class for the Joomla Platform.
  *
  * @package     Joomla.Platform
  * @subpackage  GitHub
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die;
 class JGithubForks extends JGithubObject
 {
 	/**
-	 * Method to create an issue.
+	 * Method to fork a repository.
 	 *
 	 * @param   string  $user  The name of the owner of the GitHub repository.
 	 * @param   string  $repo  The name of the GitHub repository.
@@ -28,6 +28,7 @@ class JGithubForks extends JGithubObject
 	 * @return  object
 	 *
 	 * @since   11.4
+	 * @throws  DomainException
 	 */
 	public function create($user, $repo, $org = '')
 	{
@@ -49,7 +50,7 @@ class JGithubForks extends JGithubObject
 		$response = $this->client->post($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 201)
+		if ($response->code != 202)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -70,6 +71,7 @@ class JGithubForks extends JGithubObject
 	 * @return  array
 	 *
 	 * @since   11.4
+	 * @throws  DomainException
 	 */
 	public function getList($user, $repo, $page = 0, $limit = 0)
 	{

--- a/tests/suites/unit/joomla/github/JGithubForksTest.php
+++ b/tests/suites/unit/joomla/github/JGithubForksTest.php
@@ -66,7 +66,7 @@ class JGithubForksTest extends PHPUnit_Framework_TestCase
 	public function testCreate()
 	{
 		$returnData = new stdClass;
-		$returnData->code = 201;
+		$returnData->code = 202;
 		$returnData->body = $this->sampleString;
 
 		// Build the request data.


### PR DESCRIPTION
The GitHub API sends a 202 response on successful completion of forking a repo, not a 201.  This fixes that as well as a few docblock lines in the class.
