### PR TITLE
Stop default handling of href in toolbar buttons

### DIFF
--- a/libraries/legacy/toolbar/button/confirm.php
+++ b/libraries/legacy/toolbar/button/confirm.php
@@ -47,7 +47,7 @@ class JToolbarButtonConfirm extends JButton
 		$class = $this->fetchIconClass($name);
 		$doTask = $this->_getCommand($msg, $name, $task, $list);
 
-		$html = "<a href=\"#\" onclick=\"$doTask\" class=\"toolbar\">\n";
+		$html = "<a href=\"javascript:void(0)\" onclick=\"$doTask\" class=\"toolbar\">\n";
 		$html .= "<span class=\"$class\">\n";
 		$html .= "</span>\n";
 		$html .= "$text\n";

--- a/libraries/legacy/toolbar/button/help.php
+++ b/libraries/legacy/toolbar/button/help.php
@@ -42,7 +42,7 @@ class JToolbarButtonHelp extends JButton
 		$class = $this->fetchIconClass('help');
 		$doTask = $this->_getCommand($ref, $com, $override, $component);
 
-		$html = "<a href=\"#\" onclick=\"$doTask\" rel=\"help\" class=\"toolbar\">\n";
+		$html = "<a href=\"javascript:void(0)\" onclick=\"$doTask\" rel=\"help\" class=\"toolbar\">\n";
 		$html .= "<span class=\"$class\">\n";
 		$html .= "</span>\n";
 		$html .= "$text\n";

--- a/libraries/legacy/toolbar/button/standard.php
+++ b/libraries/legacy/toolbar/button/standard.php
@@ -44,7 +44,7 @@ class JToolbarButtonStandard extends JButton
 		$class = $this->fetchIconClass($name);
 		$doTask = $this->_getCommand($text, $task, $list);
 
-		$html = "<a href=\"#\" onclick=\"$doTask\" class=\"toolbar\">\n";
+		$html = "<a href=\"javascript:void(0)\" onclick=\"$doTask\" class=\"toolbar\">\n";
 		$html .= "<span class=\"$class\">\n";
 		$html .= "</span>\n";
 		$html .= "$i18n_text\n";


### PR DESCRIPTION
I refer to https://github.com/joomla/joomla-cms/pull/189 and http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28404

It has been suggested that this pull is done against the platform.
