### PR TITLE
Remove dependency on JObject from JApplicationBase.

### DIFF
--- a/libraries/joomla/application/base.php
+++ b/libraries/joomla/application/base.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Application
  * @since       12.1
  */
-abstract class JApplicationBase extends JObject
+abstract class JApplicationBase
 {
 	/**
 	 * The application dispatcher object.

--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -629,7 +629,7 @@ class JCache
 		$app = JFactory::getApplication();
 
 		// Get url parameters set by plugins
-		$registeredurlparams = $app->get('registeredurlparams');
+		$registeredurlparams = $app->registeredurlparams;
 
 		// Platform defaults
 		$registeredurlparams->format = 'WORD';

--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -132,10 +132,10 @@ class JApplication extends JApplicationBase
 
 		$this->loadDispatcher();
 
-		$this->set('requestTime', gmdate('Y-m-d H:i'));
+		$this->requestTime = gmdate('Y-m-d H:i');
 
 		// Used by task system to ensure that the system doesn't go over time.
-		$this->set('startTime', JProfiler::getmicrotime());
+		$this->startTime = JProfiler::getmicrotime();
 	}
 
 	/**

--- a/libraries/legacy/controller/controller.php
+++ b/libraries/legacy/controller/controller.php
@@ -648,7 +648,7 @@ class JController extends JObject
 			{
 				$app = JFactory::getApplication();
 
-				$registeredurlparams = $app->get('registeredurlparams');
+				$registeredurlparams = $app->registeredurlparams;
 
 				if (empty($registeredurlparams))
 				{
@@ -661,11 +661,10 @@ class JController extends JObject
 					$registeredurlparams->$key = $value;
 				}
 
-				$app->set('registeredurlparams', $registeredurlparams);
+				$app->registeredurlparams = $registeredurlparams;
 			}
 
 			$cache->get($view, 'display');
-
 		}
 		else
 		{


### PR DESCRIPTION
Causes some small backwards compatibility problems in the CMS but overall still a good idea.

Special pull request for @LouisLandry
