### PR TITLE
Added some method inside JDatabaseDriver to create database and alter character set

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -378,6 +378,27 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	}
 
 	/**
+	 * Alter database's character set, obtaining query string from protected member.
+	 *
+	 * @param   string  $dbName  The database name that will be altered
+	 *
+	 * @return  string  The query that alter the database query string
+	 *
+	 * @since   12.2
+	 * @throws  RuntimeException
+	 */
+	public function alterDbCharacterSet($dbName)
+	{
+		if (is_null($dbName))
+		{
+			throw new RuntimeException('Database name must not be null.');
+		}
+
+		$this->setQuery($this->getAlterDbCharacterSet($dbName));
+		return $this->execute();
+	}
+
+	/**
 	 * Connects to the database if needed.
 	 *
 	 * @return  void  Returns void if the database connected successfully.
@@ -396,6 +417,31 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 */
 	abstract public function connected();
 
+	/**
+	 * Create a new database using information from $options object, obtaining query string
+	 * from protected member.
+	 *
+	 * @param   JObject  $options  JObject coming from CMS' "initialise" function to pass user
+	 *								and database name to database driver.
+	 * @param   boolean  $utf      True if the database supports the UTF-8 character set.
+	 *
+	 * @return  string  The query that creates database
+	 *
+	 * @since   12.2
+	 * @throws  RuntimeException
+	 */
+	public function createDatabase($options, $utf = true)
+	{
+		if (is_null($options))
+		{
+			throw new RuntimeException('$options object must not be null.');
+		}
+
+		$this->setQuery($this->getCreateDatabaseQuery($options, $utf));
+		return $this->execute();
+	}
+	
+	
 	/**
 	 * Disconnects the database.
 	 *
@@ -484,6 +530,48 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 */
 	abstract public function getAffectedRows();
 
+	/**
+	 * Return the query string to alter the database character set.
+	 *
+	 * @param   string  $dbName  The database name
+	 *
+	 * @return  string  The query that alter the database query string
+	 *
+	 * @since   12.2
+	 */
+	protected function getAlterDbCharacterSet($dbName)
+	{
+		$query = 'ALTER DATABASE ' . $this->quoteName($dbName) . ' CHARACTER SET `utf8`';
+
+		return $query;
+	}
+
+	/**
+	 * Return the query string to create new Database.
+	 * Each database driver, other than MySQL, need to override this member to return correct string.
+	 *
+	 * @param   JObject  $options  JObject coming from CMS' "initialise" function to pass user
+	 *								and database name to database driver.
+	 * @param   boolean  $utf      True if the database supports the UTF-8 character set.
+	 *
+	 * @return  string  The query that creates database
+	 *
+	 * @since   12.2
+	 */
+	protected function getCreateDatabaseQuery($options, $utf)
+	{
+		if ($utf)
+		{
+			$query = 'CREATE DATABASE ' . $this->quoteName($options->db_name) . ' CHARACTER SET `utf8`';
+		}
+		else
+		{
+			$query = 'CREATE DATABASE ' . $this->quoteName($options->db_name);
+		}
+
+		return $query;
+	}
+	
 	/**
 	 * Method to get the database collation in use by sampling a text field of a table in the database.
 	 *

--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -436,12 +436,19 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 		{
 			throw new RuntimeException('$options object must not be null.');
 		}
+		elseif (!isset($options->db_name) || empty($options->db_name))
+		{
+			throw new RuntimeException('$options object must have db_name set.');
+		}
+		elseif (!isset($options->db_user) || empty($options->db_user))
+		{
+			throw new RuntimeException('$options object must have db_user set.');
+		}
 
 		$this->setQuery($this->getCreateDatabaseQuery($options, $utf));
 		return $this->execute();
 	}
-	
-	
+
 	/**
 	 * Disconnects the database.
 	 *
@@ -571,7 +578,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 
 		return $query;
 	}
-	
+
 	/**
 	 * Method to get the database collation in use by sampling a text field of a table in the database.
 	 *

--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -421,9 +421,9 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 * Create a new database using information from $options object, obtaining query string
 	 * from protected member.
 	 *
-	 * @param   JObject  $options  JObject coming from CMS' "initialise" function to pass user
-	 *								and database name to database driver.
-	 * @param   boolean  $utf      True if the database supports the UTF-8 character set.
+	 * @param   stdClass  $options  Object used to pass user and database name to database driver.
+	 * 									This object must have "db_name" and "db_user" set.
+	 * @param   boolean   $utf      True if the database supports the UTF-8 character set.
 	 *
 	 * @return  string  The query that creates database
 	 *
@@ -436,11 +436,11 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 		{
 			throw new RuntimeException('$options object must not be null.');
 		}
-		elseif (!isset($options->db_name) || empty($options->db_name))
+		elseif (empty($options->db_name))
 		{
 			throw new RuntimeException('$options object must have db_name set.');
 		}
-		elseif (!isset($options->db_user) || empty($options->db_user))
+		elseif (empty($options->db_user))
 		{
 			throw new RuntimeException('$options object must have db_user set.');
 		}

--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -557,9 +557,9 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 * Return the query string to create new Database.
 	 * Each database driver, other than MySQL, need to override this member to return correct string.
 	 *
-	 * @param   JObject  $options  JObject coming from CMS' "initialise" function to pass user
-	 *								and database name to database driver.
-	 * @param   boolean  $utf      True if the database supports the UTF-8 character set.
+	 * @param   stdClass  $options  Object used to pass user and database name to database driver.
+	 * 									This object must have "db_name" and "db_user" set.
+	 * @param   boolean   $utf      True if the database supports the UTF-8 character set.
 	 *
 	 * @return  string  The query that creates database
 	 *

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -787,7 +787,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	/**
 	 * This function return a field value as a prepared string to be used in a SQL statement.
 	 *
-	 * @param   array   $columns      Array of table's column returned by JDatabasePostgreSQL::getTableColumns.
+	 * @param   array   &$columns     Array of table's column returned by JDatabasePostgreSQL::getTableColumns.
 	 * @param   string  $field_name   The table field's name.
 	 * @param   string  $field_value  The variable value to quote and return.
 	 * 

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -787,7 +787,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	/**
 	 * This function return a field value as a prepared string to be used in a SQL statement.
 	 *
-	 * @param   array   $columns      Array of table's column returned by ::getTableColumns.
+	 * @param   array   $columns      Array of table's column returned by JDatabasePostgreSQL::getTableColumns.
 	 * @param   string  $field_name   The table field's name.
 	 * @param   string  $field_value  The variable value to quote and return.
 	 * 
@@ -795,7 +795,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	 *
 	 * @since   11.3
 	 */
-	public function sqlValue($columns, $field_name, $field_value)
+	protected function sqlValue(&$columns, $field_name, $field_value)
 	{
 		switch ($columns[$field_name])
 		{
@@ -814,7 +814,6 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 			case 'bigserial':
 			case 'integer':
 			case 'money':
-			case 'numeric':
 			case 'real':
 			case 'smallint':
 			case 'serial':

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -1093,15 +1093,15 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	}
 
 	/**
-	 * Get the query string to alter the database character set.
+	 * Return the query string to alter the database character set.
 	 *
 	 * @param   string  $dbName  The database name
 	 *
 	 * @return  string  The query that alter the database query string
 	 *
-	 * @since   12.1
+	 * @since   12.2
 	 */
-	public function getAlterDbCharacterSet( $dbName )
+	protected function getAlterDbCharacterSet($dbName)
 	{
 		$query = 'ALTER DATABASE ' . $this->quoteName($dbName) . ' SET CLIENT_ENCODING TO ' . $this->quote('UTF8');
 
@@ -1109,18 +1109,17 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	}
 
 	/**
-	 * Get the query string to create new Database in correct PostgreSQL syntax.
+	 * Return the query string to create new Database using PostgreSQL's syntax
 	 *
-	 * @param   object   $options  object coming from "initialise" function to pass user
-	 * 									and database name to database driver.
-	 * @param   boolean  $utf      True if the database supports the UTF-8 character set,
-	 * 									not used in PostgreSQL "CREATE DATABASE" query.
+	 * @param   JObject  $options  JObject coming from CMS' "initialise" function to pass user
+	 *								and database name to database driver.
+	 * @param   boolean  $utf      True if the database supports the UTF-8 character set.
 	 *
-	 * @return  string	The query that creates database, owned by $options['user']
+	 * @return  string  The query that creates database, owned by $options['user']
 	 *
-	 * @since   12.1
+	 * @since   12.2
 	 */
-	public function getCreateDbQuery($options, $utf)
+	protected function getCreateDatabaseQuery($options, $utf)
 	{
 		$query = 'CREATE DATABASE ' . $this->quoteName($options->db_name) . ' OWNER ' . $this->quoteName($options->db_user);
 

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -1110,9 +1110,9 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	/**
 	 * Return the query string to create new Database using PostgreSQL's syntax
 	 *
-	 * @param   JObject  $options  JObject coming from CMS' "initialise" function to pass user
-	 *								and database name to database driver.
-	 * @param   boolean  $utf      True if the database supports the UTF-8 character set.
+	 * @param   stdClass  $options  Object used to pass user and database name to database driver.
+	 * 									This object must have "db_name" and "db_user" set.
+	 * @param   boolean   $utf      True if the database supports the UTF-8 character set.
 	 *
 	 * @return  string  The query that creates database, owned by $options['user']
 	 *

--- a/tests/suites/database/driver/mysql/JDatabaseMySQLTest.php
+++ b/tests/suites/database/driver/mysql/JDatabaseMySQLTest.php
@@ -16,6 +16,22 @@
 class JDatabaseMysqlTest extends TestCaseDatabaseMysql
 {
 	/**
+	 * Data for the getCreateDbQuery test.
+	 *
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	public function dataGetCreateDbQuery()
+	{
+		$obj = new stdClass;
+		$obj->db_user = 'testName';
+		$obj->db_name = 'testDb';
+
+		return array(array($obj, false), array($obj, true));
+	}
+
+	/**
 	 * Data for the testEscape test.
 	 *
 	 * @return  array
@@ -52,12 +68,36 @@ class JDatabaseMysqlTest extends TestCaseDatabaseMysql
 	}
 
 	/**
+	 * Test alterDbCharacterSet with null param.
+	 *
+	 * @return   void
+	 *
+	 * @expectedException RuntimeException
+	 */
+	public function testAlterDbCharacterSet()
+	{
+		self::$driver->alterDbCharacterSet(null);
+	}
+
+	/**
 	 * @todo Implement testConnected().
 	 */
 	public function testConnected()
 	{
 		// Remove the following lines when you implement this test.
 		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	/**
+	 * Test createDatabase with null param.
+	 *
+	 * @return   void
+	 *
+	 * @expectedException RuntimeException
+	 */
+	public function testCreateDatabase()
+	{
+		self::$driver->createDatabase(null);
 	}
 
 	/**
@@ -105,6 +145,45 @@ class JDatabaseMysqlTest extends TestCaseDatabaseMysql
 		$result = self::$driver->execute();
 
 		$this->assertThat(self::$driver->getAffectedRows(), $this->equalTo(4), __LINE__);
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql getAlterDbCharacterSet method.
+	 *
+	 * @return  void
+	 */
+	public function testGetAlterDbCharacterSet()
+	{
+		$expected = 'ALTER DATABASE ' . self::$driver->quoteName('test') . ' CHARACTER SET ' . self::$driver->quote('utf8');
+
+		$result = TestReflection::invoke(self::$driver, 'getAlterDbCharacterSet', 'test');
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Tests the JDatabaseMysqli getCreateDbQuery method.
+	 *
+	 * @param   JObject  $options  JObject coming from "initialise" function to pass user
+	 * 									and database name to database driver.
+	 * @param   boolean  $utf      True if the database supports the UTF-8 character set.
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider dataGetCreateDbQuery
+	 */
+	public function testGetCreateDatabaseQuery($options, $utf)
+	{
+		$expected = 'CREATE DATABASE ' . self::$driver->quoteName($options->db_name);
+
+		if ($utf)
+		{
+			$expected .= ' CHARACTER SET ' . self::$driver->quote('utf8');
+		}
+
+		$result = TestReflection::invoke(self::$driver, 'getCreateDatabaseQuery', $options, $utf);
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
 
 	/**

--- a/tests/suites/database/driver/mysql/JDatabaseMySQLTest.php
+++ b/tests/suites/database/driver/mysql/JDatabaseMySQLTest.php
@@ -148,7 +148,7 @@ class JDatabaseMysqlTest extends TestCaseDatabaseMysql
 	}
 
 	/**
-	 * Tests the JDatabasePostgresql getAlterDbCharacterSet method.
+	 * Tests the JDatabaseMysql getAlterDbCharacterSet method.
 	 *
 	 * @return  void
 	 */

--- a/tests/suites/database/driver/mysql/JDatabaseMySQLTest.php
+++ b/tests/suites/database/driver/mysql/JDatabaseMySQLTest.php
@@ -164,9 +164,9 @@ class JDatabaseMysqlTest extends TestCaseDatabaseMysql
 	/**
 	 * Tests the JDatabaseMysqli getCreateDbQuery method.
 	 *
-	 * @param   JObject  $options  JObject coming from "initialise" function to pass user
-	 * 									and database name to database driver.
-	 * @param   boolean  $utf      True if the database supports the UTF-8 character set.
+	 * @param   stdClass  $options  Object used to pass user and database name to database driver.
+	 * 									This object must have "db_name" and "db_user" set.
+	 * @param   boolean   $utf      True if the database supports the UTF-8 character set.
 	 *
 	 * @return  void
 	 *

--- a/tests/suites/database/driver/mysqli/JDatabaseMySQLiTest.php
+++ b/tests/suites/database/driver/mysqli/JDatabaseMySQLiTest.php
@@ -164,9 +164,9 @@ class JDatabaseMysqliTest extends TestCaseDatabaseMysqli
 	/**
 	 * Tests the JDatabaseMysqli getCreateDbQuery method.
 	 *
-	 * @param   JObject  $options  JObject coming from "initialise" function to pass user
-	 * 									and database name to database driver.
-	 * @param   boolean  $utf      True if the database supports the UTF-8 character set.
+	 * @param   stdClass  $options  Object used to pass user and database name to database driver.
+	 * 									This object must have "db_name" and "db_user" set.
+	 * @param   boolean   $utf      True if the database supports the UTF-8 character set.
 	 *
 	 * @return  void
 	 *

--- a/tests/suites/database/driver/mysqli/JDatabaseMySQLiTest.php
+++ b/tests/suites/database/driver/mysqli/JDatabaseMySQLiTest.php
@@ -148,7 +148,7 @@ class JDatabaseMysqliTest extends TestCaseDatabaseMysqli
 	}
 
 	/**
-	 * Tests the JDatabasePostgresql getAlterDbCharacterSet method.
+	 * Tests the JDatabaseMysqli getAlterDbCharacterSet method.
 	 *
 	 * @return  void
 	 */

--- a/tests/suites/database/driver/mysqli/JDatabaseMySQLiTest.php
+++ b/tests/suites/database/driver/mysqli/JDatabaseMySQLiTest.php
@@ -16,6 +16,22 @@
 class JDatabaseMysqliTest extends TestCaseDatabaseMysqli
 {
 	/**
+	 * Data for the getCreateDbQuery test.
+	 *
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	public function dataGetCreateDbQuery()
+	{
+		$obj = new stdClass;
+		$obj->db_user = 'testName';
+		$obj->db_name = 'testDb';
+
+		return array(array($obj, false), array($obj, true));
+	}
+
+	/**
 	 * Data for the testEscape test.
 	 *
 	 * @return  array
@@ -52,12 +68,36 @@ class JDatabaseMysqliTest extends TestCaseDatabaseMysqli
 	}
 
 	/**
+	 * Test alterDbCharacterSet with null param.
+	 *
+	 * @return   void
+	 *
+	 * @expectedException RuntimeException
+	 */
+	public function testAlterDbCharacterSet()
+	{
+		self::$driver->alterDbCharacterSet(null);
+	}
+
+	/**
 	 * @todo Implement testConnected().
 	 */
 	public function testConnected()
 	{
 		// Remove the following lines when you implement this test.
 		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	/**
+	 * Test createDatabase with null param.
+	 *
+	 * @return   void
+	 *
+	 * @expectedException RuntimeException
+	 */
+	public function testCreateDatabase()
+	{
+		self::$driver->createDatabase(null);
 	}
 
 	/**
@@ -105,6 +145,45 @@ class JDatabaseMysqliTest extends TestCaseDatabaseMysqli
 		$result = self::$driver->execute();
 
 		$this->assertThat(self::$driver->getAffectedRows(), $this->equalTo(4), __LINE__);
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql getAlterDbCharacterSet method.
+	 *
+	 * @return  void
+	 */
+	public function testGetAlterDbCharacterSet()
+	{
+		$expected = 'ALTER DATABASE ' . self::$driver->quoteName('test') . ' CHARACTER SET ' . self::$driver->quote('utf8');
+
+		$result = TestReflection::invoke(self::$driver, 'getAlterDbCharacterSet', 'test');
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Tests the JDatabaseMysqli getCreateDbQuery method.
+	 *
+	 * @param   JObject  $options  JObject coming from "initialise" function to pass user
+	 * 									and database name to database driver.
+	 * @param   boolean  $utf      True if the database supports the UTF-8 character set.
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider dataGetCreateDbQuery
+	 */
+	public function testGetCreateDatabaseQuery($options, $utf)
+	{
+		$expected = 'CREATE DATABASE ' . self::$driver->quoteName($options->db_name);
+
+		if ($utf)
+		{
+			$expected .= ' CHARACTER SET ' . self::$driver->quote('utf8');
+		}
+
+		$result = TestReflection::invoke(self::$driver, 'getCreateDatabaseQuery', $options, $utf);
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
 
 	/**

--- a/tests/suites/database/driver/postgresql/JDatabasePostgresqlTest.php
+++ b/tests/suites/database/driver/postgresql/JDatabasePostgresqlTest.php
@@ -259,6 +259,51 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 	}
 
 	/**
+	 * Test createDatabase with null database's name.
+	 *
+	 * @return   void
+	 *
+	 * @expectedException RuntimeException
+	 */
+	public function testCreateDatabase_nullDbName()
+	{
+		$obj = new JObject;
+		$obj->db_user = 'test';
+
+		self::$driver->createDatabase($obj);
+	}
+
+	/**
+	 * Test createDatabase with null user's name.
+	 *
+	 * @return   void
+	 *
+	 * @expectedException RuntimeException
+	 */
+	public function testCreateDatabase_nullUserName()
+	{
+		$obj = new JObject;
+		$obj->db_name = 'test';
+
+		self::$driver->createDatabase($obj);
+	}
+
+	/**
+	 * Test createDatabase with empty user's name.
+	 *
+	 * @return   void
+	 *
+	 * @expectedException RuntimeException
+	 */
+	public function testCreateDatabase_emptyUserName()
+	{
+		$obj = new JObject;
+		$obj->db_name = '';
+
+		self::$driver->createDatabase($obj);
+	}
+
+	/**
 	 * Tests the JDatabasePostgresql escape method.
 	 *
 	 * @param   string  $text    The string to be escaped.

--- a/tests/suites/database/driver/postgresql/JDatabasePostgresqlTest.php
+++ b/tests/suites/database/driver/postgresql/JDatabasePostgresqlTest.php
@@ -1179,7 +1179,7 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 
 		foreach (get_object_vars($tst) as $key => $val)
 		{
-			$values[] = self::$driver->sqlValue($tablCol, $key, $val);
+			$values[] = TestReflection::invoke(self::$driver, 'sqlValue', $tablCol, $key, $val);
 		}
 
 		$this->assertThat(

--- a/tests/suites/database/driver/postgresql/JDatabasePostgresqlTest.php
+++ b/tests/suites/database/driver/postgresql/JDatabasePostgresqlTest.php
@@ -225,6 +225,18 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 	}
 
 	/**
+	 * Test alterDbCharacterSet with null param.
+	 *
+	 * @return   void
+	 *
+	 * @expectedException RuntimeException
+	 */
+	public function testAlterDbCharacterSet()
+	{
+		self::$driver->alterDbCharacterSet(null);
+	}
+
+	/**
 	 * Check if connected() method returns true.
 	 *
 	 * @return   void
@@ -232,6 +244,18 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 	public function testConnected()
 	{
 		$this->assertThat(self::$driver->connected(), $this->equalTo(true), 'Not connected to database');
+	}
+
+	/**
+	 * Test createDatabase with null param.
+	 *
+	 * @return   void
+	 *
+	 * @expectedException RuntimeException
+	 */
+	public function testCreateDatabase()
+	{
+		self::$driver->createDatabase(null);
 	}
 
 	/**
@@ -268,6 +292,45 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 		$result = self::$driver->execute();
 
 		$this->assertThat(self::$driver->getAffectedRows(), $this->equalTo(4), __LINE__);
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql getCreateDbQuery method.
+	 *
+	 * @param   JObject  $options  JObject coming from "initialise" function to pass user
+	 * 									and database name to database driver.
+	 * @param   boolean  $utf      True if the database supports the UTF-8 character set.
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider dataGetCreateDbQuery
+	 */
+	public function testGetCreateDatabaseQuery($options, $utf)
+	{
+		$expected = 'CREATE DATABASE ' . self::$driver->quoteName($options->db_name) . ' OWNER ' . self::$driver->quoteName($options->db_user);
+
+		if ($utf)
+		{
+			$expected .= ' ENCODING ' . self::$driver->quote('UTF-8');
+		}
+
+		$result = TestReflection::invoke(self::$driver, 'getCreateDatabaseQuery', $options, $utf);
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Tests the JDatabasePostgresql getAlterDbCharacterSet method.
+	 *
+	 * @return  void
+	 */
+	public function testGetAlterDbCharacterSet()
+	{
+		$expected = 'ALTER DATABASE ' . self::$driver->quoteName('test') . ' SET CLIENT_ENCODING TO ' . self::$driver->quote('UTF8');
+
+		$result = TestReflection::invoke(self::$driver, 'getAlterDbCharacterSet', 'test');
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
 
 	/**
@@ -1345,44 +1408,5 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 	public function testTransactionSavepoint( /*$savepointName*/ )
 	{
 		$this->markTestSkipped('This command is tested inside testTransactionRollback.');
-	}
-
-	/**
-	 * Tests the JDatabasePostgresql getCreateDbQuery method.
-	 *
-	 * @param   JObject  $options  JObject coming from "initialise" function to pass user
-	 * 									and database name to database driver.
-	 * @param   boolean  $utf      True if the database supports the UTF-8 character set.
-	 *
-	 * @return  void
-	 *
-	 * @dataProvider dataGetCreateDbQuery
-	 */
-	public function testGetCreateDbQuery($options, $utf)
-	{
-		$expected = 'CREATE DATABASE ' . self::$driver->quoteName($options->db_name) . ' OWNER ' . self::$driver->quoteName($options->db_user);
-
-		if ($utf)
-		{
-			$expected .= ' ENCODING ' . self::$driver->quote('UTF-8');
-		}
-
-		$result = self::$driver->getCreateDbQuery($options, $utf);
-
-		$this->assertThat($result, $this->equalTo($expected), __LINE__);
-	}
-
-	/**
-	 * Tests the JDatabasePostgresql getAlterDbCharacterSet method.
-	 *
-	 * @return  void
-	 */
-	public function testGetAlterDbCharacterSet()
-	{
-		$expected = 'ALTER DATABASE ' . self::$driver->quoteName('test') . ' SET CLIENT_ENCODING TO ' . self::$driver->quote('UTF8');
-
-		$result = self::$driver->getAlterDbCharacterSet('test');
-
-		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
 }

--- a/tests/suites/database/driver/postgresql/JDatabasePostgresqlTest.php
+++ b/tests/suites/database/driver/postgresql/JDatabasePostgresqlTest.php
@@ -267,7 +267,7 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function testCreateDatabase_nullDbName()
 	{
-		$obj = new JObject;
+		$obj = new stdClass;
 		$obj->db_user = 'test';
 
 		self::$driver->createDatabase($obj);
@@ -282,7 +282,7 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function testCreateDatabase_nullUserName()
 	{
-		$obj = new JObject;
+		$obj = new stdClass;
 		$obj->db_name = 'test';
 
 		self::$driver->createDatabase($obj);
@@ -297,7 +297,7 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function testCreateDatabase_emptyUserName()
 	{
-		$obj = new JObject;
+		$obj = new stdClass;
 		$obj->db_name = '';
 
 		self::$driver->createDatabase($obj);
@@ -342,9 +342,9 @@ class JDatabasePostgresqlTest extends TestCaseDatabasePostgresql
 	/**
 	 * Tests the JDatabasePostgresql getCreateDbQuery method.
 	 *
-	 * @param   JObject  $options  JObject coming from "initialise" function to pass user
-	 * 									and database name to database driver.
-	 * @param   boolean  $utf      True if the database supports the UTF-8 character set.
+	 * @param   stdClass  $options  Object used to pass user and database name to database driver.
+	 * 									This object must have "db_name" and "db_user" set.
+	 * @param   boolean   $utf      True if the database supports the UTF-8 character set.
 	 *
 	 * @return  void
 	 *


### PR DESCRIPTION
Added two public method inside JDatabaseDriver:
- alterDbCharacterSet to change database's character set
- createDatabase to create a new database

AlterDbCharacterSet needs database name as parameter, createDatabase
needs a JObject, similar to that used inside CMS' "initialise" function,
and a bool to set UTF8 database's support.

They use two protected method to obtain correct query in database's
supported syntax:
- getAlterDbCharacterSet
- getCreateDatabaseQuery

Protected method inside JDatabaseDriver return query for MySQL and
MySQLi syntax, this commit contain also overridden version for
PostgreSQL database.

There are tests only for protected methods inside MySQL, MySQLi and
PostgreSQL test classes.
