### PR TITLE
Fix a parse error

### DIFF
--- a/libraries/legacy/error/error.php
+++ b/libraries/legacy/error/error.php
@@ -16,7 +16,7 @@ const JERROR_ILLEGAL_OPTIONS = 1;
 const JERROR_CALLBACK_NOT_CALLABLE = 2;
 
 // Error Definition: Illegal Handler
-const JERROR_ILLEGAL_MODE = 3
+const JERROR_ILLEGAL_MODE = 3;
 
 /**
  * Error Handling Class


### PR DESCRIPTION
So it happened that a parse error was committed and Mr. Jenkins let is pass silently ([almost](http://build.joomla.org/job/platform/847/console)) pushing it to the master branch.

It would be nice to implement a call to php lint to prevent those "accidents" in the future.
