### PR TITLE
Joomla PHPCS is excluding files and folders starting with js

### DIFF
--- a/build/phpcs/Joomla/ruleset.xml
+++ b/build/phpcs/Joomla/ruleset.xml
@@ -3,7 +3,7 @@
  <description>The Joomla coding standard.</description>
 
  <!-- Exclude all javascript files. There are bugs and we don't have any rules anyways. -->
- <exclude-pattern>*.js</exclude-pattern>
+ <exclude-pattern>*\.js</exclude-pattern>
 
  <!-- Exclude 3rd party libraries. -->
  <exclude-pattern>*/phputf8/*</exclude-pattern>


### PR DESCRIPTION
Currently the rule: <exclude-pattern>*.js</exclude-pattern> is excluding the files and folders that start with js. That is because . is interpreted as any single character instead of the dot character.

Escaping dots from the exclude-pattern will fix that.
