### PR TITLE
New (and generic) web application routers.

### DIFF
--- a/libraries/joomla/application/web/router.php
+++ b/libraries/joomla/application/web/router.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Application
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Class to define an abstract Web application router.
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Application
+ * @since       12.3
+ */
+abstract class JApplicationWebRouter
+{
+	/**
+	 * @var    JApplicationWeb  The web application on whose behalf we are routing the request.
+	 * @since  12.3
+	 */
+	protected $app;
+
+	/**
+	 * @var    string  The default page controller name for an empty route.
+	 * @since  12.3
+	 */
+	protected $default;
+
+	/**
+	 * @var    string  Controller class name prefix for creating controller objects by name.
+	 * @since  12.3
+	 */
+	protected $controllerPrefix;
+
+	/**
+	 * @var    JInput  An input object from which to derive the route.
+	 * @since  12.3
+	 */
+	protected $input;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   JApplicationWeb  $app    The web application on whose behalf we are routing the request.
+	 * @param   JInput           $input  An optional input object from which to derive the route.  If none
+	 *                                   is given than the input from the application object will be used.
+	 *
+	 * @since   12.3
+	 */
+	public function __construct(JApplicationWeb $app, JInput $input = null)
+	{
+		$this->app   = $app;
+		$this->input = ($input === null) ? $this->app->input : $input;
+	}
+
+	/**
+	 * Find and execute the appropriate controller based on a given route.
+	 *
+	 * @param   string  $route  The route string for which to find and execute a controller.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.3
+	 * @throws  InvalidArgumentException
+	 * @throws  RuntimeException
+	 */
+	public function execute($route)
+	{
+		// Get the controller name based on the route patterns and requested route.
+		$name = $this->parseRoute($route);
+
+		// Get the controller object by name.
+		$controller = $this->fetchController($name);
+
+		// Execute the controller.
+		$controller->execute();
+	}
+
+	/**
+	 * Set the controller name prefix.
+	 *
+	 * @param   string  $prefix  Controller class name prefix for creating controller objects by name.
+	 *
+	 * @return  JApplicationWebRouter  This object for method chaining.
+	 *
+	 * @since   12.3
+	 */
+	public function setControllerPrefix($prefix)
+	{
+		$this->controllerPrefix	= (string) $prefix;
+
+		return $this;
+	}
+
+	/**
+	 * Set the default controller name.
+	 *
+	 * @param   string  $name  The default page controller name for an empty route.
+	 *
+	 * @return  JApplicationWebRouter  This object for method chaining.
+	 *
+	 * @since   12.3
+	 */
+	public function setDefaultController($name)
+	{
+		$this->default = (string) $name;
+
+		return $this;
+	}
+
+	/**
+	 * Parse the given route and return the name of a controller mapped to the given route.
+	 *
+	 * @param   string  $route  The route string for which to find and execute a controller.
+	 *
+	 * @return  string  The controller name for the given route excluding prefix.
+	 *
+	 * @since   12.3
+	 * @throws  InvalidArgumentException
+	 */
+	abstract protected function parseRoute($route);
+
+	/**
+	 * Get a JController object for a given name.
+	 *
+	 * @param   string  $name  The controller name (excluding prefix) for which to fetch and instance.
+	 *
+	 * @return  JController
+	 *
+	 * @since   12.3
+	 * @throws  RuntimeException
+	 */
+	protected function fetchController($name)
+	{
+		// Derive the controller class name.
+		$class = $this->controllerPrefix . ucfirst($name);
+
+		// If the controller class does not exist panic.
+		if (!class_exists($class))
+		{
+			throw new RuntimeException(sprintf('Unable to locate controller `%s`.', $class), 404);
+		}
+
+		// Instantiate the controller.
+		$controller = new $class($this->input, $this->app);
+
+		return $controller;
+	}
+}

--- a/libraries/joomla/application/web/router.php
+++ b/libraries/joomla/application/web/router.php
@@ -140,7 +140,7 @@ abstract class JApplicationWebRouter
 		$class = $this->controllerPrefix . ucfirst($name);
 
 		// If the controller class does not exist panic.
-		if (!class_exists($class))
+		if (!class_exists($class) || !is_subclass_of($class, 'JController'))
 		{
 			throw new RuntimeException(sprintf('Unable to locate controller `%s`.', $class), 404);
 		}

--- a/libraries/joomla/application/web/router/base.php
+++ b/libraries/joomla/application/web/router/base.php
@@ -50,7 +50,7 @@ class JApplicationWebRouterBase extends JApplicationWebRouter
 	 *
 	 * @since   12.3
 	 */
-	public function addMaps(array $maps)
+	public function addMaps($maps)
 	{
 		foreach ($maps as $pattern => $controller)
 		{
@@ -82,7 +82,7 @@ class JApplicationWebRouterBase extends JApplicationWebRouter
 		$routeLength = count($route);
 
 		// If the route is empty then simply return the default route.  No parsing necessary.
-		if (($routeLength == 1) && ($route[0] == ''))
+		if ($routeLength == 1 && $route[0] == '')
 		{
 			return $this->default;
 		}

--- a/libraries/joomla/application/web/router/base.php
+++ b/libraries/joomla/application/web/router/base.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Application
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Basic Web application router class for the Joomla Platform.
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Application
+ * @since       12.3
+ */
+class JApplicationWebRouterBase extends JApplicationWebRouter
+{
+	/**
+	 * @var    array  An array of pattern => controller pairs for routing the request.
+	 * @since  12.3
+	 */
+	protected $maps = array();
+
+	/**
+	 * Add a route map to the router.  If the pattern already exists it will be overwritten.
+	 *
+	 * @param   string  $pattern     The route pattern to use for matching.
+	 * @param   string  $controller  The controller name to map to the given pattern.
+	 *
+	 * @return  JApplicationWebRouter  This object for method chaining.
+	 *
+	 * @since   12.3
+	 */
+	public function addMap($pattern, $controller)
+	{
+		$this->maps[(string) $pattern] = (string) $controller;
+
+		return $this;
+	}
+
+	/**
+	 * Add a route map to the router.  If the pattern already exists it will be overwritten.
+	 *
+	 * @param   array  $maps  A list of route maps to add to the router as $pattern => $controller.
+	 *
+	 * @return  JApplicationWebRouter  This object for method chaining.
+	 *
+	 * @since   12.3
+	 */
+	public function addMaps(array $maps)
+	{
+		foreach ($maps as $pattern => $controller)
+		{
+			$this->maps[(string) $pattern] = (string) $controller;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Parse the given route and return the name of a controller mapped to the given route.
+	 *
+	 * @param   string  $route  The route string for which to find and execute a controller.
+	 *
+	 * @return  string  The controller name for the given route excluding prefix.
+	 *
+	 * @since   12.3
+	 * @throws  InvalidArgumentException
+	 */
+	protected function parseRoute($route)
+	{
+		// Initialize variables.
+		$controller = false;
+
+		// Sanitize and explode the route.
+		$route = explode('/', trim(parse_url($route, PHP_URL_PATH), ' /'));
+
+		// Cache the route length so we don't have to calculate this on every iteration through the pattern loop.
+		$routeLength = count($route);
+
+		// If the route is empty then simply return the default route.  No parsing necessary.
+		if (($routeLength == 1) && ($route[0] == ''))
+		{
+			return $this->default;
+		}
+
+		// Iterate through all of the known route maps looking for a match.
+		foreach ($this->maps as $pattern => $name)
+		{
+			// Reset the route variables each time.  Cleanliness is next to buglessness ... or something. :-)
+			$vars = array();
+
+			// Sanitize and explode the pattern.
+			$pattern = explode('/', trim(parse_url($pattern, PHP_URL_PATH), ' /'));
+
+			// If we don't have the same number of segments then we definitely do not have a match.
+			if ($routeLength != count($pattern))
+			{
+				continue;
+			}
+
+			// Iterate through all of the segments of the pattern to validate static and variable segments.
+			foreach ($pattern as $i => $segment)
+			{
+				// If we are looking at a variable segment then save the value.
+				if (strpos($segment, ':') === 0)
+				{
+					$vars[substr($segment, 1)] = $route[$i];
+				}
+				// If we are looking at a static segment and the value doesn't match the route segment then the pattern doesn't match.
+				elseif ($segment != $route[$i])
+				{
+					continue 2;
+				}
+			}
+
+			// If we have gotten this far then we have a positive match.
+			$controller = $name;
+
+			// Time to set the input variables.
+			// We are only going to set them if they don't already exist to avoid overwriting things.
+			foreach ($vars as $k => $v)
+			{
+				$this->input->def($k, $v);
+
+				// Don't forget to do an explicit set on the GET superglobal.
+				$this->input->get->def($k, $v);
+			}
+
+			break;
+		}
+
+		// We were unable to find a route match for the request.  Panic.
+		if (!$controller)
+		{
+			throw new InvalidArgumentException(sprintf('Unable to handle request for route `%s`.', implode('/', $route)), 404);
+		}
+
+		return $controller;
+	}
+}

--- a/libraries/joomla/application/web/router/rest.php
+++ b/libraries/joomla/application/web/router/rest.php
@@ -33,6 +33,32 @@ class JApplicationWebRouterRest extends JApplicationWebRouterBase
 	);
 
 	/**
+	 * Find and execute the appropriate controller based on a given route.
+	 *
+	 * @param   string  $route  The route string for which to find and execute a controller.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.3
+	 * @throws  InvalidArgumentException
+	 * @throws  RuntimeException
+	 */
+	public function execute($route)
+	{
+		// Get the controller name based on the route patterns and requested route.
+		$name = $this->parseRoute($route);
+
+		// Append the HTTP method based suffix.
+		$name .= $this->fetchControllerSuffix();
+
+		// Get the controller object by name.
+		$controller = $this->fetchController($name);
+
+		// Execute the controller.
+		$controller->execute();
+	}
+
+	/**
 	 * Set a controller class suffix for a given HTTP method.
 	 *
 	 * @param   string  $method  The HTTP method for which to set the class suffix.
@@ -45,25 +71,8 @@ class JApplicationWebRouterRest extends JApplicationWebRouterBase
 	public function setHttpMethodSuffix($method, $suffix)
 	{
 		$this->suffixMap[strtoupper((string) $method)] = (string) $suffix;
-	}
 
-	/**
-	 * Get a JController object for a given name.
-	 *
-	 * @param   string  $name  The controller name (excluding prefix) for which to fetch and instance.
-	 *
-	 * @return  JController
-	 *
-	 * @codeCoverageIgnore
-	 * @since   12.3
-	 * @throws  RuntimeException
-	 */
-	protected function fetchController($name)
-	{
-		// Append the HTTP method based suffix.
-		$name .= $this->fetchControllerSuffix();
-
-		return parent::fetchController($name);
+		return $this;
 	}
 
 	/**

--- a/libraries/joomla/application/web/router/rest.php
+++ b/libraries/joomla/application/web/router/rest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Application
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * RESTful Web application router class for the Joomla Platform.
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Application
+ * @since       12.3
+ */
+class JApplicationWebRouterRest extends JApplicationWebRouterBase
+{
+	/**
+	 * @var    array  An array of HTTP Method => controller suffix pairs for routing the request.
+	 * @since  12.3
+	 */
+	protected $suffixMap = array(
+		'GET' => 'Get',
+		'POST' => 'Create',
+		'PUT' => 'Update',
+		'PATCH' => 'Update',
+		'DELETE' => 'Delete',
+		'HEAD' => 'Head',
+		'OPTIONS' => 'Options'
+	);
+
+	/**
+	 * Set a controller class suffix for a given HTTP method.
+	 *
+	 * @param   string  $method  The HTTP method for which to set the class suffix.
+	 * @param   string  $suffix  The class suffix to use when fetching the controller name for a given request.
+	 *
+	 * @return  JApplicationWebRouter  This object for method chaining.
+	 *
+	 * @since   12.3
+	 */
+	public function setHttpMethodSuffix($method, $suffix)
+	{
+		$this->suffixMap[strtoupper((string) $method)] = (string) $suffix;
+	}
+
+	/**
+	 * Get a JController object for a given name.
+	 *
+	 * @param   string  $name  The controller name (excluding prefix) for which to fetch and instance.
+	 *
+	 * @return  JController
+	 *
+	 * @since   12.3
+	 * @throws  RuntimeException
+	 */
+	protected function fetchController($name)
+	{
+		// Validate that we have a map to handle the given HTTP method.
+		if (!isset($this->suffixMap[$this->input->getMethod()]))
+		{
+			throw new RuntimeException(sprintf('Unable to support the HTTP method `%s`.', $this->input->getMethod()), 404);
+		}
+
+		// Derive the controller class name.
+		$class = $this->controllerPrefix . ucfirst($name) . $this->suffixMap[$this->input->getMethod()];
+
+		// If the controller class does not exist panic.
+		if (!class_exists($class))
+		{
+			throw new RuntimeException(sprintf('Unable to locate controller `%s`.', $class), 404);
+		}
+
+		// Instantiate the controller.
+		$controller = new $class($this->input, $this->app);
+
+		return $controller;
+	}
+}

--- a/libraries/joomla/application/web/router/rest.php
+++ b/libraries/joomla/application/web/router/rest.php
@@ -54,10 +54,27 @@ class JApplicationWebRouterRest extends JApplicationWebRouterBase
 	 *
 	 * @return  JController
 	 *
+	 * @codeCoverageIgnore
 	 * @since   12.3
 	 * @throws  RuntimeException
 	 */
 	protected function fetchController($name)
+	{
+		// Append the HTTP method based suffix.
+		$name .= $this->fetchControllerSuffix();
+
+		return parent::fetchController($name);
+	}
+
+	/**
+	 * Get the controller class suffix string.
+	 *
+	 * @return  string
+	 *
+	 * @since   12.3
+	 * @throws  RuntimeException
+	 */
+	protected function fetchControllerSuffix()
 	{
 		// Validate that we have a map to handle the given HTTP method.
 		if (!isset($this->suffixMap[$this->input->getMethod()]))
@@ -65,18 +82,6 @@ class JApplicationWebRouterRest extends JApplicationWebRouterBase
 			throw new RuntimeException(sprintf('Unable to support the HTTP method `%s`.', $this->input->getMethod()), 404);
 		}
 
-		// Derive the controller class name.
-		$class = $this->controllerPrefix . ucfirst($name) . $this->suffixMap[$this->input->getMethod()];
-
-		// If the controller class does not exist panic.
-		if (!class_exists($class))
-		{
-			throw new RuntimeException(sprintf('Unable to locate controller `%s`.', $class), 404);
-		}
-
-		// Instantiate the controller.
-		$controller = new $class($this->input, $this->app);
-
-		return $controller;
+		return ucfirst($this->suffixMap[$this->input->getMethod()]);
 	}
 }

--- a/tests/suites/unit/joomla/application/web/JApplicationWebRouterTest.php
+++ b/tests/suites/unit/joomla/application/web/JApplicationWebRouterTest.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Application
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+JLoader::register('TControllerBar', __DIR__ . '/stubs/controllers/bar.php');
+JLoader::register('MyTestControllerBaz', __DIR__ . '/stubs/controllers/baz.php');
+JLoader::register('MyTestControllerFoo', __DIR__ . '/stubs/controllers/foo.php');
+
+/**
+ * Test class for JApplicationWebRouter.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Application
+ * @since       12.3
+ */
+class JApplicationWebRouterTest extends TestCase
+{
+	/**
+	 * @var    JApplicationWebRouter  The object to be tested.
+	 * @since  12.3
+	 */
+	private $_instance;
+
+	/**
+	 * Tests the __construct method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JApplicationWebRouter::__construct
+	 * @since   12.3
+	 */
+	public function test__construct()
+	{
+		$this->assertAttributeInstanceOf('JApplicationWeb', 'app', $this->_instance);
+		$this->assertAttributeInstanceOf('JInput', 'input', $this->_instance);
+	}
+
+	/**
+	 * Tests the setControllerPrefix method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JApplicationWebRouter::setControllerPrefix
+	 * @since   12.3
+	 */
+	public function testSetControllerPrefix()
+	{
+		$this->_instance->setControllerPrefix('MyApplication');
+		$this->assertAttributeEquals('MyApplication', 'controllerPrefix', $this->_instance);
+	}
+
+	/**
+	 * Tests the setDefaultController method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JApplicationWebRouter::setDefaultController
+	 * @since   12.3
+	 */
+	public function testSetDefaultController()
+	{
+		$this->_instance->setDefaultController('foobar');
+		$this->assertAttributeEquals('foobar', 'default', $this->_instance);
+	}
+
+	/**
+	 * Tests the fetchController method if the controller class is missing.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JApplicationWebRouter::fetchController
+	 * @since   12.3
+	 */
+	public function testFetchControllerWithMissingClass()
+	{
+		$this->setExpectedException('RuntimeException');
+		$controller = TestReflection::invoke($this->_instance, 'fetchController', 'goober');
+	}
+
+	/**
+	 * Tests the fetchController method if the class not a controller.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JApplicationWebRouter::fetchController
+	 * @since   12.3
+	 */
+	public function testFetchControllerWithNonController()
+	{
+		$this->setExpectedException('RuntimeException');
+		$controller = TestReflection::invoke($this->_instance, 'fetchController', 'MyTestControllerBaz');
+	}
+
+	/**
+	 * Tests the fetchController method with a prefix set.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JApplicationWebRouter::fetchController
+	 * @since   12.3
+	 */
+	public function testFetchControllerWithPrefixSet()
+	{
+		TestReflection::setValue($this->_instance, 'controllerPrefix', 'MyTestController');
+		$controller = TestReflection::invoke($this->_instance, 'fetchController', 'foo');
+	}
+
+	/**
+	 * Tests the fetchController method without a prefix set even though it is necessary.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JApplicationWebRouter::fetchController
+	 * @since   12.3
+	 */
+	public function testFetchControllerWithoutPrefixSetThoughNecessary()
+	{
+		$this->setExpectedException('RuntimeException');
+		$controller = TestReflection::invoke($this->_instance, 'fetchController', 'foo');
+	}
+
+	/**
+	 * Tests the fetchController method without a prefix set.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JApplicationWebRouter::fetchController
+	 * @since   12.3
+	 */
+	public function testFetchControllerWithoutPrefixSet()
+	{
+		$controller = TestReflection::invoke($this->_instance, 'fetchController', 'TControllerBar');
+	}
+
+	/**
+	 * Prepares the environment before running a test.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.3
+	 */
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->_instance = $this->getMockForAbstractClass('JApplicationWebRouter', array($this->getMockWeb()));
+	}
+
+	/**
+	 * Cleans up the environment after running a test.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.3
+	 */
+	protected function tearDown()
+	{
+		$this->_instance = null;
+
+		parent::tearDown();
+	}
+}

--- a/tests/suites/unit/joomla/application/web/router/JApplicationWebRouterBaseTest.php
+++ b/tests/suites/unit/joomla/application/web/router/JApplicationWebRouterBaseTest.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Application
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Test class for JApplicationWebRouterBase.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Application
+ * @since       12.3
+ */
+class JApplicationWebRouterBaseTest extends TestCase
+{
+	/**
+	 * @var    JApplicationWebRouterBase  The object to be tested.
+	 * @since  12.3
+	 */
+	private $_instance;
+
+	/**
+	 * @var    JInput  The JInput object to be inspected for route variables.
+	 * @since  12.3
+	 */
+	private $_input;
+
+	/**
+	 * Provides test data for route parsing.
+	 *
+	 * @return  array
+	 *
+	 * @since   12.3
+	 */
+	public static function getParseRouteData()
+	{
+		// Route, Exception, ControllerName, InputData, MapSet
+		return array(
+			array('', false, 'home', array(), 1),
+			array('articles/4', true, 'home', array(), 1),
+			array('', false, 'index', array(), 2),
+			array('login', false, 'login', array(), 2),
+			array('articles', false, 'articles', array(), 2),
+			array('articles/4', false, 'article', array('article_id' => 4), 2),
+			array('articles/4/crap', true, '', array(), 2),
+			array('test', true, '', array(), 2),
+			array('test/foo', true, '', array(), 2),
+			array('test/foo/path', true, '', array(), 2),
+			array('test/foo/path/bar', false, 'test', array('seg1' => 'foo', 'seg2' => 'bar'), 2)
+		);
+	}
+
+	/**
+	 * Tests the addMap method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JApplicationWebRouterBase::addMap
+	 * @since   12.3
+	 */
+	public function testAddMap()
+	{
+		$this->assertAttributeEmpty('maps', $this->_instance);
+		$this->_instance->addMap('foo', 'MyApplicationFoo');
+		$this->assertAttributeEquals(array('foo' => 'MyApplicationFoo'), 'maps', $this->_instance);
+	}
+
+	/**
+	 * Tests the addMaps method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JApplicationWebRouterBase::addMaps
+	 * @since   12.3
+	 */
+	public function testAddMaps()
+	{
+		$maps = array(
+			'login' => 'login',
+			'logout' => 'logout',
+			'requests' => 'requests',
+			'requests/:request_id' => 'request'
+		);
+
+		$this->assertAttributeEmpty('maps', $this->_instance);
+		$this->_instance->addMaps($maps);
+		$this->assertAttributeEquals($maps, 'maps', $this->_instance);
+	}
+
+	/**
+	 * Tests the JApplicationWebRouterBase::parseRoute method.
+	 *
+	 * @param   string   $r  The route to parse.
+	 * @param   boolean  $e  True if an exception is expected.
+	 * @param   string   $c  The expected controller name.
+	 * @param   array    $i  The expected input object data.
+	 * @param   integer  $m  The map set to use for setting up the router.
+	 *
+	 * @return  void
+	 *
+	 * @covers       JApplicationWebRouterBase::parseRoute
+	 * @dataProvider getParseRouteData
+	 * @since        12.3
+	 */
+	public function testParseRoute($r, $e, $c, $i, $m)
+	{
+		// Setup the router maps.
+		$mapSetup = 'setMaps' . $m;
+		$this->$mapSetup();
+
+		// If we should expect an exception set that up.
+		if ($e)
+		{
+			$this->setExpectedException('InvalidArgumentException');
+		}
+
+		// Execute the route parsing.
+		$actual = TestReflection::invoke($this->_instance, 'parseRoute', $r);
+
+		// Test the assertions.
+		$this->assertEquals($c, $actual, 'Incorrect controller name found.');
+		$this->assertAttributeEquals($i, 'data', $this->_input, 'The input data is incorrect.');
+	}
+
+	/**
+	 * Setup the router maps to option 1.
+	 *
+	 * This has no routes but has a default controller for the home page.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.3
+	 */
+	protected function setMaps1()
+	{
+		$this->_instance->addMaps(array());
+		$this->_instance->setDefaultController('home');
+	}
+
+	/**
+	 * Setup the router maps to option 2.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.3
+	 */
+	protected function setMaps2()
+	{
+		$this->_instance->addMaps(
+			array(
+				'login' => 'login',
+				'logout' => 'logout',
+				'articles' => 'articles',
+				'articles/:article_id' => 'article',
+				'test/:seg1/path/:seg2' => 'test'
+			)
+		);
+		$this->_instance->setDefaultController('index');
+	}
+
+	/**
+	 * Prepares the environment before running a test.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.3
+	 */
+	protected function setUp()
+	{
+		parent::setUp();
+
+		// Construct the clean JInput object.
+		$this->_input = new JInput(array());
+
+		$this->_instance = new JApplicationWebRouterBase($this->getMockWeb(), $this->_input);
+	}
+
+	/**
+	 * Cleans up the environment after running a test.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.3
+	 */
+	protected function tearDown()
+	{
+		$this->_instance = null;
+
+		parent::tearDown();
+	}
+}

--- a/tests/suites/unit/joomla/application/web/router/JApplicationWebRouterBaseTest.php
+++ b/tests/suites/unit/joomla/application/web/router/JApplicationWebRouterBaseTest.php
@@ -49,7 +49,11 @@ class JApplicationWebRouterBaseTest extends TestCase
 			array('test', true, '', array(), 2),
 			array('test/foo', true, '', array(), 2),
 			array('test/foo/path', true, '', array(), 2),
-			array('test/foo/path/bar', false, 'test', array('seg1' => 'foo', 'seg2' => 'bar'), 2)
+			array('test/foo/path/bar', false, 'test', array('seg1' => 'foo', 'seg2' => 'bar'), 2),
+			array('content/article-1/*', false, 'content', array(), 2),
+			array('content/cat-1/article-1', false, 'article', array('category' => 'cat-1', 'article' => 'article-1'), 2),
+			array('content/cat-1/cat-2/article-1', false, 'article', array('category' => 'cat-1/cat-2', 'article' => 'article-1'), 2),
+			array('content/cat-1/cat-2/cat-3/article-1', false, 'article', array('category' => 'cat-1/cat-2/cat-3', 'article' => 'article-1'), 2)
 		);
 	}
 
@@ -65,7 +69,17 @@ class JApplicationWebRouterBaseTest extends TestCase
 	{
 		$this->assertAttributeEmpty('maps', $this->_instance);
 		$this->_instance->addMap('foo', 'MyApplicationFoo');
-		$this->assertAttributeEquals(array('foo' => 'MyApplicationFoo'), 'maps', $this->_instance);
+		$this->assertAttributeEquals(
+			array(
+				array(
+					'regex' => chr(1) . '^foo$' . chr(1),
+					'vars' => array(),
+					'controller' => 'MyApplicationFoo'
+				)
+			),
+			'maps',
+			$this->_instance
+		);
 	}
 
 	/**
@@ -85,9 +99,32 @@ class JApplicationWebRouterBaseTest extends TestCase
 			'requests/:request_id' => 'request'
 		);
 
+		$rules = array(
+			array(
+				'regex' => chr(1) . '^login$' . chr(1),
+				'vars' => array(),
+				'controller' => 'login'
+			),
+			array(
+				'regex' => chr(1) . '^logout$' . chr(1),
+				'vars' => array(),
+				'controller' => 'logout'
+			),
+			array(
+				'regex' => chr(1) . '^requests$' . chr(1),
+				'vars' => array(),
+				'controller' => 'requests'
+			),
+			array(
+				'regex' => chr(1) . '^requests/([^/]*)$' . chr(1),
+				'vars' => array('request_id'),
+				'controller' => 'request'
+			)
+		);
+
 		$this->assertAttributeEmpty('maps', $this->_instance);
 		$this->_instance->addMaps($maps);
-		$this->assertAttributeEquals($maps, 'maps', $this->_instance);
+		$this->assertAttributeEquals($rules, 'maps', $this->_instance);
 	}
 
 	/**
@@ -155,7 +192,9 @@ class JApplicationWebRouterBaseTest extends TestCase
 				'logout' => 'logout',
 				'articles' => 'articles',
 				'articles/:article_id' => 'article',
-				'test/:seg1/path/:seg2' => 'test'
+				'test/:seg1/path/:seg2' => 'test',
+				'content/:/\*' => 'content',
+				'content/*category/:article' => 'article'
 			)
 		);
 		$this->_instance->setDefaultController('index');
@@ -173,7 +212,8 @@ class JApplicationWebRouterBaseTest extends TestCase
 		parent::setUp();
 
 		// Construct the clean JInput object.
-		$this->_input = new JInput(array());
+		$array = array();
+		$this->_input = new JInput($array);
 
 		$this->_instance = new JApplicationWebRouterBase($this->getMockWeb(), $this->_input);
 	}

--- a/tests/suites/unit/joomla/application/web/router/JApplicationWebRouterRestTest.php
+++ b/tests/suites/unit/joomla/application/web/router/JApplicationWebRouterRestTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Application
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Test class for JApplicationWebRouterRest.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Application
+ * @since       12.3
+ */
+class JApplicationWebRouterRestTest extends TestCase
+{
+	/**
+	 * @var    JApplicationWebRouterRest  The object to be tested.
+	 * @since  12.3
+	 */
+	private $_instance;
+
+	/**
+	 * @var    string  The server REQUEST_METHOD cached to keep it clean.
+	 * @since  12.3
+	 */
+	private $_method;
+
+	/**
+	 * Tests the setHttpMethodSuffix method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JApplicationWebRouterRest::setHttpMethodSuffix
+	 * @since   12.3
+	 */
+	public function testSetHttpMethodSuffix()
+	{
+		$this->_instance->setHttpMethodSuffix('FOO', 'Bar');
+		$s = TestReflection::getValue($this->_instance, 'suffixMap');
+		$this->assertEquals('Bar', $s['FOO']);
+	}
+
+	/**
+	 * Tests the fetchControllerSuffix method if the suffix map is missing.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JApplicationWebRouterRest::fetchControllerSuffix
+	 * @since   12.3
+	 */
+	public function testFetchControllerSuffixWithMissingSuffixMap()
+	{
+		$_SERVER['REQUEST_METHOD'] = 'FOOBAR';
+
+		$this->setExpectedException('RuntimeException');
+		$suffix = TestReflection::invoke($this->_instance, 'fetchControllerSuffix');
+	}
+
+	/**
+	 * Tests the fetchControllerSuffix method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JApplicationWebRouterRest::fetchControllerSuffix
+	 * @since   12.3
+	 */
+	public function testFetchControllerSuffix()
+	{
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		$suffix = TestReflection::invoke($this->_instance, 'fetchControllerSuffix');
+		$this->assertEquals('Get', $suffix);
+	}
+
+	/**
+	 * Prepares the environment before running a test.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.3
+	 */
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->_instance = new JApplicationWebRouterRest($this->getMockWeb());
+		$this->_method = @$_SERVER['REQUEST_METHOD'];
+	}
+
+	/**
+	 * Cleans up the environment after running a test.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.3
+	 */
+	protected function tearDown()
+	{
+		$this->_instance = null;
+		$_SERVER['REQUEST_METHOD'] = $this->_method;
+
+		parent::tearDown();
+	}
+}

--- a/tests/suites/unit/joomla/application/web/stubs/controllers/bar.php
+++ b/tests/suites/unit/joomla/application/web/stubs/controllers/bar.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Application
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Test stub controller.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Application
+ * @since       12.3
+ */
+class TControllerBar extends JControllerBase
+{
+	/**
+	 * Execute the controller.
+	 *
+	 * @return  boolean  True if controller finished execution, false if the controller did not
+	 *                   finish execution. A controller might return false if some precondition for
+	 *                   the controller to run has not been satisfied.
+	 *
+	 * @since   12.1
+	 * @throws  LogicException
+	 * @throws  RuntimeException
+	 */
+	public function execute()
+	{
+		return true;
+	}
+}

--- a/tests/suites/unit/joomla/application/web/stubs/controllers/baz.php
+++ b/tests/suites/unit/joomla/application/web/stubs/controllers/baz.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Application
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Test stub non-controller.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Application
+ * @since       12.3
+ */
+class MyTestControllerBaz
+{
+}

--- a/tests/suites/unit/joomla/application/web/stubs/controllers/foo.php
+++ b/tests/suites/unit/joomla/application/web/stubs/controllers/foo.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Application
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Test stub controller.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Application
+ * @since       12.3
+ */
+class MyTestControllerFoo extends JControllerBase
+{
+	/**
+	 * Execute the controller.
+	 *
+	 * @return  boolean  True if controller finished execution, false if the controller did not
+	 *                   finish execution. A controller might return false if some precondition for
+	 *                   the controller to run has not been satisfied.
+	 *
+	 * @since   12.1
+	 * @throws  LogicException
+	 * @throws  RuntimeException
+	 */
+	public function execute()
+	{
+		return true;
+	}
+}


### PR DESCRIPTION
I still need to write some documentation, but hopefully the code is simple and clean enough to understand clearly.  There are three new classes: `JApplicationWebRouter`, `JApplicationWebRouterBase` and `JApplicationWebRouterRest`.  These are not meant to be one size fits all.  They are meant to provide a solid foundation for what is hopefully the majority of use cases in URL routing.
### JApplicationWebRouter

The foundational web router class is abstract.  The premise of the class is that some sort of route string would be passed into the execute method, that string would be parsed within the `parseRoute()` method to determine the name of the appropriate controller to execute, then `fetchController()` would be called to actually instantiate the controller object and return it.  Once that is done then the controller is simply executed.

I've purposefully not provided an implementation of `parseRoute()` in the base class because there are infinite different ways a route can be examined to determine how to proceed.  Other features of the class include the ability to set a default controller name if an empty route was given, and also the ability to set a controller class prefix that would be prepended to any controller name returned from `parseRoute()`.
### JApplicationWebRouterBase

The basic concrete implementation of `JApplicationWebRouter` provides a very simple algorithm to parse routes based on a `pattern => controller` mapping.  The premise is that if an incoming route matches the given pattern than the associated controller will be returned and ultimately executed.  It is important to note that for this implementation the pattern is not a regular expression.  The route and patterns are broken down into segments split over `/` and evaluated segment by segment.  There must be an exact match for all segments to constitute the route matching the pattern.

For example if we have pattern `continents/europe`:
- The route `continents/europe` is a match. [Every segment matches]
- The route `continents/asia` is **NOT** a match. [The second segment asia does not match europe]
- The route `continents/europe/germany` is also **NOT** a match. [The final segment germany is not in the pattern]
#### Variables

Along with standard string comparison for route segments, patterns can include variables by prefixing the segment with a `:`.  To continue with our previous example let's make the actual continent a variable.

The new pattern is `continents/:continent`:
- The route `continents/europe` is a match. [Every segment matches because europe is in a variable segment]
- The route `continents/asia` is **ALSO** a match. [Again, asia is in a variable segment]
- The route `continents/europe/germany` does **NOT** a match. [The final segment germany is still not in the pattern even though the europe segment works since it is in a variable segment]

A side effect of using variables is that the variable name (everything in the segment except the opening `:`) is added to the application input object with the value found in a successful route match.  Using the same example as above; pattern `continents/:continent`:
- The route `continents/europe` matches and the application input object will have `europe` set for input variable `continent`.
- The route `continents/asia` matches and the application input object will have `asia` set for input variable `continent`.

_**Note:** If you need to start a segment of your pattern with a `:` and do not want the segment to be considered a variable simply escape the colon like `\:`._
#### Splats

In addition to the standard per-segment variables you can use the asterisk `*` symbol to indicate a match across segments.  For example the pattern `continents/*/berlin` would match a route `continents/europe/germany/berlin`.  It would not match the route `continents/europe/germany/frankfurt` since it is looking for the last segments to be `berlin`.

If you want to capture the part of the route that matches the splat then you simply need to name the segment.  For example the pattern `continents/*cont_nation/berlin` would still match the route `continents/europe/germany/berlin` however this time the input object will have `europe/germany` set for the input variable `cont_nation`.

You can also mix and match the splats and variables such as the pattern `continents/*/:city`.  That will match the route `continents/europe/germany/berlin` and `berlin` will be the value for the input variable `city`.

_**Note:** Similar to variables if you need to start a segment of your pattern with a `*` and do not want the segment to be considered a splat simply escape the asterisk like `\*`._
### JApplicationWebRouterRest

The generic RESTful router extends `JApplicationWebRouterBase` and inherits the same pattern matching with variables as discussed above.  The only addition is that `JApplicationWebRouterRest` also maintains a map of HTTP Methods [GET, POST, PUT, etc.] to controller class suffixes.  This is used so that you can namespace your controllers based on the type of action being performed on the resource. As an example if we have an application that manages resources called "articles" we would only need two pattern rules: one for with an article ID and one for without.
- `articles` => `articles` - If no ID is present.
- `articles/:article_id` => `articles` - If an article ID is present.

Let's also set the controller prefix to `MyController` since that happens to be my application's prefix for finding controllers.

Now all we need are the following classes since the `JApplicationWebRouterRest` router is going to take care of the HTTP Method mapping for us.
- `MyControllerArticlesCreate` - `POST /articles` - Create a new article.
- `MyControllerArticlesDelete` - `DELETE /articles/42` - Delete article 42.
- `MyControllerArticlesGet -`GET /articles/7` - Get article 7.
- `MyControllerArticlesUpdate` - `PUT /articles/7` - Save an update to article 7.
