### PR TITLE
Changed PostgreSQL's minimum version.

### DIFF
--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -43,7 +43,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	 * @var    string  The minimum supported database version.
 	 * @since  12.1
 	 */
-	protected static $dbMinimum = '9.1.2';
+	protected static $dbMinimum = '8.3.18';
 
 	/**
 	 * Operator used for concatenation

--- a/tests/suites/database/driver/postgresql/JDatabasePostgresqlTest.php
+++ b/tests/suites/database/driver/postgresql/JDatabasePostgresqlTest.php
@@ -553,7 +553,10 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function testInsertObject()
 	{
-		self::$driver->setQuery('TRUNCATE TABLE "jos_dbtest" RESTART IDENTITY');
+		self::$driver->setQuery('ALTER SEQUENCE jos_dbtest_id_seq RESTART WITH 1');
+		$result = self::$driver->execute();
+
+		self::$driver->setQuery('TRUNCATE TABLE "jos_dbtest"');
 		$result = self::$driver->execute();
 
 		$tst = new JObject;


### PR DESCRIPTION
This pull only contains change of minimum required version of PostgreSQL database.

Test class was run and returns same result under these PostgreSQL's versions:
- 8.3.18
- 8.4.11
- 9.0.7
- 9.1.3

This pull includes a change inside "insertObject" test because 8.3 version doesn't support 'RESTART IDENTITY' clause, so switched to old-style sequence restart.
