### PR TITLE
Reduce the use of JBrowser.

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -520,19 +520,6 @@ class JApplicationWeb extends JApplicationBase
 
 				echo $html;
 			}
-			/*
-			 * For WebKit based browsers do not send a 303, as it causes subresource reloading.  You can view the
-			 * bug report at: https://bugs.webkit.org/show_bug.cgi?id=38690
-			 */
-			elseif (!$moved && ($this->client->engine == JApplicationWebClient::WEBKIT))
-			{
-				$html = '<html><head>';
-				$html .= '<meta http-equiv="refresh" content="0; url=' . $url . '" />';
-				$html .= '<meta http-equiv="content-type" content="text/html; charset=' . $this->charSet . '" />';
-				$html .= '</head><body></body></html>';
-
-				echo $html;
-			}
 			else
 			{
 				// All other cases use the more efficient HTTP header for redirection.
@@ -962,6 +949,18 @@ class JApplicationWeb extends JApplicationBase
 	protected function header($string, $replace = true, $code = null)
 	{
 		header($string, $replace, $code);
+	}
+
+	/**
+	 * Determine if we are using a secure (SSL) connection.
+	 *
+	 * @return  boolean  True if using SSL, false if not.
+	 *
+	 * @since   12.2
+	 */
+	public function isSSLConnection()
+	{
+		return ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION'));
 	}
 
 	/**

--- a/libraries/joomla/application/web/client.php
+++ b/libraries/joomla/application/web/client.php
@@ -129,9 +129,9 @@ class JApplicationWebClient
 	/**
 	 * Class constructor.
 	 *
-	 * @param   mixed  $userAgent       The optional user-agent string to parse.
-	 * @param   mixed  $acceptEncoding  The optional client accept encoding string to parse.
-	 * @param   mixed  $acceptLanguage  The optional client accept language string to parse.
+	 * @param   string  $userAgent       The optional user-agent string to parse.
+	 * @param   string  $acceptEncoding  The optional client accept encoding string to parse.
+	 * @param   string  $acceptLanguage  The optional client accept language string to parse.
 	 *
 	 * @since   12.1
 	 */

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -21,11 +21,9 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Platform
  * @subpackage  Environment
  * @since       11.1
- * @deprecated  This API may be changed in the near future and should not be considered stable
  */
 class JBrowser
 {
-
 	/**
 	 * @var    integer  Major version number
 	 * @since  12.1
@@ -653,9 +651,13 @@ class JBrowser
 	 * @return  boolean  True if using SSL, false if not.
 	 *
 	 * @since   11.1
+	 * @deprecated  13.3  Use the isSSLConnection method on the application object.
 	 */
 	public function isSSLConnection()
 	{
+		JLog::add('JBrowser::isSSLConnection() is deprecated. Use the isSSLConnection method on the application object instead.',
+			JLog::WARNING, 'deprecated');
+
 		return ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION'));
 	}
 }

--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -73,6 +73,12 @@ class JApplication extends JApplicationBase
 	public $startTime = null;
 
 	/**
+	 * @var    JApplicationWebClient  The application client object.
+	 * @since  12.2
+	 */
+	public $client;
+
+	/**
 	 * @var    array  JApplication instances container.
 	 * @since  11.3
 	 */
@@ -106,6 +112,10 @@ class JApplication extends JApplicationBase
 		// Create the input object
 		$this->input = new JInput;
 
+		$this->client = new JApplicationWebClient;
+
+		$this->loadDispatcher();
+
 		// Set the session default name.
 		if (!isset($config['session_name']))
 		{
@@ -129,8 +139,6 @@ class JApplication extends JApplicationBase
 		{
 			$this->_createSession(self::getHash($config['session_name']));
 		}
-
-		$this->loadDispatcher();
 
 		$this->requestTime = gmdate('Y-m-d H:i');
 
@@ -385,10 +393,9 @@ class JApplication extends JApplicationBase
 		else
 		{
 			$document = JFactory::getDocument();
-			jimport('joomla.environment.browser');
-			$navigator = JBrowser::getInstance();
+
 			jimport('phputf8.utils.ascii');
-			if ($navigator->isBrowser('msie') && !utf8_is_ascii($url))
+			if (($this->client->engine == JApplicationWebClient::TRIDENT) && !utf8_is_ascii($url))
 			{
 				// MSIE type browser and/or server cause issues when url contains utf8 character,so use a javascript redirect method
 				echo '<html><head><meta http-equiv="content-type" content="text/html; charset=' . $document->getCharset() . '" />'
@@ -1108,6 +1115,18 @@ class JApplication extends JApplicationBase
 		JLog::add('JApplication::isWinOS() is deprecated. Use the IS_WIN constant instead.', JLog::WARNING, 'deprecated');
 
 		return IS_WIN;
+	}
+
+	/**
+	 * Determine if we are using a secure (SSL) connection.
+	 *
+	 * @return  boolean  True if using SSL, false if not.
+	 *
+	 * @since   12.2
+	 */
+	public function isSSLConnection()
+	{
+		return ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION'));
 	}
 
 	/**

--- a/tests/suites/legacy/application/JApplicationTest.php
+++ b/tests/suites/legacy/application/JApplicationTest.php
@@ -14,6 +14,15 @@
 class JApplicationTest extends PHPUnit_Framework_TestCase
 {
 	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 */
+	protected function setUp()
+	{
+		$this->object = new JApplication(array('session' => false));
+	}
+
+	/**
 	 * @todo Implement testGetInstance().
 	 */
 	public function testGetInstance()
@@ -35,13 +44,18 @@ class JApplicationTest extends PHPUnit_Framework_TestCase
 	 * @todo Implement testInitialise().
 	 * @cover JApplication::__construct
 	 */
-	public function testConstructJInput()
+	public function testConstruct()
 	{
-		$app = new JApplication(array('session' => false));
 		$this->assertThat(
-			$app->input,
+			$this->object->input,
 			$this->isInstanceOf('JInput'),
 			__LINE__ . 'JApplication->input not initialized properly'
+		);
+
+		$this->assertInstanceOf(
+			'JApplicationWebClient',
+			$this->object->client,
+			'Client property wrong type'
 		);
 	}
 
@@ -300,5 +314,25 @@ class JApplicationTest extends PHPUnit_Framework_TestCase
 	{
 		// Remove the following lines when you implement this test.
 		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	/**
+	 * @covers JApplication::isSSLConnection
+	 */
+	public function testIsSSLConnection()
+	{
+		unset($_SERVER['HTTPS']);
+
+		$this->assertThat(
+			$this->object->isSSLConnection(),
+			$this->equalTo(false)
+		);
+
+		$_SERVER['HTTPS'] = 'on';
+
+		$this->assertThat(
+			$this->object->isSSLConnection(),
+			$this->equalTo(true)
+		);
 	}
 }

--- a/tests/suites/unit/joomla/application/JApplicationWebTest.php
+++ b/tests/suites/unit/joomla/application/JApplicationWebTest.php
@@ -108,7 +108,6 @@ class JApplicationWebTest extends TestCase
 
 		JFactory::$document = $this->getMockDocument();
 		JFactory::$language = $this->getMockLanguage();
-
 	}
 
 	/**
@@ -1563,43 +1562,6 @@ class JApplicationWebTest extends TestCase
 	}
 
 	/**
-	 * Tests the JApplicationWeb::redirect method with webkit bug.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.3
-	 */
-	public function testRedirectWithWebkitBug()
-	{
-		$url = 'http://j.org/index.php';
-
-		// Inject the client information.
-		TestReflection::setValue(
-			$this->class,
-			'client',
-			(object) array(
-				'engine' => JApplicationWebClient::WEBKIT,
-			)
-		);
-
-		// Capture the output for this test.
-		ob_start();
-		$this->class->redirect($url);
-		$buffer = ob_get_contents();
-		ob_end_clean();
-
-		$this->assertThat(
-			trim($buffer),
-			$this->equalTo(
-				'<html><head>' .
-				'<meta http-equiv="refresh" content="0; url=' . $url . '" />' .
-				'<meta http-equiv="content-type" content="text/html; charset=utf-8" />' .
-				'</head><body></body></html>'
-			)
-		);
-	}
-
-	/**
 	 * Tests the JApplicationWeb::registerEvent method.
 	 *
 	 * @return  void
@@ -1792,6 +1754,26 @@ class JApplicationWebTest extends TestCase
 				)
 			),
 			'Tests that headers of the same name are replaced.'
+		);
+	}
+
+	/**
+	 * @covers JApplicationWeb::isSSLConnection
+	 */
+	public function testIsSSLConnection()
+	{
+		unset($_SERVER['HTTPS']);
+
+		$this->assertThat(
+			$this->class->isSSLConnection(),
+			$this->equalTo(false)
+		);
+
+		$_SERVER['HTTPS'] = 'on';
+
+		$this->assertThat(
+			$this->class->isSSLConnection(),
+			$this->equalTo(true)
 		);
 	}
 }

--- a/tests/suites/unit/joomla/environment/JBrowserTest.php
+++ b/tests/suites/unit/joomla/environment/JBrowserTest.php
@@ -8,7 +8,6 @@ require_once JPATH_PLATFORM.'/joomla/environment/browser.php';
  */
 class JBrowserTest extends PHPUnit_Framework_TestCase
 {
-
 	/**
 	 * @var JBrowser
 	 */
@@ -186,6 +185,9 @@ class JBrowserTest extends PHPUnit_Framework_TestCase
 		);
 	}
 
+	/**
+	 * @covers JBrowser::isSSLConnection
+	 */
 	public function testIsSSLConnection()
 	{
 		unset($_SERVER['HTTPS']);
@@ -202,5 +204,4 @@ class JBrowserTest extends PHPUnit_Framework_TestCase
 			$this->equalTo(true)
 		);
 	}
-
 }


### PR DESCRIPTION
Note that JHtml still depends on JBrowser, we'll need to fix that before we can move JBrowser to legacy.

Legacy unit tests run fine on my local machine.
