### PR TITLE
Remove references to zend.ze1_compatibility_mode.

### DIFF
--- a/tests/bootstrap.legacy.php
+++ b/tests/bootstrap.legacy.php
@@ -18,7 +18,6 @@ define('_JEXEC', 1);
 @ini_set('magic_quotes_runtime', 0);
 
 // Maximise error reporting.
-@ini_set('zend.ze1_compatibility_mode', '0');
 error_reporting(E_ALL & ~E_STRICT);
 ini_set('display_errors', 1);
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,7 +18,6 @@ define('_JEXEC', 1);
 @ini_set('magic_quotes_runtime', 0);
 
 // Maximise error reporting.
-@ini_set('zend.ze1_compatibility_mode', '0');
 error_reporting(E_ALL & ~E_STRICT);
 ini_set('display_errors', 1);
 


### PR DESCRIPTION
It has been removed in PHP 5.3.
