### PR TITLE
Fixes for Oracle driver, Oracle query and PDO driver

### DIFF
--- a/libraries/joomla/database/query/oracle.php
+++ b/libraries/joomla/database/query/oracle.php
@@ -150,14 +150,31 @@ class JDatabaseQueryOracle extends JDatabaseQueryPdo implements JDatabaseQueryPr
 	 */
 	public function processLimit($query, $limit, $offset = 0)
 	{
-		$query = "SELECT joomla2.*
-	              FROM (
-	                  SELECT joomla1.*, ROWNUM AS joomla_db_rownum
-	                  FROM (
-	                      " . $query . "
-	                  ) joomla1
-	              ) joomla2
-	              WHERE joomla2.joomla_db_rownum BETWEEN " . ($offset + 1) . " AND " . ($offset + $limit);
+		// Check if we need to mangle the query.
+		if ($limit || $offset)
+		{
+			$query = "SELECT joomla2.*
+		              FROM (
+		                  SELECT joomla1.*, ROWNUM AS joomla_db_rownum
+		                  FROM (
+		                      " . $query . "
+		                  ) joomla1
+		              ) joomla2";
+
+			// Check if the limit value is greater than zero.
+			if ($limit > 0)
+			{
+				$query .= ' WHERE joomla2.joomla_db_rownum BETWEEN ' . ($offset + 1) . ' AND ' . ($offset + $limit);
+			}
+			else
+			{
+				// Check if there is an offset and then use this.
+				if ($offset)
+				{
+					$query .= ' WHERE joomla2.joomla_db_rownum > ' . ($offset + 1);
+				}
+			}
+		}
 
 		return $query;
 	}


### PR DESCRIPTION
This pull request introduces various fixes for the Oracle driver, Oracle query class and PDO driver. 
# Summarised changes:
- Add double quote as the Oracle name quote to handle name quoting properly.
- Added support for supplying a query to execute to verify that a connection is active.
- Override default connection verification query for Oracle to support "dual" idiom.
- Update getTableColumns() to support rewriting a prefix on Oracle.
- Fix getTableColumns() to return results consistent with other drivers.
- Add replacePrefix() to Oracle driver to ignore double quoted items (it being the name quote character).
- Fix getEscaped() for PDO driver to not automatically quote it's results inline with other drivers.
- Store a copy of the error message in PDO execute() before trying to run keep-alive query which wipes out previous value.
- Suppress error message from lastInsertId() to avoid PDO warning you that a given database platform doesn't support it natively.
- Add a sudden death when trying to check if connected when already trying to check if connected to prevent infinite loop.
- Update Oracle query to only mangle the query for limiting and offset when applicable otherwise pass the query through unmodified.
