### PR TITLE
Add support for changing the default schema when connecting to Oracle.

### DIFF
--- a/libraries/joomla/database/driver/oracle.php
+++ b/libraries/joomla/database/driver/oracle.php
@@ -102,6 +102,11 @@ class JDatabaseDriverOracle extends JDatabaseDriverPdo
 
 		parent::connect();
 
+		if (isset($this->options['schema']))
+		{
+			$this->setQuery('ALTER SESSION SET CURRENT_SCHEMA = ' . $this->quoteName($this->options['schema']))->execute();
+		}
+
 		$this->setDateFormat($this->dateformat);
 	}
 


### PR DESCRIPTION
This pull request adds support for changing the default schema when connecting to an Oracle database. This is useful for when the user connecting isn't the same user as the desired schema where the Oracle tables are being stored. This adds a new `schema` option to the supported options for Oracle. Schema is similar to database name in other systems however as Oracle treats database names differently when connecting this is a distinct option.
