### PR TITLE
Fix an issue with providing a zero ID to JUser::getInstance

### DIFF
--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -236,6 +236,14 @@ class JUser extends JObject
 			$id = $identifier;
 		}
 
+		// If the $id is zero, just return an empty JUser.
+		// Note: don't cache this user because it'll have a new ID on save!
+		if ($id === 0)
+		{
+			return new JUser;
+		}
+
+		// Check if the user ID is already cached.
 		if (empty(self::$instances[$id]))
 		{
 			$user = new JUser($id);


### PR DESCRIPTION
This pull request resolves an edge case where two requests to JUser::getInstance (and by extension JFactory::getUser) would return a user with a different ID. When called with a user ID of 0, a user object is created and cached in JUser::getInstance and then returned. If this JUser object is then persisted to the database, it is updated to have it's new user ID. However if another call to JUser::getInstance is made for a user ID of zero again, the existing object with it's new user ID will be returned.

This resolves the situation by ensuring that when the ID is zero that a new JUser object is returned and not cached.
