### PR TITLE
Add "preset" attribute to form fields and adapt list/checkboxes multiple default/selected values

### DIFF
--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -166,6 +166,22 @@ abstract class JFormField
 	protected $value;
 
 	/**
+	 * The default value of the form field.
+	 *
+	 * @var    mixed
+	 * @since  12.2
+	 */
+	protected $default;
+
+	/**
+	 * The preset value of the form field.
+	 *
+	 * @var    mixed
+	 * @since  12.2
+	 */
+	protected $preset;
+
+	/**
 	 * The label's CSS class of the form field
 	 *
 	 * @var    mixed
@@ -272,6 +288,12 @@ abstract class JFormField
 			case 'title':
 				return $this->getTitle();
 				break;
+			case 'default':
+				return $this->getDefault();
+				break;
+			case 'preset':
+				return $this->getPreset();
+				break;
 		}
 
 		return null;
@@ -292,6 +314,87 @@ abstract class JFormField
 		$this->formControl = $form->getFormControl();
 
 		return $this;
+	}
+
+	/**
+	 * Method to get the preset value for a field (used for setup)
+	 *
+	 * @return  mixed  The preset value
+	 *
+	 * @since   12.2
+	 */
+	protected function getPreset()
+	{
+		if (!isset($this->preset))
+		{
+			if (isset($this->element['preset']))
+			{
+				/*
+				 * Get the value for the form field if not set.
+				 * Default to the translated version of the 'preset' attribute
+				 * if 'translate_preset' attribute if set to 'true' or '1'
+				 * else the value of the 'preset' attribute for the field.
+				 */
+				$preset = (string) $this->element['preset'];
+				if (($translate = $this->element['translate_preset']) && ((string) $translate == 'true' || (string) $translate == '1'))
+				{
+					$lang = JFactory::getLanguage();
+					if ($lang->hasKey($preset))
+					{
+						$debug = $lang->setDebug(false);
+						$preset = JText::_($preset);
+						$lang->setDebug($debug);
+					}
+					else
+					{
+						$preset = JText::_($preset);
+					}
+				}
+			}
+			else
+			{
+				$preset = self::getDefault();
+			}
+			$this->preset = $preset;
+		}
+		return $this->preset;
+	}
+
+	/**
+	 * Method to get the default value for a field (used for filtering)
+	 *
+	 * @return  mixed  The default value
+	 *
+	 * @since   12.2
+	 */
+	protected function getDefault()
+	{
+		if (!isset($this->default))
+		{
+			/*
+			 * Get the value for the form field if not set.
+			 * Default to the translated version of the 'default' attribute
+			 * if 'translate_default' attribute if set to 'true' or '1'
+			 * else the value of the 'default' attribute for the field.
+			 */
+			$default = (string) $this->element['default'];
+			if (($translate = $this->element['translate_default']) && ((string) $translate == 'true' || (string) $translate == '1'))
+			{
+				$lang = JFactory::getLanguage();
+				if ($lang->hasKey($default))
+				{
+					$debug = $lang->setDebug(false);
+					$default = JText::_($default);
+					$lang->setDebug($debug);
+				}
+				else
+				{
+					$default = JText::_($default);
+				}
+			}
+			$this->default = $default;
+		}
+		return $this->default;
 	}
 
 	/**
@@ -378,7 +481,14 @@ abstract class JFormField
 		$this->id = $this->getId($id, $this->fieldname);
 
 		// Set the field default value.
-		$this->value = $value;
+		if ($value === null)
+		{
+			$this->value = $this->getPreset();
+		}
+		else
+		{
+			$this->value = $value;
+		}
 
 		// Set the CSS class of field label
 		$this->labelClass = (string) $element['labelclass'];

--- a/libraries/joomla/form/fields/checkboxes.php
+++ b/libraries/joomla/form/fields/checkboxes.php
@@ -51,7 +51,6 @@ class JFormFieldCheckboxes extends JFormField
 
 		// Initialize some field attributes.
 		$class = $this->element['class'] ? ' class="checkboxes ' . (string) $this->element['class'] . '"' : ' class="checkboxes"';
-		$checkedOptions = explode(',', (string) $this->element['checked']);
 
 		// Start the checkbox field output.
 		$html[] = '<fieldset id="' . $this->id . '"' . $class . '>';
@@ -64,15 +63,7 @@ class JFormFieldCheckboxes extends JFormField
 		foreach ($options as $i => $option)
 		{
 			// Initialize some option attributes.
-			if (!isset($this->value) || empty($this->value))
-			{
-				$checked = (in_array((string) $option->value, (array) $checkedOptions) ? ' checked="checked"' : '');
-			}
-			else
-			{
-				$value = !is_array($this->value) ? explode(',', $this->value) : $this->value;
-				$checked = (in_array((string) $option->value, $value) ? ' checked="checked"' : '');
-			}
+			$checked = (in_array((string) $option->value, (array) $this->value) ? ' checked="checked"' : '');
 			$class = !empty($option->class) ? ' class="' . $option->class . '"' : '';
 			$disabled = !empty($option->disable) ? ' disabled="disabled"' : '';
 
@@ -134,5 +125,58 @@ class JFormFieldCheckboxes extends JFormField
 		reset($options);
 
 		return $options;
+	}
+
+	/**
+	 * Method to get the field default value.
+	 *
+	 * @return  mixed  The field default value.
+	 *
+	 * @since   12.2
+	 */
+	protected function getDefault()
+	{
+		$default = parent::getDefault();
+		if ($default == '')
+		{
+			// Initialize variables.
+			$default = array();
+
+			foreach ($this->element->xpath('option[@default="true"]') as $option)
+			{
+				$default[] = (string) $option['value'];
+			}
+		}
+		return $default;
+	}
+
+	/**
+	 * Method to get the field preset value.
+	 *
+	 * @return  mixed  The field default value.
+	 *
+	 * @since   12.2
+	 */
+	protected function getPreset()
+	{
+		$preset = parent::getPreset();
+		if ($preset == '')
+		{
+			if (isset($this->element['checked']))
+			{
+				$preset = explode(',', $this->element['checked']);
+			}
+			else
+			{
+				// Initialize variables.
+				$preset = array();
+
+				foreach ($this->element->xpath('option[@checked="true"]') as $option)
+				{
+					$preset[] = (string) $option['value'];
+				}
+			}
+		}
+		return $preset;
 	}
 }

--- a/libraries/joomla/form/fields/groupedlist.php
+++ b/libraries/joomla/form/fields/groupedlist.php
@@ -178,4 +178,57 @@ class JFormFieldGroupedList extends JFormField
 
 		return implode($html);
 	}
+
+	/**
+	 * Method to get the field default value.
+	 *
+	 * @return  mixed  The field default value.
+	 *
+	 * @since   12.2
+	 */
+	protected function getDefault()
+	{
+		$default = parent::getDefault();
+		if ($this->multiple && $default == '')
+		{
+			// Initialize variables.
+			$default = array();
+
+			foreach ($this->element->xpath('//option[@default="true"]') as $option)
+			{
+				$default[] = (string) $option['value'];
+			}
+		}
+		return $default;
+	}
+
+	/**
+	 * Method to get the field preset value.
+	 *
+	 * @return  mixed  The field default value.
+	 *
+	 * @since   12.2
+	 */
+	protected function getPreset()
+	{
+		$preset = parent::getPreset();
+		if ($this->multiple && $preset == '')
+		{
+			if (isset($this->element['selected']))
+			{
+				$preset = explode(',', $this->element['selected']);
+			}
+			else
+			{
+				// Initialize variables.
+				$preset = array();
+
+				foreach ($this->element->xpath('//option[@selected="true"]') as $option)
+				{
+					$preset[] = (string) $option['value'];
+				}
+			}
+		}
+		return $preset;
+	}
 }

--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -59,16 +59,22 @@ class JFormFieldList extends JFormField
 		// Get the field options.
 		$options = (array) $this->getOptions();
 
+		// Get the value
+		$values = (array) $this->value;
+
 		// Create a read-only list (no name) with a hidden input to store the value.
 		if ((string) $this->element['readonly'] == 'true')
 		{
-			$html[] = JHtml::_('select.genericlist', $options, '', trim($attr), 'value', 'text', $this->value, $this->id);
-			$html[] = '<input type="hidden" name="' . $this->name . '" value="' . $this->value . '"/>';
+			$html[] = JHtml::_('select.genericlist', $options, '', trim($attr), 'value', 'text', $values, $this->id);
+			foreach ($values as $value)
+			{
+				$html[] = '<input type="hidden" name="' . $this->name . '" value="' . $value . '"/>';
+			}
 		}
 		// Create a regular list.
 		else
 		{
-			$html[] = JHtml::_('select.genericlist', $options, $this->name, trim($attr), 'value', 'text', $this->value, $this->id);
+			$html[] = JHtml::_('select.genericlist', $options, $this->name, trim($attr), 'value', 'text', $values, $this->id);
 		}
 
 		return implode($html);
@@ -115,5 +121,58 @@ class JFormFieldList extends JFormField
 		reset($options);
 
 		return $options;
+	}
+
+	/**
+	 * Method to get the field default value.
+	 *
+	 * @return  mixed  The field default value.
+	 *
+	 * @since   12.2
+	 */
+	protected function getDefault()
+	{
+		$default = parent::getDefault();
+		if ($this->multiple && $default == '')
+		{
+			// Initialize variables.
+			$default = array();
+
+			foreach ($this->element->xpath('option[@default="true"]') as $option)
+			{
+				$default[] = (string) $option['value'];
+			}
+		}
+		return $default;
+	}
+
+	/**
+	 * Method to get the field preset value.
+	 *
+	 * @return  mixed  The field default value.
+	 *
+	 * @since   12.2
+	 */
+	protected function getPreset()
+	{
+		$preset = parent::getPreset();
+		if ($this->multiple && $preset == '')
+		{
+			if (isset($this->element['selected']))
+			{
+				$preset = explode(',', $this->element['selected']);
+			}
+			else
+			{
+				// Initialize variables.
+				$preset = array();
+
+				foreach ($this->element->xpath('option[@selected="true"]') as $option)
+				{
+					$preset[] = (string) $option['value'];
+				}
+			}
+		}
+		return $preset;
 	}
 }

--- a/tests/suites/unit/joomla/form/JFormDataHelper.php
+++ b/tests/suites/unit/joomla/form/JFormDataHelper.php
@@ -89,6 +89,8 @@ class JFormDataHelper
 			name="params"
 			description="Optional Settings">
 			<field
+				name="show_image" filter="int" default="1" />
+			<field
 				name="show_title" filter="int" />
 			<fieldset
 				name="basic">
@@ -249,6 +251,11 @@ class JFormDataHelper
 			name="title"
 			type="text"
 			description="The title." />
+		<field
+			name="alias"
+			type="text"
+			description="The alias."
+			preset="preset-alias" />
 		<fields
 			name="params">
 			<field
@@ -370,6 +377,11 @@ class JFormDataHelper
 			label="Title"
 			description="The title." />
 
+		<field
+			name="unexisting"
+			type="unexisting"
+		/>
+
 		<fields
 			name="params">
 			<field
@@ -406,6 +418,12 @@ class JFormDataHelper
 			name="translate_default"
 			default="DEFAULT_KEY"
 			translate_default="true"
+			type="text"/>
+
+		<field
+			name="translate_preset"
+			preset="PRESET_KEY"
+			translate_preset="true"
 			type="text"/>
 	</fields>
 </form>';

--- a/tests/suites/unit/joomla/form/JFormFieldTest.php
+++ b/tests/suites/unit/joomla/form/JFormFieldTest.php
@@ -518,4 +518,121 @@ class JFormFieldTest extends TestCase
 			'Line:'.__LINE__.' The property should be computed from the XML.'
 		);
 	}
+
+	/**
+	 * Tests the JFormField::getDefault method
+	 */
+	public function testGetDefault()
+	{
+		$form = new JFormInspector('form1');
+
+		$this->assertThat(
+			$form->load(JFormDataHelper::$loadFieldDocument),
+			$this->isTrue(),
+			'Line:'.__LINE__.' XML string should load successfully.'
+		);
+
+		$xml = $form->getXML();
+		$translate_default = array_pop($xml->xpath('fields/field[@name="translate_default"]'));
+
+		// Standard usage.
+		$field = new JFormFieldInspector($form);
+		$this->assertThat(
+			$field->setup($translate_default, null),
+			$this->isTrue(),
+			'Line:'.__LINE__.' The setup method should return true if successful.'
+		);
+
+		$this->assertThat(
+			$field->default,
+			$this->equalTo('DEFAULT_KEY'),
+			'Line:'.__LINE__.' The property should be computed from the XML.'
+		);
+
+		// With key language
+		$lang = JFactory::getLanguage();
+		JFactory::$language = new JLanguage();
+		JFactory::$language->load('form_test', __DIR__);
+
+		$field = new JFormFieldInspector($form);
+		$this->assertThat(
+			$field->setup($translate_default, null),
+			$this->isTrue(),
+			'Line:'.__LINE__.' The setup method should return true if successful.'
+		);
+
+		$this->assertThat(
+			$field->default,
+			$this->equalTo('My Default'),
+			'Line:'.__LINE__.' The property should be computed from the XML.'
+		);
+
+		JFactory::$language = $lang;
+	}
+
+	/**
+	 * Tests the JFormField::getPreset method
+	 */
+	public function testGetPreset()
+	{
+		$form = new JFormInspector('form1');
+
+		$this->assertThat(
+			$form->load(JFormDataHelper::$loadFieldDocument),
+			$this->isTrue(),
+			'Line:'.__LINE__.' XML string should load successfully.'
+		);
+
+		$xml = $form->getXML();
+		$translate_preset = array_pop($xml->xpath('fields/field[@name="translate_preset"]'));
+		$translate_default = array_pop($xml->xpath('fields/field[@name="translate_default"]'));
+
+		// Standard usage
+		$field = new JFormFieldInspector($form);
+		$this->assertThat(
+			$field->setup($translate_preset, null),
+			$this->isTrue(),
+			'Line:'.__LINE__.' The setup method should return true if successful.'
+		);
+
+		$this->assertThat(
+			$field->preset,
+			$this->equalTo('PRESET_KEY'),
+			'Line:'.__LINE__.' The property should be computed from the XML.'
+		);
+
+		// Using default as a fallback
+		$field = new JFormFieldInspector($form);
+		$this->assertThat(
+			$field->setup($translate_default, null),
+			$this->isTrue(),
+			'Line:'.__LINE__.' The setup method should return true if successful.'
+		);
+
+		$this->assertThat(
+			$field->preset,
+			$this->equalTo('DEFAULT_KEY'),
+			'Line:'.__LINE__.' The property should be computed from the XML.'
+		);
+
+		// With key language
+		$lang = JFactory::getLanguage();
+		JFactory::$language = new JLanguage();
+		JFactory::$language->load('form_test', __DIR__);
+
+		$field = new JFormFieldInspector($form);
+		$this->assertThat(
+			$field->setup($translate_preset, null),
+			$this->isTrue(),
+			'Line:'.__LINE__.' The setup method should return true if successful.'
+		);
+
+		$this->assertThat(
+			$field->preset,
+			$this->equalTo('My Preset'),
+			'Line:'.__LINE__.' The property should be computed from the XML.'
+		);
+
+		JFactory::$language = $lang;
+	}
 }

--- a/tests/suites/unit/joomla/form/JFormTest.php
+++ b/tests/suites/unit/joomla/form/JFormTest.php
@@ -316,6 +316,12 @@ class JFormTest extends TestCase
 		);
 
 		$this->assertThat(
+			$filtered['params']['show_image'],
+			$this->equalTo(1),
+			'Line:'.__LINE__.' The nested variable should be present.'
+		);
+
+		$this->assertThat(
 			$filtered['params']['show_author'],
 			$this->equalTo(0),
 			'Line:'.__LINE__.' The nested variable should be present.'
@@ -814,10 +820,17 @@ class JFormTest extends TestCase
 			'Line:'.__LINE__.' Prior to binding data, the defaults in the field should be used.'
 		);
 
+		$this->assertThat(
+			$form->getField('alias')->value,
+			$this->equalTo('preset-alias'),
+			'Line:'.__LINE__.' Prior to binding data, the presets in the field should be used.'
+		);
+
 		// Check values after binding.
 
 		$data = array(
 			'title' => 'The title',
+			'alias' => '',
 			'show_title' => 3,
 			'params' => array(
 				'show_title' => 2,
@@ -833,6 +846,12 @@ class JFormTest extends TestCase
 		$this->assertThat(
 			$form->getField('title')->value,
 			$this->equalTo('The title'),
+			'Line:'.__LINE__.' Check the field value bound correctly.'
+		);
+
+		$this->assertThat(
+			$form->getField('alias')->value,
+			$this->equalTo(''),
 			'Line:'.__LINE__.' Check the field value bound correctly.'
 		);
 
@@ -1421,10 +1440,23 @@ class JFormTest extends TestCase
 			'Line:'.__LINE__.' An unknown field should return false.'
 		);
 
+		$this->assertThat(
+			$form->loadField('bogus'),
+			$this->isFalse(),
+			'Line:'.__LINE__.' An unknown field should return false.'
+		);
+
 		// Test correct usage.
 
 		$field = $form->getField('title');
 		$field = $form->loadField($field);
+
+		$field = $form->getField('unexisting');
+		$this->assertThat(
+			$field->type,
+			$this->equalTo('Text'),
+			'Line:'.__LINE__.' An unknown type should return "text".'
+		);
 	}
 
 	/**

--- a/tests/suites/unit/joomla/form/fields/JFormFieldCheckboxesTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldCheckboxesTest.php
@@ -54,12 +54,10 @@ class JFormFieldCheckboxesTest extends TestCase
 			<option value="red">red</option>
 			<option value="blue">blue</option>
 			</field>');
-		TestReflection::setValue($formFieldCheckboxes, 'element', $element);
-		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
-		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
+		$formFieldCheckboxes->setup($element, null);
 
 		$this->assertEquals(
-			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
+			'<fieldset id="color" class="checkboxes"><ul><li><input type="checkbox" id="color0" name="color[]" value="red"/><label for="color0">red</label></li><li><input type="checkbox" id="color1" name="color[]" value="blue"/><label for="color1">blue</label></li></ul></fieldset>',
 			TestReflection::invoke($formFieldCheckboxes, 'getInput'),
 			'The field with no value and no checked values did not produce the right html'
 		);
@@ -93,13 +91,10 @@ class JFormFieldCheckboxesTest extends TestCase
 			<option value="red">red</option>
 			<option value="blue">blue</option>
 			</field>');
-		TestReflection::setValue($formFieldCheckboxes, 'element', $element);
-		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
-		TestReflection::setValue($formFieldCheckboxes, 'value', 'red');
-		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
+		$formFieldCheckboxes->setup($element, 'red');
 
 		$this->assertEquals(
-			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red" checked="checked"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
+			'<fieldset id="color" class="checkboxes"><ul><li><input type="checkbox" id="color0" name="color[]" value="red" checked="checked"/><label for="color0">red</label></li><li><input type="checkbox" id="color1" name="color[]" value="blue"/><label for="color1">blue</label></li></ul></fieldset>',
 			TestReflection::invoke($formFieldCheckboxes, 'getInput'),
 			'The field with one value did not produce the right html'
 		);
@@ -134,13 +129,10 @@ class JFormFieldCheckboxesTest extends TestCase
 			<option value="blue">blue</option>
 			</field>');
 		$valuearray = array ('red');
-		TestReflection::setValue($formFieldCheckboxes, 'element', $element);
-		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
-		TestReflection::setValue($formFieldCheckboxes, 'value', $valuearray);
-		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
+		$formFieldCheckboxes->setup($element, $valuearray);
 
 		$this->assertEquals(
-			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red" checked="checked"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
+			'<fieldset id="color" class="checkboxes"><ul><li><input type="checkbox" id="color0" name="color[]" value="red" checked="checked"/><label for="color0">red</label></li><li><input type="checkbox" id="color1" name="color[]" value="blue"/><label for="color1">blue</label></li></ul></fieldset>',
 			TestReflection::invoke($formFieldCheckboxes, 'getInput'),
 			'The field with one value did not produce the right html'
 		);
@@ -174,12 +166,10 @@ class JFormFieldCheckboxesTest extends TestCase
 			<option value="red">red</option>
 			<option value="blue">blue</option>
 			</field>');
-		TestReflection::setValue($formFieldCheckboxes, 'element', $element);
-		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
-		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
+		$formFieldCheckboxes->setup($element, null);
 
 		$this->assertEquals(
-			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue" checked="checked"/><label for="myTestId1">blue</label></li></ul></fieldset>',
+			'<fieldset id="color" class="checkboxes"><ul><li><input type="checkbox" id="color0" name="color[]" value="red"/><label for="color0">red</label></li><li><input type="checkbox" id="color1" name="color[]" value="blue" checked="checked"/><label for="color1">blue</label></li></ul></fieldset>',
 			TestReflection::invoke($formFieldCheckboxes, 'getInput'),
 			'The field with no values and one value in the checked element did not produce the right html'
 		);
@@ -341,6 +331,82 @@ class JFormFieldCheckboxesTest extends TestCase
 			$optionsExpected,
 			TestReflection::invoke($formFieldCheckboxes, 'getOptions'),
 			'The field with two values did not produce the right options'
+		);
+	}
+
+	/**
+	 * Data provider for testGetDefaultPreset
+	 *
+	 * @since  12.2
+	 */
+	public function caseGetDefaultPreset()
+	{
+		return array(
+			// no default, no preset
+			array(
+				'',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				array(),
+				array()
+			),
+			// one default, no preset
+			array(
+				'default="1"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'1',
+				'1'
+			),
+			// no default, one preset
+			array(
+				'preset="1"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				array(),
+				'1'
+			),
+			// one default, one preset
+			array(
+				'preset="1" default="2"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'2',
+				'1'
+			),
+			// many default, many preset
+			array(
+				'',
+				'<option value="1" checked="true">1</option><option value="2" checked="true" default="true">2</option><option value="3" default="true">3</option>',
+				array(2, 3),
+				array(1, 2)
+			),
+		);
+	}
+
+	/**
+	 * Test the getDefault and getPreset method.
+	 *
+	 * @dataProvider caseGetDefaultPreset
+	 *
+	 * @since  12.2
+	 */
+	public function testGetDefaultPreset($attributes, $options, $default, $preset)
+	{
+		$form = new JFormInspector('form1');
+
+		$this->assertThat(
+			$form->load('<form><field name="checkboxes" type="checkboxes" ' . $attributes . ' >' . $options . '</field></form>'),
+			$this->isTrue(),
+			'Line:'.__LINE__.' XML string should load successfully.'
+		);
+
+		$this->assertThat(
+			$form->getField('checkboxes')->default,
+			$this->equalTo($default),
+			'Line:'.__LINE__.' The getDefault method should return correct default.'
+		);
+
+		$this->assertThat(
+			$form->getField('checkboxes')->preset,
+			$this->equalTo($preset),
+			'Line:'.__LINE__.' The getDefault method should return correct preset.'
 		);
 	}
 }

--- a/tests/suites/unit/joomla/form/fields/JFormFieldGroupedListTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldGroupedListTest.php
@@ -62,4 +62,82 @@ class JFormFieldGroupedListTest extends TestCase
 
 		// TODO: Should check all the attributes have come in properly.
 	}
+
+	/**
+	 * Data provider for testGetDefaultPreset
+	 *
+	 * @since  12.2
+	 */
+	public function caseGetDefaultPreset()
+	{
+		// $attributes, $options, $default, $preset
+		return array(
+			array(
+				'',
+				'<option value="1">1</option><option value="2">2</option><group name="Group"><option value="3">3</option></group>',
+				'',
+				''
+			),
+			array(
+				'default="1"',
+				'<option value="1">1</option><option value="2">2</option><group name="Group"><option value="3">3</option></group>',
+				'1',
+				'1'
+			),
+			array(
+				'preset="1"',
+				'<option value="1">1</option><option value="2">2</option><group name="Group"><option value="3">3</option></group>',
+				'',
+				'1'
+			),
+			array(
+				'preset="1" default="2"',
+				'<option value="1">1</option><option value="2">2</option><group name="Group"><option value="3">3</option></group>',
+				'2',
+				'1'
+			),
+			array(
+				'multiple="true"',
+				'<option value="1">1</option><option value="2">2</option><group name="Group"><option value="3">3</option></group>',
+				array(),
+				array()
+			),
+			array(
+				'multiple="true"',
+				'<option value="1" selected="true">1</option><option value="2" selected="true" default="true">2</option><group name="Group"><option value="3" default="true">3</option></group>',
+				array(2, 3),
+				array(1, 2)
+			),
+		);
+	}
+
+	/**
+	 * Test the getDefault and getPreset method.
+	 *
+	 * @dataProvider caseGetDefaultPreset
+	 *
+	 * @since  12.2
+	 */
+	public function testGetDefaultPreset($attributes, $options, $default, $preset)
+	{
+		$form = new JFormInspector('form1');
+
+		$this->assertThat(
+			$form->load('<form><field name="groupedlist" type="groupedlist" ' . $attributes . ' >' . $options . '</field></form>'),
+			$this->isTrue(),
+			'Line:'.__LINE__.' XML string should load successfully.'
+		);
+
+		$this->assertThat(
+			$form->getField('groupedlist')->default,
+			$this->equalTo($default),
+			'Line:'.__LINE__.' The getDefault method should return correct default.'
+		);
+
+		$this->assertThat(
+			$form->getField('groupedlist')->preset,
+			$this->equalTo($preset),
+			'Line:'.__LINE__.' The getDefault method should return correct preset.'
+		);
+	}
 }

--- a/tests/suites/unit/joomla/form/fields/JFormFieldListTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldListTest.php
@@ -53,4 +53,82 @@ class JFormFieldListTest extends TestCase
 
 		// TODO: Should check all the attributes have come in properly.
 	}
+
+	/**
+	 * Data provider for testGetDefaultPreset
+	 *
+	 * @since  12.2
+	 */
+	public function caseGetDefaultPreset()
+	{
+		// $attributes, $options, $default, $preset
+		return array(
+			array(
+				'',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'',
+				''
+			),
+			array(
+				'default="1"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'1',
+				'1'
+			),
+			array(
+				'preset="1"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'',
+				'1'
+			),
+			array(
+				'preset="1" default="2"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				'2',
+				'1'
+			),
+			array(
+				'multiple="true"',
+				'<option value="1">1</option><option value="2">2</option><option value="3">3</option>',
+				array(),
+				array()
+			),
+			array(
+				'multiple="true"',
+				'<option value="1" selected="true">1</option><option value="2" selected="true" default="true">2</option><option value="3" default="true">3</option>',
+				array(2, 3),
+				array(1, 2)
+			),
+		);
+	}
+
+	/**
+	 * Test the getDefault and getPreset method.
+	 *
+	 * @dataProvider caseGetDefaultPreset
+	 *
+	 * @since  12.2
+	 */
+	public function testGetDefaultPreset($attributes, $options, $default, $preset)
+	{
+		$form = new JFormInspector('form1');
+
+		$this->assertThat(
+			$form->load('<form><field name="list" type="list" ' . $attributes . ' >' . $options . '</field></form>'),
+			$this->isTrue(),
+			'Line:'.__LINE__.' XML string should load successfully.'
+		);
+
+		$this->assertThat(
+			$form->getField('list')->default,
+			$this->equalTo($default),
+			'Line:'.__LINE__.' The getDefault method should return correct default.'
+		);
+
+		$this->assertThat(
+			$form->getField('list')->preset,
+			$this->equalTo($preset),
+			'Line:'.__LINE__.' The getDefault method should return correct preset.'
+		);
+	}
 }

--- a/tests/suites/unit/joomla/form/language/en-GB/en-GB.form_test.ini
+++ b/tests/suites/unit/joomla/form/language/en-GB/en-GB.form_test.ini
@@ -1,1 +1,3 @@
 DEFAULT_KEY="My Default"
+PRESET_KEY="My Preset"
+


### PR DESCRIPTION
Currently, the "default" attribute in form fields is used in two way
- filling a field when the current the value is empty (editing a form)
- storing the field when filtering data (saving a form)

These two behaviors need to be distinct because we need to provide an initial value for some fields and allow to save an empty value.

This pull request introduces a new attribute for field: "preset". It is used for filling the attribute when the current value is empty (it falls back to the "default" attribute if it does not exist)

For multiple fields (list, checkboxes, and groupedlist), similar behavior has been introduced.

It's a solution for Joomla CMS [#28402] JFormFieldList (and derivatives) do not utilize multiple default values when multiple=true (http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28402)

It has been extended for supporting preset values in form fields
## in an single valued field, you can now use

```
<field name="text1" type="text" preset="Preset value" />
<field name="text2" type="text" preset="KEY_TO_PRESET_VALUE" translate_preset="true" />
```

This will fill the field the first time the form is edited
## in a list

```
<field name="list1" type="list" default="1">
    <option value="1">1</option>
    <option value="2">2</option>
    <option value="3">3</option>
</field>
```

This will fill the field the with 1 if the current value is empty

```
<field name="list2" type="list" preset="1">
    <option value="1">1</option>
    <option value="2">2</option>
    <option value="3">3</option>
</field>
```

This will fill the field the with 1 the first time the form is edited

```
<field name="list3" type="list">
    <option value="1" default="true">1</option>
    <option value="2">2</option>
    <option value="3" default="true">3</option>
</field>
```

This will fill the field the with 1,3 if the current value is empty

```
<field name="list4" type="list">
    <option value="1" selected="true">1</option>
    <option value="2">2</option>
    <option value="3" selected="true">3</option>
</field>
```

This will fill the field the with 1,3 the first time the form is edited
