### PR TITLE
Add "preset" attribute to form fields and adapt list/checkboxes multiple default/preset values

### DIFF
--- a/libraries/joomla/form/fields/checkboxes.php
+++ b/libraries/joomla/form/fields/checkboxes.php
@@ -58,13 +58,55 @@ class JFormFieldCheckboxes extends JFormField
 		// Get the field options.
 		$options = $this->getOptions();
 
+		// Get the value(s)
+		if (empty($this->value))
+		{
+			// Filter the option using the preset flag
+			$filter = array_filter(
+				$options,
+				function($option)
+				{
+					return $option->preset;
+				}
+			);
+
+			// If the data exists or there is no preset
+			if ($this->form->existValue($this->fieldname, $this->group) || empty($filter))
+			{
+				$filter = array_filter(
+					$options,
+					function($option)
+					{
+						return $option->default;
+					}
+				);
+			}
+
+			// Extract the values from the filter
+			$values = array_map(
+				function ($option)
+				{
+					return $option->value;
+				},
+				$filter
+			);
+		}
+		elseif (is_array($this->value))
+		{
+			$values = $this->value;
+		}
+		else
+		{
+			$values = array($this->value);
+		}
+
 		// Build the checkbox field output.
 		$html[] = '<ul>';
 		foreach ($options as $i => $option)
 		{
 
 			// Initialize some option attributes.
-			$checked = (in_array((string) $option->value, (array) $this->value) ? ' checked="checked"' : '');
+			$checked = (in_array((string) $option->value, $values) ? ' checked="checked"' : '');
 			$class = !empty($option->class) ? ' class="' . $option->class . '"' : '';
 			$disabled = !empty($option->disable) ? ' disabled="disabled"' : '';
 
@@ -118,6 +160,12 @@ class JFormFieldCheckboxes extends JFormField
 
 			// Set some JavaScript option attributes.
 			$tmp->onclick = (string) $option['onclick'];
+
+			// Set the default attribute.
+			$tmp->default = (string) $option['default'] == 'true';
+
+			// Set the preset attribute.
+			$tmp->preset = (string) $option['preset'] == 'true';
 
 			// Add the option object to the result set.
 			$options[] = $tmp;

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -622,6 +622,31 @@ class JForm
 	}
 
 	/**
+	 * Method to test if the value of a field exists.
+	 *
+	 * @param   string  $name   The name of the field for which to get the value.
+	 * @param   string  $group  The optional dot-separated form group path on which to get the value.
+	 *
+	 * @return  bool  TRUE on success, FALSE on failure.
+	 *
+	 * @since   12.2
+	 */
+	public function existValue($name, $group = null)
+	{
+		// If a group is set use it.
+		if ($group)
+		{
+			$return = $this->data->exists($group . '.' . $name);
+		}
+		else
+		{
+			$return = $this->data->exists($name);
+		}
+
+		return $return;
+	}
+
+	/**
 	 * Method to load the form description from an XML string or object.
 	 *
 	 * The replace option works per field.  If a field being loaded already exists in the current
@@ -1667,6 +1692,9 @@ class JForm
 			return false;
 		}
 
+		// Get the field name.
+		$name = (string) $element['name'];
+
 		// Get the field type.
 		$type = $element['type'] ? (string) $element['type'] : 'text';
 
@@ -1687,6 +1715,7 @@ class JForm
 		 */
 		if ($value === null)
 		{
+			// Get the default value
 			$default = (string) $element['default'];
 			if (($translate = $element['translate_default']) && ((string) $translate == 'true' || (string) $translate == '1'))
 			{
@@ -1702,7 +1731,32 @@ class JForm
 					$default = JText::_($default);
 				}
 			}
-			$value = $this->getValue((string) $element['name'], $group, $default);
+
+			// Get the value
+			if ($this->existValue($name, $group) || !isset($element['preset']))
+			{
+				$value = $this->getValue($name, $group, $default);
+			}
+			else
+			{
+				// Get the preset value
+				$preset = (string) $element['preset'];
+				if (($translate = $element['translate_preset']) && ((string) $translate == 'true' || (string) $translate == '1'))
+				{
+					$lang = JFactory::getLanguage();
+					if ($lang->hasKey($default))
+					{
+						$debug = $lang->setDebug(false);
+						$preset = JText::_($preset);
+						$lang->setDebug($debug);
+					}
+					else
+					{
+						$preset = JText::_($preset);
+					}
+				}
+				$value = $this->getValue((string) $element['name'], $group, $preset);
+			}
 		}
 
 		// Setup the JFormField object.

--- a/tests/suites/unit/joomla/form/JFormDataHelper.php
+++ b/tests/suites/unit/joomla/form/JFormDataHelper.php
@@ -249,6 +249,11 @@ class JFormDataHelper
 			name="title"
 			type="text"
 			description="The title." />
+		<field
+			name="alias"
+			type="text"
+			description="The alias."
+			preset="preset-alias" />
 		<fields
 			name="params">
 			<field

--- a/tests/suites/unit/joomla/form/JFormTest.php
+++ b/tests/suites/unit/joomla/form/JFormTest.php
@@ -814,10 +814,17 @@ class JFormTest extends TestCase
 			'Line:'.__LINE__.' Prior to binding data, the defaults in the field should be used.'
 		);
 
+		$this->assertThat(
+			$form->getField('alias')->value,
+			$this->equalTo('preset-alias'),
+			'Line:'.__LINE__.' Prior to binding data, the presets in the field should be used.'
+		);
+
 		// Check values after binding.
 
 		$data = array(
 			'title' => 'The title',
+			'alias' => '',
 			'show_title' => 3,
 			'params' => array(
 				'show_title' => 2,
@@ -833,6 +840,12 @@ class JFormTest extends TestCase
 		$this->assertThat(
 			$form->getField('title')->value,
 			$this->equalTo('The title'),
+			'Line:'.__LINE__.' Check the field value bound correctly.'
+		);
+
+		$this->assertThat(
+			$form->getField('alias')->value,
+			$this->equalTo(''),
 			'Line:'.__LINE__.' Check the field value bound correctly.'
 		);
 
@@ -1134,6 +1147,42 @@ class JFormTest extends TestCase
 			$form->getValue('title'),
 			$this->equalTo('Avatar'),
 			'Line:'.__LINE__.' The bind value should be returned.'
+		);
+	}
+
+	/**
+	 * Test for JForm::existValue method.
+	 */
+	public function testExistValue()
+	{
+		$form = new JFormInspector('form1');
+
+		$this->assertThat(
+			$form->load(JFormDataHelper::$loadFieldDocument),
+			$this->isTrue(),
+			'Line:'.__LINE__.' XML string should load successfully.'
+		);
+
+		$this->assertThat(
+			$form->existValue('title'),
+			$this->equalTo(false),
+			'Line:'.__LINE__.' The value should not exist.'
+		);
+
+		$data = array(
+			'title'		=> 'Avatar',
+		);
+
+		$this->assertThat(
+			$form->bind($data),
+			$this->isTrue(),
+			'Line:'.__LINE__.' The data should bind successfully.'
+		);
+
+		$this->assertThat(
+			$form->existValue('title'),
+			$this->equalTo(true),
+			'Line:'.__LINE__.' The value should exist.'
 		);
 	}
 

--- a/tests/suites/unit/joomla/form/fields/JFormFieldCheckboxesTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldCheckboxesTest.php
@@ -48,4 +48,127 @@ class JFormFieldCheckboxesTest extends TestCase
 
 		// TODO: Should check all the attributes have come in properly.
 	}
+
+	/**
+	 * Data provider for testGetInputDefaultPreset
+	 */
+	public function caseGetInputDefaultPreset()
+	{
+		return array(
+			// no default, no preset, existing value
+			array(
+				'',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'1',
+				'<fieldset id="checkboxes" class="checkboxes"><ul><li><input type="checkbox" id="checkboxes0" name="checkboxes[]" value="1"/><label for="checkboxes0">1</label></li><li><input type="checkbox" id="checkboxes1" name="checkboxes[]" value="2"/><label for="checkboxes1">2</label></li><li><input type="checkbox" id="checkboxes2" name="checkboxes[]" value="3"/><label for="checkboxes2">3</label></li></ul></fieldset>',
+				'<fieldset id="checkboxes" class="checkboxes"><ul><li><input type="checkbox" id="checkboxes0" name="checkboxes[]" value="1" checked="checked"/><label for="checkboxes0">1</label></li><li><input type="checkbox" id="checkboxes1" name="checkboxes[]" value="2"/><label for="checkboxes1">2</label></li><li><input type="checkbox" id="checkboxes2" name="checkboxes[]" value="3"/><label for="checkboxes2">3</label></li></ul></fieldset>',
+			),
+
+			// one default, no preset, existing value
+			array(
+				'default="1"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'2',
+				'<fieldset id="checkboxes" class="checkboxes"><ul><li><input type="checkbox" id="checkboxes0" name="checkboxes[]" value="1" checked="checked"/><label for="checkboxes0">1</label></li><li><input type="checkbox" id="checkboxes1" name="checkboxes[]" value="2"/><label for="checkboxes1">2</label></li><li><input type="checkbox" id="checkboxes2" name="checkboxes[]" value="3"/><label for="checkboxes2">3</label></li></ul></fieldset>',
+				'<fieldset id="checkboxes" class="checkboxes"><ul><li><input type="checkbox" id="checkboxes0" name="checkboxes[]" value="1"/><label for="checkboxes0">1</label></li><li><input type="checkbox" id="checkboxes1" name="checkboxes[]" value="2" checked="checked"/><label for="checkboxes1">2</label></li><li><input type="checkbox" id="checkboxes2" name="checkboxes[]" value="3"/><label for="checkboxes2">3</label></li></ul></fieldset>',
+			),
+
+			// one default, no preset, empty value
+			array(
+				'default="1"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'',
+				'<fieldset id="checkboxes" class="checkboxes"><ul><li><input type="checkbox" id="checkboxes0" name="checkboxes[]" value="1" checked="checked"/><label for="checkboxes0">1</label></li><li><input type="checkbox" id="checkboxes1" name="checkboxes[]" value="2"/><label for="checkboxes1">2</label></li><li><input type="checkbox" id="checkboxes2" name="checkboxes[]" value="3"/><label for="checkboxes2">3</label></li></ul></fieldset>',
+				'<fieldset id="checkboxes" class="checkboxes"><ul><li><input type="checkbox" id="checkboxes0" name="checkboxes[]" value="1" checked="checked"/><label for="checkboxes0">1</label></li><li><input type="checkbox" id="checkboxes1" name="checkboxes[]" value="2"/><label for="checkboxes1">2</label></li><li><input type="checkbox" id="checkboxes2" name="checkboxes[]" value="3"/><label for="checkboxes2">3</label></li></ul></fieldset>',
+			),
+
+			// no default, one preset, existing value
+			array(
+				'preset="1"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'2',
+				'<fieldset id="checkboxes" class="checkboxes"><ul><li><input type="checkbox" id="checkboxes0" name="checkboxes[]" value="1" checked="checked"/><label for="checkboxes0">1</label></li><li><input type="checkbox" id="checkboxes1" name="checkboxes[]" value="2"/><label for="checkboxes1">2</label></li><li><input type="checkbox" id="checkboxes2" name="checkboxes[]" value="3"/><label for="checkboxes2">3</label></li></ul></fieldset>',
+				'<fieldset id="checkboxes" class="checkboxes"><ul><li><input type="checkbox" id="checkboxes0" name="checkboxes[]" value="1"/><label for="checkboxes0">1</label></li><li><input type="checkbox" id="checkboxes1" name="checkboxes[]" value="2" checked="checked"/><label for="checkboxes1">2</label></li><li><input type="checkbox" id="checkboxes2" name="checkboxes[]" value="3"/><label for="checkboxes2">3</label></li></ul></fieldset>',
+			),
+
+			// one default, one preset, empty value
+			array(
+				'preset="1" default="2"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'',
+				'<fieldset id="checkboxes" class="checkboxes"><ul><li><input type="checkbox" id="checkboxes0" name="checkboxes[]" value="1" checked="checked"/><label for="checkboxes0">1</label></li><li><input type="checkbox" id="checkboxes1" name="checkboxes[]" value="2"/><label for="checkboxes1">2</label></li><li><input type="checkbox" id="checkboxes2" name="checkboxes[]" value="3"/><label for="checkboxes2">3</label></li></ul></fieldset>',
+				'<fieldset id="checkboxes" class="checkboxes"><ul><li><input type="checkbox" id="checkboxes0" name="checkboxes[]" value="1"/><label for="checkboxes0">1</label></li><li><input type="checkbox" id="checkboxes1" name="checkboxes[]" value="2" checked="checked"/><label for="checkboxes1">2</label></li><li><input type="checkbox" id="checkboxes2" name="checkboxes[]" value="3"/><label for="checkboxes2">3</label></li></ul></fieldset>',
+			),
+
+			// one default, one preset, existing value
+			array(
+				'preset="1" default="2"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'3',
+				'<fieldset id="checkboxes" class="checkboxes"><ul><li><input type="checkbox" id="checkboxes0" name="checkboxes[]" value="1" checked="checked"/><label for="checkboxes0">1</label></li><li><input type="checkbox" id="checkboxes1" name="checkboxes[]" value="2"/><label for="checkboxes1">2</label></li><li><input type="checkbox" id="checkboxes2" name="checkboxes[]" value="3"/><label for="checkboxes2">3</label></li></ul></fieldset>',
+				'<fieldset id="checkboxes" class="checkboxes"><ul><li><input type="checkbox" id="checkboxes0" name="checkboxes[]" value="1"/><label for="checkboxes0">1</label></li><li><input type="checkbox" id="checkboxes1" name="checkboxes[]" value="2"/><label for="checkboxes1">2</label></li><li><input type="checkbox" id="checkboxes2" name="checkboxes[]" value="3" checked="checked"/><label for="checkboxes2">3</label></li></ul></fieldset>',
+			),
+
+			// many default, many preset, empty value
+			array(
+				'',
+				'<option value="1" preset="true">1</option><option value="2" preset="true">2</option><option value="3" default="true">3</option>',
+				'',
+				'<fieldset id="checkboxes" class="checkboxes"><ul><li><input type="checkbox" id="checkboxes0" name="checkboxes[]" value="1" checked="checked"/><label for="checkboxes0">1</label></li><li><input type="checkbox" id="checkboxes1" name="checkboxes[]" value="2" checked="checked"/><label for="checkboxes1">2</label></li><li><input type="checkbox" id="checkboxes2" name="checkboxes[]" value="3"/><label for="checkboxes2">3</label></li></ul></fieldset>',
+				'<fieldset id="checkboxes" class="checkboxes"><ul><li><input type="checkbox" id="checkboxes0" name="checkboxes[]" value="1"/><label for="checkboxes0">1</label></li><li><input type="checkbox" id="checkboxes1" name="checkboxes[]" value="2"/><label for="checkboxes1">2</label></li><li><input type="checkbox" id="checkboxes2" name="checkboxes[]" value="3" checked="checked"/><label for="checkboxes2">3</label></li></ul></fieldset>',
+			),
+
+			// many default, many preset, existing value
+			array(
+				'',
+				'<option value="1" preset="true">1</option><option value="2" preset="true">2</option><option value="3" default="true">3</option>',
+				'2',
+				'<fieldset id="checkboxes" class="checkboxes"><ul><li><input type="checkbox" id="checkboxes0" name="checkboxes[]" value="1" checked="checked"/><label for="checkboxes0">1</label></li><li><input type="checkbox" id="checkboxes1" name="checkboxes[]" value="2" checked="checked"/><label for="checkboxes1">2</label></li><li><input type="checkbox" id="checkboxes2" name="checkboxes[]" value="3"/><label for="checkboxes2">3</label></li></ul></fieldset>',
+				'<fieldset id="checkboxes" class="checkboxes"><ul><li><input type="checkbox" id="checkboxes0" name="checkboxes[]" value="1"/><label for="checkboxes0">1</label></li><li><input type="checkbox" id="checkboxes1" name="checkboxes[]" value="2" checked="checked"/><label for="checkboxes1">2</label></li><li><input type="checkbox" id="checkboxes2" name="checkboxes[]" value="3"/><label for="checkboxes2">3</label></li></ul></fieldset>',
+			),
+
+			// many default, many preset, existing value
+			array(
+				'',
+				'<option value="1" preset="true">1</option><option value="2" preset="true">2</option><option value="3" default="true">3</option>',
+				array('2', '3'),
+				'<fieldset id="checkboxes" class="checkboxes"><ul><li><input type="checkbox" id="checkboxes0" name="checkboxes[]" value="1" checked="checked"/><label for="checkboxes0">1</label></li><li><input type="checkbox" id="checkboxes1" name="checkboxes[]" value="2" checked="checked"/><label for="checkboxes1">2</label></li><li><input type="checkbox" id="checkboxes2" name="checkboxes[]" value="3"/><label for="checkboxes2">3</label></li></ul></fieldset>',
+				'<fieldset id="checkboxes" class="checkboxes"><ul><li><input type="checkbox" id="checkboxes0" name="checkboxes[]" value="1"/><label for="checkboxes0">1</label></li><li><input type="checkbox" id="checkboxes1" name="checkboxes[]" value="2" checked="checked"/><label for="checkboxes1">2</label></li><li><input type="checkbox" id="checkboxes2" name="checkboxes[]" value="3" checked="checked"/><label for="checkboxes2">3</label></li></ul></fieldset>',
+			),
+		);
+	}
+
+	/**
+	 * Test the getInput method.
+	 *
+	 * @dataProvider caseGetInputDefaultPreset
+	 */
+	public function testGetInputDefaultPreset($attributes, $options, $bind, $before, $after)
+	{
+		$form = new JFormInspector('form1');
+
+		$this->assertThat(
+			$form->load('<form><field name="checkboxes" type="checkboxes" ' . $attributes . ' >' . $options . '</field></form>'),
+			$this->isTrue(),
+			'Line:'.__LINE__.' XML string should load successfully.'
+		);
+
+		$this->assertThat(
+			$form->getField('checkboxes')->input,
+			$this->equalTo($before),
+			'Line:'.__LINE__.' The getInput method should return correct input.'
+		);
+
+		$this->assertThat(
+			$form->bind(array('checkboxes' => $bind)),
+			$this->isTrue(),
+			'Line:'.__LINE__.' The data should bind successfully.'
+		);
+
+		$this->assertThat(
+			$form->getField('checkboxes')->input,
+			$this->equalTo($after),
+			'Line:'.__LINE__.' The getInput method should return correct input.'
+		);
+	}
 }

--- a/tests/suites/unit/joomla/form/fields/JFormFieldListTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldListTest.php
@@ -53,4 +53,293 @@ class JFormFieldListTest extends TestCase
 
 		// TODO: Should check all the attributes have come in properly.
 	}
+
+	/**
+	 * Data provider for testGetInputDefaultPreset
+	 */
+	public function caseGetInputDefaultPreset()
+	{
+		return array(
+			// no multiple, no default, no preset, existing value
+			array(
+				'',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'1',
+'<select id="list" name="list">
+	<option value="1">1</option>
+	<option value="2">2</option>
+	<option value="3">3</option>
+</select>
+',
+'<select id="list" name="list">
+	<option value="1" selected="selected">1</option>
+	<option value="2">2</option>
+	<option value="3">3</option>
+</select>
+'
+			),
+
+			// multiple, no default, no preset, existing value
+			array(
+				'multiple="true"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'1',
+'<select id="list" name="list[]" multiple="multiple">
+	<option value="1">1</option>
+	<option value="2">2</option>
+	<option value="3">3</option>
+</select>
+',
+'<select id="list" name="list[]" multiple="multiple">
+	<option value="1" selected="selected">1</option>
+	<option value="2">2</option>
+	<option value="3">3</option>
+</select>
+'
+			),
+
+			// no multiple, one default, no preset, existing value
+			array(
+				'default="1"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'2',
+'<select id="list" name="list">
+	<option value="1" selected="selected">1</option>
+	<option value="2">2</option>
+	<option value="3">3</option>
+</select>
+',
+'<select id="list" name="list">
+	<option value="1">1</option>
+	<option value="2" selected="selected">2</option>
+	<option value="3">3</option>
+</select>
+'
+			),
+
+			// no multiple, one default, no preset, empty value
+			array(
+				'default="1"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'',
+'<select id="list" name="list">
+	<option value="1" selected="selected">1</option>
+	<option value="2">2</option>
+	<option value="3">3</option>
+</select>
+',
+'<select id="list" name="list">
+	<option value="1" selected="selected">1</option>
+	<option value="2">2</option>
+	<option value="3">3</option>
+</select>
+'
+			),
+
+			// no multiple, no default, one preset, existing value
+			array(
+				'preset="1"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'2',
+'<select id="list" name="list">
+	<option value="1" selected="selected">1</option>
+	<option value="2">2</option>
+	<option value="3">3</option>
+</select>
+',
+'<select id="list" name="list">
+	<option value="1">1</option>
+	<option value="2" selected="selected">2</option>
+	<option value="3">3</option>
+</select>
+'
+			),
+
+			// no multiple, no default, no preset, existing value, readonly
+			array(
+				'readonly="true"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'2',
+'<select id="list" name="" disabled="disabled">
+	<option value="1">1</option>
+	<option value="2">2</option>
+	<option value="3">3</option>
+</select>
+<input type="hidden" name="list" value=""/>',
+'<select id="list" name="" disabled="disabled">
+	<option value="1">1</option>
+	<option value="2" selected="selected">2</option>
+	<option value="3">3</option>
+</select>
+<input type="hidden" name="list" value="2"/>'
+			),
+
+			// multiple, no default, one preset, existing value, readonly
+			array(
+				'multiple="true" readonly="true"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'2',
+'<select id="list" name="" disabled="disabled" multiple="multiple">
+	<option value="1">1</option>
+	<option value="2">2</option>
+	<option value="3">3</option>
+</select>
+',
+'<select id="list" name="" disabled="disabled" multiple="multiple">
+	<option value="1">1</option>
+	<option value="2" selected="selected">2</option>
+	<option value="3">3</option>
+</select>
+<input type="hidden" name="list[]" value="2"/>'
+			),
+
+			// multiple, no default, one preset, existing value, readonly
+			array(
+				'multiple="true" readonly="true"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				array('1', '2'),
+'<select id="list" name="" disabled="disabled" multiple="multiple">
+	<option value="1">1</option>
+	<option value="2">2</option>
+	<option value="3">3</option>
+</select>
+',
+'<select id="list" name="" disabled="disabled" multiple="multiple">
+	<option value="1" selected="selected">1</option>
+	<option value="2" selected="selected">2</option>
+	<option value="3">3</option>
+</select>
+<input type="hidden" name="list[]" value="1"/><input type="hidden" name="list[]" value="2"/>'
+			),
+
+			// no multiple, one default, one preset, empty value
+			array(
+				'preset="1" default="2"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'',
+'<select id="list" name="list">
+	<option value="1" selected="selected">1</option>
+	<option value="2">2</option>
+	<option value="3">3</option>
+</select>
+',
+'<select id="list" name="list">
+	<option value="1">1</option>
+	<option value="2" selected="selected">2</option>
+	<option value="3">3</option>
+</select>
+'
+			),
+
+			// no multiple, one default, one preset, existing value
+			array(
+				'preset="1" default="2"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'3',
+'<select id="list" name="list">
+	<option value="1" selected="selected">1</option>
+	<option value="2">2</option>
+	<option value="3">3</option>
+</select>
+',
+'<select id="list" name="list">
+	<option value="1">1</option>
+	<option value="2">2</option>
+	<option value="3" selected="selected">3</option>
+</select>
+'
+			),
+
+			// multiple, many default, many preset, empty value
+			array(
+				'multiple="true"',
+				'<option value="1" preset="true">1</option><option value="2" preset="true">2</option><option value="3" default="true">3</option>',
+				'',
+'<select id="list" name="list[]" multiple="multiple">
+	<option value="1" selected="selected">1</option>
+	<option value="2" selected="selected">2</option>
+	<option value="3">3</option>
+</select>
+',
+'<select id="list" name="list[]" multiple="multiple">
+	<option value="1">1</option>
+	<option value="2">2</option>
+	<option value="3" selected="selected">3</option>
+</select>
+'
+			),
+
+			// multiple, many default, many preset, existing value
+			array(
+				'multiple="true"',
+				'<option value="1" preset="true">1</option><option value="2" preset="true">2</option><option value="3" default="true">3</option>',
+				'2',
+'<select id="list" name="list[]" multiple="multiple">
+	<option value="1" selected="selected">1</option>
+	<option value="2" selected="selected">2</option>
+	<option value="3">3</option>
+</select>
+',
+'<select id="list" name="list[]" multiple="multiple">
+	<option value="1">1</option>
+	<option value="2" selected="selected">2</option>
+	<option value="3">3</option>
+</select>
+'
+			),
+
+			// multiple, many default, many preset, existing value
+			array(
+				'multiple="true"',
+				'<option value="1" preset="true">1</option><option value="2" preset="true">2</option><option value="3" default="true">3</option>',
+				array('2', '3'),
+'<select id="list" name="list[]" multiple="multiple">
+	<option value="1" selected="selected">1</option>
+	<option value="2" selected="selected">2</option>
+	<option value="3">3</option>
+</select>
+',
+'<select id="list" name="list[]" multiple="multiple">
+	<option value="1">1</option>
+	<option value="2" selected="selected">2</option>
+	<option value="3" selected="selected">3</option>
+</select>
+'
+			),
+		);
+	}
+
+	/**
+	 * Test the getInput method.
+	 *
+	 * @dataProvider caseGetInputDefaultPreset
+	 */
+	public function testGetInputDefaultPreset($attributes, $options, $bind, $before, $after)
+	{
+		$form = new JFormInspector('form1');
+
+		$this->assertThat(
+			$form->load('<form><field name="list" type="list" ' . $attributes . ' >' . $options . '</field></form>'),
+			$this->isTrue(),
+			'Line:'.__LINE__.' XML string should load successfully.'
+		);
+
+		$this->assertThat(
+			$form->getField('list')->input,
+			$this->equalTo($before),
+			'Line:'.__LINE__.' The getInput method should return correct input.'
+		);
+
+		$this->assertThat(
+			$form->bind(array('list' => $bind)),
+			$this->isTrue(),
+			'Line:'.__LINE__.' The data should bind successfully.'
+		);
+
+		$this->assertThat(
+			$form->getField('list')->input,
+			$this->equalTo($after),
+			'Line:'.__LINE__.' The getInput method should return correct input.'
+		);
+	}
 }


### PR DESCRIPTION
It's a solution for Joomla CMS [#28402] JFormFieldList (and derivatives) do not utilize multiple default values when multiple=true (http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28402)

It has been extended for supporting preset values in form fields
## in an single valued field, you can now use

```
<field name="text1" type="text" preset="Preset value" />
<field name="text2" type="text" preset="KEY_TO_PRESET_VALUE" translate_preset="true" />
```

This will fill the field the first time the form is edited
## in a list/checkboxes

```
<field name="list1" type="list" default="1">
    <option value="1">1</option>
    <option value="2">2</option>
    <option value="3">3</option>
</field>
```

This will fill the field the with 1 if the current value is empty

```
<field name="list2" type="list" preset="1">
    <option value="1">1</option>
    <option value="2">2</option>
    <option value="3">3</option>
</field>
```

This will fill the field the with 1 the first time the form is edited

```
<field name="list3" type="list">
    <option value="1" default="true">1</option>
    <option value="2">2</option>
    <option value="3" default="true">3</option>
</field>
```

This will fill the field the with 1,3 if the current value is empty

```
<field name="list4" type="list">
    <option value="1" preset="true">1</option>
    <option value="2">2</option>
    <option value="3" preset="true">3</option>
</field>
```

This will fill the field the with 1,3 the first time the form is edited
