### PR TITLE
Checkboxes fixes and tests

### DIFF
--- a/libraries/joomla/form/fields/checkboxes.php
+++ b/libraries/joomla/form/fields/checkboxes.php
@@ -69,8 +69,9 @@ class JFormFieldCheckboxes extends JFormField
 				$checked = (in_array((string) $option->value, (array) $checkedOptions) ? ' checked="checked"' : '');
 			}
 			else
-			{
-				$checked = (in_array((string) $option->value, explode(',', $this->value)) ? ' checked="checked"' : '');
+			{var_dump($this->value);
+				$value = !is_array($this->value) ? explode(',', $this->value) : $this->value;
+				$checked = (in_array((string) $option->value, $value) ? ' checked="checked"' : '');
 			}
 			$class = !empty($option->class) ? ' class="' . $option->class . '"' : '';
 			$disabled = !empty($option->disable) ? ' disabled="disabled"' : '';

--- a/libraries/joomla/form/fields/checkboxes.php
+++ b/libraries/joomla/form/fields/checkboxes.php
@@ -51,6 +51,7 @@ class JFormFieldCheckboxes extends JFormField
 
 		// Initialize some field attributes.
 		$class = $this->element['class'] ? ' class="checkboxes ' . (string) $this->element['class'] . '"' : ' class="checkboxes"';
+		$checkedOptions = explode(',',(string) $this->element['checked']);
 
 		// Start the checkbox field output.
 		$html[] = '<fieldset id="' . $this->id . '"' . $class . '>';
@@ -62,9 +63,15 @@ class JFormFieldCheckboxes extends JFormField
 		$html[] = '<ul>';
 		foreach ($options as $i => $option)
 		{
-
 			// Initialize some option attributes.
-			$checked = (in_array((string) $option->value, (array) $this->value) ? ' checked="checked"' : '');
+			if (empty($this->value))
+			{
+				$checked =  (in_array((string) $option->value, (array) $checkedOptions) ? ' checked="checked"' : '');
+			} 
+			else
+			{
+				$checked =  (in_array((string) $option->value, (array) $this->value) ? ' checked="checked"' : '');
+			}
 			$class = !empty($option->class) ? ' class="' . $option->class . '"' : '';
 			$disabled = !empty($option->disable) ? ' disabled="disabled"' : '';
 

--- a/libraries/joomla/form/fields/checkboxes.php
+++ b/libraries/joomla/form/fields/checkboxes.php
@@ -51,7 +51,7 @@ class JFormFieldCheckboxes extends JFormField
 
 		// Initialize some field attributes.
 		$class = $this->element['class'] ? ' class="checkboxes ' . (string) $this->element['class'] . '"' : ' class="checkboxes"';
-		$checkedOptions = explode(',',(string) $this->element['checked']);
+		$checkedOptions = explode(',', (string) $this->element['checked']);
 
 		// Start the checkbox field output.
 		$html[] = '<fieldset id="' . $this->id . '"' . $class . '>';
@@ -64,13 +64,13 @@ class JFormFieldCheckboxes extends JFormField
 		foreach ($options as $i => $option)
 		{
 			// Initialize some option attributes.
-			if (empty($this->value))
+			if (!isset($this->value) || empty($this->value))
 			{
-				$checked =  (in_array((string) $option->value, (array) $checkedOptions) ? ' checked="checked"' : '');
-			} 
+				$checked = (in_array((string) $option->value, (array) $checkedOptions) ? ' checked="checked"' : '');
+			}
 			else
 			{
-				$checked =  (in_array((string) $option->value, (array) $this->value) ? ' checked="checked"' : '');
+				$checked = (in_array((string) $option->value, explode(',', $this->value)) ? ' checked="checked"' : '');
 			}
 			$class = !empty($option->class) ? ' class="' . $option->class . '"' : '';
 			$disabled = !empty($option->disable) ? ' disabled="disabled"' : '';

--- a/libraries/joomla/form/fields/checkboxes.php
+++ b/libraries/joomla/form/fields/checkboxes.php
@@ -69,7 +69,7 @@ class JFormFieldCheckboxes extends JFormField
 				$checked = (in_array((string) $option->value, (array) $checkedOptions) ? ' checked="checked"' : '');
 			}
 			else
-			{var_dump($this->value);
+			{
 				$value = !is_array($this->value) ? explode(',', $this->value) : $this->value;
 				$checked = (in_array((string) $option->value, $value) ? ' checked="checked"' : '');
 			}

--- a/tests/suites/unit/joomla/form/fields/JFormFieldCheckboxesTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldCheckboxesTest.php
@@ -36,7 +36,7 @@ class JFormFieldCheckboxesTest extends TestCase
 	{
 		$formField = new JFormFieldCheckboxes;
 
-        // Test with no value, no checked element
+		// Test with no value, no checked element
 		$element = simplexml_load_string(
 			'<field name="color" type="checkboxes">
 			<option value="red">red</option>
@@ -62,7 +62,7 @@ class JFormFieldCheckboxesTest extends TestCase
 	{
 		$formField = new JFormFieldCheckboxes;
 
-        // Test with one value checked, no checked element
+		// Test with one value checked, no checked element
 		$element = simplexml_load_string(
 			'<field name="color" type="checkboxes">
 			<option value="red">red</option>
@@ -89,7 +89,7 @@ class JFormFieldCheckboxesTest extends TestCase
 	{
 		$formField = new JFormFieldCheckboxes;
 		
-        // Test with nothing checked, one value in checked element
+		// Test with nothing checked, one value in checked element
 		$element = simplexml_load_string(
 			'<field name="color" type="checkboxes" checked="blue">
 			<option value="red">red</option>
@@ -115,7 +115,7 @@ class JFormFieldCheckboxesTest extends TestCase
 	{
 		$formField = new JFormFieldCheckboxes;
 		
-        // Test with nothing checked, two values in checked element
+		// Test with nothing checked, two values in checked element
 		$element = simplexml_load_string(
 			'<field name="color" type="checkboxes" checked="red,blue">
 			<option value="red">red</option>
@@ -142,7 +142,7 @@ class JFormFieldCheckboxesTest extends TestCase
 	{
 		$formField = new JFormFieldCheckboxes;
 
-        // Test with one item checked, a different value in checked element
+		// Test with one item checked, a different value in checked element
 		$element = simplexml_load_string(
 			'<field name="color" type="checkboxes" checked="blue">
 			<option value="red">red</option>
@@ -158,8 +158,6 @@ class JFormFieldCheckboxesTest extends TestCase
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red" checked="checked"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
 			'The field with one value and a different value in the checked element did not produce the right html'
 		);
-
-		// TODO: Should check all the attributes have come in properly.
 	}
 
 	/**
@@ -171,7 +169,7 @@ class JFormFieldCheckboxesTest extends TestCase
 	{
 		$formField = new JFormFieldCheckboxes;
 
-        // Test with two values checked, no checked element
+		// Test with two values checked, no checked element
 		$element = simplexml_load_string(
 			'<field name="color" type="checkboxes">
 			<option value="yellow">yellow</option>
@@ -187,6 +185,7 @@ class JFormFieldCheckboxesTest extends TestCase
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="yellow" checked="checked"/><label for="myTestId0">yellow</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="green" checked="checked"/><label for="myTestId1">green</label></li></ul></fieldset>',
 			'The field with two values did not produce the right html'
 		);
+		// TODO: Should check any other attributes have come in properly.
 	}
 
 	/**

--- a/tests/suites/unit/joomla/form/fields/JFormFieldCheckboxesTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldCheckboxesTest.php
@@ -47,8 +47,8 @@ class JFormFieldCheckboxesTest extends TestCase
 		TestReflection::setValue($formField, 'name', 'myTestName');
 
 		$this->assertEquals(
-			TestReflection::invoke($formField, 'getInput'),
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
+			TestReflection::invoke($formField, 'getInput'),
 			'The field with no value and no checked values did not produce the right html'
 		);
 	}
@@ -74,8 +74,8 @@ class JFormFieldCheckboxesTest extends TestCase
 		TestReflection::setValue($formField, 'name', 'myTestName');
 
 		$this->assertEquals(
-			TestReflection::invoke($formField, 'getInput'),
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red" checked="checked"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
+			TestReflection::invoke($formField, 'getInput'),
 			'The field with one value did not produce the right html'
 		);
 	}
@@ -100,8 +100,8 @@ class JFormFieldCheckboxesTest extends TestCase
 		TestReflection::setValue($formField, 'name', 'myTestName');
 
 		$this->assertEquals(
-			TestReflection::invoke($formField, 'getInput'),
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue" checked="checked"/><label for="myTestId1">blue</label></li></ul></fieldset>',
+			TestReflection::invoke($formField, 'getInput'),
 			'The field with no values and one value in the checked element did not produce the right html'
 		);
 	}
@@ -127,8 +127,8 @@ class JFormFieldCheckboxesTest extends TestCase
 		TestReflection::setValue($formField, 'value', '""');
 
 		$this->assertEquals(
-			TestReflection::invoke($formField, 'getInput'),
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
+			TestReflection::invoke($formField, 'getInput'),
 			'The field with no values and two items in the checked element did not produce the right html'
 		);
 	}
@@ -154,8 +154,8 @@ class JFormFieldCheckboxesTest extends TestCase
 		TestReflection::setValue($formField, 'name', 'myTestName');
 
 		$this->assertEquals(
-			TestReflection::invoke($formField, 'getInput'),
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red" checked="checked"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
+			TestReflection::invoke($formField, 'getInput'),
 			'The field with one value and a different value in the checked element did not produce the right html'
 		);
 	}
@@ -181,8 +181,8 @@ class JFormFieldCheckboxesTest extends TestCase
 		TestReflection::setValue($formField, 'name', 'myTestName');
 
 		$this->assertEquals(
-			TestReflection::invoke($formField, 'getInput'),
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="yellow" checked="checked"/><label for="myTestId0">yellow</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="green" checked="checked"/><label for="myTestId1">green</label></li></ul></fieldset>',
+			TestReflection::invoke($formField, 'getInput'),
 			'The field with two values did not produce the right html'
 		);
 		// TODO: Should check any other attributes have come in properly.

--- a/tests/suites/unit/joomla/form/fields/JFormFieldCheckboxesTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldCheckboxesTest.php
@@ -81,6 +81,34 @@ class JFormFieldCheckboxesTest extends TestCase
 	}
 
 	/**
+	 * Test the getInput method with one value that is an array and no checked attribute.
+	 *
+	 * @since       12.2
+	 */
+	public function testGetInputValueArrayNoChecked()
+	{
+		$formField = new JFormFieldCheckboxes;
+
+		// Test with one value checked, no checked element
+		$element = simplexml_load_string(
+			'<field name="color" type="checkboxes">
+			<option value="red">red</option>
+			<option value="blue">blue</option>
+			</field>');
+		$valuearray = array ('red');
+		TestReflection::setValue($formField, 'element', $element);
+		TestReflection::setValue($formField, 'id', 'myTestId');
+		TestReflection::setValue($formField, 'value', $valuearray);
+		TestReflection::setValue($formField, 'name', 'myTestName');
+
+		$this->assertEquals(
+			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red" checked="checked"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
+			TestReflection::invoke($formField, 'getInput'),
+			'The field with one value did not produce the right html'
+		);
+	}
+
+	/**
 	 * Test the getInput method  with no value and one value in checked.
 	 *
 	 * @since       12.2

--- a/tests/suites/unit/joomla/form/fields/JFormFieldCheckboxesTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldCheckboxesTest.php
@@ -24,7 +24,6 @@ class JFormFieldCheckboxesTest extends TestCase
 	protected function setUp()
 	{
 		require_once JPATH_PLATFORM.'/joomla/form/fields/checkboxes.php';
-		include_once dirname(__DIR__).'/inspectors.php';
 	}
 
 	/**
@@ -34,7 +33,20 @@ class JFormFieldCheckboxesTest extends TestCase
 	 */
 	public function testGetInputNoValueNoChecked()
 	{
-		$formField = new JFormFieldCheckboxes;
+		$formFieldCheckboxes = $this->getMock('JFormFieldCheckboxes', array('getOptions'));
+
+		$option1 = new JObject;
+		$option1->set('value','red');
+		$option1->set('text','red');
+
+		$option2 = new JObject;
+		$option2->set('value','blue');
+		$option2->set('text','blue');
+
+		$optionsReturn = array($option1,$option2);
+		$formFieldCheckboxes->expects($this->any())
+							->method('getOptions')
+							->will($this->returnValue($optionsReturn));
 
 		// Test with no value, no checked element
 		$element = simplexml_load_string(
@@ -42,13 +54,13 @@ class JFormFieldCheckboxesTest extends TestCase
 			<option value="red">red</option>
 			<option value="blue">blue</option>
 			</field>');
-		TestReflection::setValue($formField, 'element', $element);
-		TestReflection::setValue($formField, 'id', 'myTestId');
-		TestReflection::setValue($formField, 'name', 'myTestName');
+		TestReflection::setValue($formFieldCheckboxes, 'element', $element);
+		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
+		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
 
 		$this->assertEquals(
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
-			TestReflection::invoke($formField, 'getInput'),
+			TestReflection::invoke($formFieldCheckboxes, 'getInput'),
 			'The field with no value and no checked values did not produce the right html'
 		);
 	}
@@ -60,7 +72,20 @@ class JFormFieldCheckboxesTest extends TestCase
 	 */
 	public function testGetInputValueNoChecked()
 	{
-		$formField = new JFormFieldCheckboxes;
+		$formFieldCheckboxes = $this->getMock('JFormFieldCheckboxes', array('getOptions'));
+
+		$option1 = new JObject;
+		$option1->set('value','red');
+		$option1->set('text','red');
+
+		$option2 = new JObject;
+		$option2->set('value','blue');
+		$option2->set('text','blue');
+
+		$optionsReturn = array($option1,$option2);
+		$formFieldCheckboxes->expects($this->any())
+							->method('getOptions')
+							->will($this->returnValue($optionsReturn));
 
 		// Test with one value checked, no checked element
 		$element = simplexml_load_string(
@@ -68,14 +93,14 @@ class JFormFieldCheckboxesTest extends TestCase
 			<option value="red">red</option>
 			<option value="blue">blue</option>
 			</field>');
-		TestReflection::setValue($formField, 'element', $element);
-		TestReflection::setValue($formField, 'id', 'myTestId');
-		TestReflection::setValue($formField, 'value', 'red');
-		TestReflection::setValue($formField, 'name', 'myTestName');
+		TestReflection::setValue($formFieldCheckboxes, 'element', $element);
+		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
+		TestReflection::setValue($formFieldCheckboxes, 'value', 'red');
+		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
 
 		$this->assertEquals(
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red" checked="checked"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
-			TestReflection::invoke($formField, 'getInput'),
+			TestReflection::invoke($formFieldCheckboxes, 'getInput'),
 			'The field with one value did not produce the right html'
 		);
 	}
@@ -87,7 +112,20 @@ class JFormFieldCheckboxesTest extends TestCase
 	 */
 	public function testGetInputValueArrayNoChecked()
 	{
-		$formField = new JFormFieldCheckboxes;
+		$formFieldCheckboxes = $this->getMock('JFormFieldCheckboxes', array('getOptions'));
+
+		$option1 = new JObject;
+		$option1->set('value','red');
+		$option1->set('text','red');
+
+		$option2 = new JObject;
+		$option2->set('value','blue');
+		$option2->set('text','blue');
+
+		$optionsReturn = array($option1,$option2);
+		$formFieldCheckboxes->expects($this->any())
+							->method('getOptions')
+							->will($this->returnValue($optionsReturn));
 
 		// Test with one value checked, no checked element
 		$element = simplexml_load_string(
@@ -96,14 +134,14 @@ class JFormFieldCheckboxesTest extends TestCase
 			<option value="blue">blue</option>
 			</field>');
 		$valuearray = array ('red');
-		TestReflection::setValue($formField, 'element', $element);
-		TestReflection::setValue($formField, 'id', 'myTestId');
-		TestReflection::setValue($formField, 'value', $valuearray);
-		TestReflection::setValue($formField, 'name', 'myTestName');
+		TestReflection::setValue($formFieldCheckboxes, 'element', $element);
+		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
+		TestReflection::setValue($formFieldCheckboxes, 'value', $valuearray);
+		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
 
 		$this->assertEquals(
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red" checked="checked"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
-			TestReflection::invoke($formField, 'getInput'),
+			TestReflection::invoke($formFieldCheckboxes, 'getInput'),
 			'The field with one value did not produce the right html'
 		);
 	}
@@ -115,7 +153,20 @@ class JFormFieldCheckboxesTest extends TestCase
 	 */
 	public function testGetInputNoValueOneChecked()
 	{
-		$formField = new JFormFieldCheckboxes;
+		$formFieldCheckboxes = $this->getMock('JFormFieldCheckboxes', array('getOptions'));
+
+		$option1 = new JObject;
+		$option1->set('value','red');
+		$option1->set('text','red');
+
+		$option2 = new JObject;
+		$option2->set('value','blue');
+		$option2->set('text','blue');
+
+		$optionsReturn = array($option1,$option2);
+		$formFieldCheckboxes->expects($this->any())
+							->method('getOptions')
+							->will($this->returnValue($optionsReturn));
 		
 		// Test with nothing checked, one value in checked element
 		$element = simplexml_load_string(
@@ -123,13 +174,13 @@ class JFormFieldCheckboxesTest extends TestCase
 			<option value="red">red</option>
 			<option value="blue">blue</option>
 			</field>');
-		TestReflection::setValue($formField, 'element', $element);
-		TestReflection::setValue($formField, 'id', 'myTestId');
-		TestReflection::setValue($formField, 'name', 'myTestName');
+		TestReflection::setValue($formFieldCheckboxes, 'element', $element);
+		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
+		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
 
 		$this->assertEquals(
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue" checked="checked"/><label for="myTestId1">blue</label></li></ul></fieldset>',
-			TestReflection::invoke($formField, 'getInput'),
+			TestReflection::invoke($formFieldCheckboxes, 'getInput'),
 			'The field with no values and one value in the checked element did not produce the right html'
 		);
 	}
@@ -141,7 +192,20 @@ class JFormFieldCheckboxesTest extends TestCase
 	 */
 	public function testGetInputNoValueTwoChecked()
 	{
-		$formField = new JFormFieldCheckboxes;
+		$formFieldCheckboxes = $this->getMock('JFormFieldCheckboxes', array('getOptions'));
+
+		$option1 = new JObject;
+		$option1->set('value','red');
+		$option1->set('text','red');
+
+		$option2 = new JObject;
+		$option2->set('value','blue');
+		$option2->set('text','blue');
+
+		$optionsReturn = array($option1,$option2);
+		$formFieldCheckboxes->expects($this->any())
+							->method('getOptions')
+							->will($this->returnValue($optionsReturn));
 		
 		// Test with nothing checked, two values in checked element
 		$element = simplexml_load_string(
@@ -149,14 +213,14 @@ class JFormFieldCheckboxesTest extends TestCase
 			<option value="red">red</option>
 			<option value="blue">blue</option>
 			</field>');
-		TestReflection::setValue($formField, 'element', $element);
-		TestReflection::setValue($formField, 'id', 'myTestId');
-		TestReflection::setValue($formField, 'name', 'myTestName');
-		TestReflection::setValue($formField, 'value', '""');
+		TestReflection::setValue($formFieldCheckboxes, 'element', $element);
+		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
+		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
+		TestReflection::setValue($formFieldCheckboxes, 'value', '""');
 
 		$this->assertEquals(
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
-			TestReflection::invoke($formField, 'getInput'),
+			TestReflection::invoke($formFieldCheckboxes, 'getInput'),
 			'The field with no values and two items in the checked element did not produce the right html'
 		);
 	}
@@ -168,7 +232,20 @@ class JFormFieldCheckboxesTest extends TestCase
 	 */
 	public function testGetInputValueChecked()
 	{
-		$formField = new JFormFieldCheckboxes;
+		$formFieldCheckboxes = $this->getMock('JFormFieldCheckboxes', array('getOptions'));
+
+		$option1 = new JObject;
+		$option1->set('value','red');
+		$option1->set('text','red');
+
+		$option2 = new JObject;
+		$option2->set('value','blue');
+		$option2->set('text','blue');
+
+		$optionsReturn = array($option1,$option2);
+		$formFieldCheckboxes->expects($this->any())
+							->method('getOptions')
+							->will($this->returnValue($optionsReturn));
 
 		// Test with one item checked, a different value in checked element
 		$element = simplexml_load_string(
@@ -176,14 +253,14 @@ class JFormFieldCheckboxesTest extends TestCase
 			<option value="red">red</option>
 			<option value="blue">blue</option>
 			</field>');
-		TestReflection::setValue($formField, 'element', $element);
-		TestReflection::setValue($formField, 'id', 'myTestId');
-		TestReflection::setValue($formField, 'value', 'red');
-		TestReflection::setValue($formField, 'name', 'myTestName');
+		TestReflection::setValue($formFieldCheckboxes, 'element', $element);
+		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
+		TestReflection::setValue($formFieldCheckboxes, 'value', 'red');
+		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
 
 		$this->assertEquals(
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red" checked="checked"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
-			TestReflection::invoke($formField, 'getInput'),
+			TestReflection::invoke($formFieldCheckboxes, 'getInput'),
 			'The field with one value and a different value in the checked element did not produce the right html'
 		);
 	}
@@ -195,25 +272,37 @@ class JFormFieldCheckboxesTest extends TestCase
 	 */
 	public function testGetInputValuesNoChecked()
 	{
-		$formField = new JFormFieldCheckboxes;
+	$formFieldCheckboxes = $this->getMock('JFormFieldCheckboxes', array('getOptions'));
+
+		$option1 = new JObject;
+		$option1->set('value','red');
+		$option1->set('text','red');
+
+		$option2 = new JObject;
+		$option2->set('value','blue');
+		$option2->set('text','blue');
+
+		$optionsReturn = array($option1,$option2);
+		$formFieldCheckboxes->expects($this->any())
+							->method('getOptions')
+							->will($this->returnValue($optionsReturn));
 
 		// Test with two values checked, no checked element
 		$element = simplexml_load_string(
 			'<field name="color" type="checkboxes">
-			<option value="yellow">yellow</option>
-			<option value="green">green</option>
+			<option value="red">red</option>
+			<option value="blue">blue</option>
 			</field>');
-		TestReflection::setValue($formField, 'element', $element);
-		TestReflection::setValue($formField, 'id', 'myTestId');
-		TestReflection::setValue($formField, 'value', 'yellow,green');
-		TestReflection::setValue($formField, 'name', 'myTestName');
+		TestReflection::setValue($formFieldCheckboxes, 'element', $element);
+		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
+		TestReflection::setValue($formFieldCheckboxes, 'value', 'yellow,green');
+		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
 
 		$this->assertEquals(
-			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="yellow" checked="checked"/><label for="myTestId0">yellow</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="green" checked="checked"/><label for="myTestId1">green</label></li></ul></fieldset>',
-			TestReflection::invoke($formField, 'getInput'),
+			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
+			TestReflection::invoke($formFieldCheckboxes, 'getInput'),
 			'The field with two values did not produce the right html'
 		);
-		// TODO: Should check any other attributes have come in properly.
 	}
 
 	/**
@@ -223,6 +312,35 @@ class JFormFieldCheckboxesTest extends TestCase
 	 */
 	public function testGetOptions()
 	{
-		$this->markTestIncomplete();	
+		$formFieldCheckboxes = new JFormFieldCheckboxes;
+
+		$option1 = new JObject;
+		$option1->set('value','yellow');
+		$option1->set('text','yellow');
+		$option1->set('disable',false);
+		$option1->set('class','');
+		$option1->set('onclick','');
+
+		$option2 = new JObject;
+		$option2->set('value','green');
+		$option2->set('text','green');
+		$option2->set('disable',false);
+		$option2->set('class','');
+		$option2->set('onclick','');
+
+		$optionsExpected = array($option1,$option2);
+
+		// Test with two values checked, no checked element
+		TestReflection::setValue($formFieldCheckboxes, 'element', simplexml_load_string(
+			'<field name="color" type="checkboxes">
+			<option value="yellow">yellow</option>
+			<option value="green">green</option>
+			</field>'));
+
+		$this->assertEquals(
+			$optionsExpected,
+			TestReflection::invoke($formFieldCheckboxes, 'getOptions'),
+			'The field with two values did not produce the right options'
+		);
 	}
 }

--- a/tests/suites/unit/joomla/form/fields/JFormFieldCheckboxesTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldCheckboxesTest.php
@@ -28,24 +28,174 @@ class JFormFieldCheckboxesTest extends TestCase
 	}
 
 	/**
-	 * Test the getInput method.
+	 * Test the getInput method with no value and no checked attribute.
 	 *
-	 * @since       11.3
+	 * @since       12.2
 	 */
-	public function testGetInput()
+	public function testGetInputNoValueNoChecked()
 	{
-		$form = new JFormInspector('form1');
+		$formField = new JFormFieldCheckboxes;
 
-		$this->assertThat(
-			$form->load('<form><field name="checkboxes" type="checkboxes" /></form>'),
-			$this->isTrue(),
-			'Line:'.__LINE__.' XML string should load successfully.'
+        // Test with no value, no checked element
+		$element = simplexml_load_string(
+			'<field name="color" type="checkboxes">
+			<option value="red">red</option>
+			<option value="blue">blue</option>
+			</field>');
+		TestReflection::setValue($formField, 'element', $element);
+		TestReflection::setValue($formField, 'id', 'myTestId');
+		TestReflection::setValue($formField, 'name', 'myTestName');
+
+		$this->assertEquals(
+			TestReflection::invoke($formField, 'getInput'),
+			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
+			'The field with no value and no checked values did not produce the right html'
+		);
+	}
+
+	/**
+	 * Test the getInput method with one value selected and no checked attribute.
+	 *
+	 * @since       12.2
+	 */
+	public function testGetInputValueNoChecked()
+	{
+		$formField = new JFormFieldCheckboxes;
+
+        // Test with one value checked, no checked element
+		$element = simplexml_load_string(
+			'<field name="color" type="checkboxes">
+			<option value="red">red</option>
+			<option value="blue">blue</option>
+			</field>');
+		TestReflection::setValue($formField, 'element', $element);
+		TestReflection::setValue($formField, 'id', 'myTestId');
+		TestReflection::setValue($formField, 'value', 'red');
+		TestReflection::setValue($formField, 'name', 'myTestName');
+
+		$this->assertEquals(
+			TestReflection::invoke($formField, 'getInput'),
+			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red" checked="checked"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
+			'The field with one value did not produce the right html'
+		);
+	}
+
+	/**
+	 * Test the getInput method  with no value and one value in checked.
+	 *
+	 * @since       12.2
+	 */
+	public function testGetInputNoValueOneChecked()
+	{
+		$formField = new JFormFieldCheckboxes;
+		
+        // Test with nothing checked, one value in checked element
+		$element = simplexml_load_string(
+			'<field name="color" type="checkboxes" checked="blue">
+			<option value="red">red</option>
+			<option value="blue">blue</option>
+			</field>');
+		TestReflection::setValue($formField, 'element', $element);
+		TestReflection::setValue($formField, 'id', 'myTestId');
+		TestReflection::setValue($formField, 'name', 'myTestName');
+
+		$this->assertEquals(
+			TestReflection::invoke($formField, 'getInput'),
+			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue" checked="checked"/><label for="myTestId1">blue</label></li></ul></fieldset>',
+			'The field with no values and one value in the checked element did not produce the right html'
+		);
+	}
+
+	/**
+	 * Test the getInput method with no value and two values in the checked element.
+	 *
+	 * @since       12.2
+	 */
+	public function testGetInputNoValueTwoChecked()
+	{
+		$formField = new JFormFieldCheckboxes;
+		
+        // Test with nothing checked, two values in checked element
+		$element = simplexml_load_string(
+			'<field name="color" type="checkboxes" checked="red,blue">
+			<option value="red">red</option>
+			<option value="blue">blue</option>
+			</field>');
+		TestReflection::setValue($formField, 'element', $element);
+		TestReflection::setValue($formField, 'id', 'myTestId');
+		TestReflection::setValue($formField, 'name', 'myTestName');
+		TestReflection::setValue($formField, 'value', '""');
+
+		$this->assertEquals(
+			TestReflection::invoke($formField, 'getInput'),
+			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
+			'The field with no values and two items in the checked element did not produce the right html'
+		);
+	}
+
+	/**
+	 * Test the getInput method with one value and a different checked value.
+	 *
+	 * @since       12.2
+	 */
+	public function testGetInputValueChecked()
+	{
+		$formField = new JFormFieldCheckboxes;
+
+        // Test with one item checked, a different value in checked element
+		$element = simplexml_load_string(
+			'<field name="color" type="checkboxes" checked="blue">
+			<option value="red">red</option>
+			<option value="blue">blue</option>
+			</field>');
+		TestReflection::setValue($formField, 'element', $element);
+		TestReflection::setValue($formField, 'id', 'myTestId');
+		TestReflection::setValue($formField, 'value', 'red');
+		TestReflection::setValue($formField, 'name', 'myTestName');
+
+		$this->assertEquals(
+			TestReflection::invoke($formField, 'getInput'),
+			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red" checked="checked"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
+			'The field with one value and a different value in the checked element did not produce the right html'
 		);
 
-		$field = new JFormFieldCheckboxes($form);
-
-		$this->markTestIncomplete();
-
 		// TODO: Should check all the attributes have come in properly.
+	}
+
+	/**
+	 * Test the getInput method with multiple values, no checked.
+	 *
+	 * @since       12.2
+	 */
+	public function testGetInputValuesNoChecked()
+	{
+		$formField = new JFormFieldCheckboxes;
+
+        // Test with two values checked, no checked element
+		$element = simplexml_load_string(
+			'<field name="color" type="checkboxes">
+			<option value="yellow">yellow</option>
+			<option value="green">green</option>
+			</field>');
+		TestReflection::setValue($formField, 'element', $element);
+		TestReflection::setValue($formField, 'id', 'myTestId');
+		TestReflection::setValue($formField, 'value', 'yellow,green');
+		TestReflection::setValue($formField, 'name', 'myTestName');
+
+		$this->assertEquals(
+			TestReflection::invoke($formField, 'getInput'),
+			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="yellow" checked="checked"/><label for="myTestId0">yellow</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="green" checked="checked"/><label for="myTestId1">green</label></li></ul></fieldset>',
+			'The field with two values did not produce the right html'
+		);
+	}
+
+	/**
+	 * Test the getOptions method.
+	 *
+	 * @since       12.2
+	 */
+	public function testGetOptions()
+	{
+		$this->markTestIncomplete();	
 	}
 }


### PR DESCRIPTION
This fixes a few issues in the checkboxes field and adds detailed tests.
1. Formerly the field was not checking for stored data when rendering, so it was always using the information from the field definition. Going to the field definition is now conditioned on there not being an existing value.
2. Formerly selecting more than one item to be checked (preset) was not working because the array of checked values was not being created correctly. 
Checkboxes continues to have the limitation that it cannot distinguish between a field that is deliberately saved as empty and one that has never been  saved, so if the checked element is used it will always render with the checked items when the form is reopened. This is inherent to the structure of the checkboxes field type so developers should be aware of that and use the checked attribute with caution or consider using a "none of the above" option to force a value to be saved.
