### PR TITLE
Standardize default Content-Type handling across all transports.

### DIFF
--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -74,7 +74,7 @@ class JHttpTransportCurl implements JHttpTransport
 		if (isset($data))
 		{
 			// If the data is a scalar value simply add it to the cURL post fields.
-			if (is_scalar($data) || (isset($headers['Content-type']) && strpos($headers['Content-type'], 'multipart/form-data') === 0))
+			if (is_scalar($data) || (isset($headers['Content-Type']) && strpos($headers['Content-Type'], 'multipart/form-data') === 0))
 			{
 				$options[CURLOPT_POSTFIELDS] = $data;
 			}
@@ -84,14 +84,15 @@ class JHttpTransportCurl implements JHttpTransport
 				$options[CURLOPT_POSTFIELDS] = http_build_query($data);
 			}
 
-			if (!isset($headers['Content-type']))
+			if (!isset($headers['Content-Type']))
 			{
-				$headers['Content-type'] = 'application/x-www-form-urlencoded';
+				$headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8';
 			}
 
+			// Add the relevant headers.
 			if (is_scalar($options[CURLOPT_POSTFIELDS]))
 			{
-				$headers['Content-length'] = strlen($options[CURLOPT_POSTFIELDS]);
+				$headers['Content-Length'] = strlen($options[CURLOPT_POSTFIELDS]);
 			}
 		}
 

--- a/libraries/joomla/http/transport/socket.php
+++ b/libraries/joomla/http/transport/socket.php
@@ -94,8 +94,12 @@ class JHttpTransportSocket implements JHttpTransport
 				$data = http_build_query($data);
 			}
 
+			if (!isset($headers['Content-type']))
+			{
+				$headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8';
+			}
+
 			// Add the relevant headers.
-			$headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8';
 			$headers['Content-Length'] = strlen($data);
 		}
 

--- a/libraries/joomla/http/transport/socket.php
+++ b/libraries/joomla/http/transport/socket.php
@@ -94,7 +94,7 @@ class JHttpTransportSocket implements JHttpTransport
 				$data = http_build_query($data);
 			}
 
-			if (!isset($headers['Content-type']))
+			if (!isset($headers['Content-Type']))
 			{
 				$headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8';
 			}

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -68,7 +68,7 @@ class JHttpTransportStream implements JHttpTransport
 		// Create the stream context options array with the required method offset.
 		$options = array('method' => strtoupper($method));
 
-		// If data exists let's encode it and make sure our Content-type header is set.
+		// If data exists let's encode it and make sure our Content-Type header is set.
 		if (isset($data))
 		{
 			// If the data is a scalar value simply add it to the stream context options.
@@ -82,12 +82,13 @@ class JHttpTransportStream implements JHttpTransport
 				$options['content'] = http_build_query($data);
 			}
 
-			if (!isset($headers['Content-type']))
+			if (!isset($headers['Content-Type']))
 			{
-				$headers['Content-type'] = 'application/x-www-form-urlencoded';
+				$headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8';
 			}
 
-			$headers['Content-length'] = strlen($options['content']);
+			// Add the relevant headers.
+			$headers['Content-Length'] = strlen($options['content']);
 		}
 
 		// Build the headers string for the request.


### PR DESCRIPTION
According to IETF (http://www.ietf.org/rfc/rfc2616.txt) and W3C (http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2) are case-insensitive, but in both documentations used in camel case.
