### PR TITLE
Import plugins on authorise instead of loading

### DIFF
--- a/libraries/joomla/user/authentication.php
+++ b/libraries/joomla/user/authentication.php
@@ -326,9 +326,9 @@ class JAuthentication extends JObject
 	 */
 	public static function authorise($response, $options = array())
 	{
-		// Get plugins in case they haven't been loaded already
-		JPluginHelper::getPlugin('user');
-		JPluginHelper::getPlugin('authentication');
+		// Get plugins in case they haven't been imported already
+		JPluginHelper::importPlugin('user');
+		JPluginHelper::importPlugin('authentication');
 		$dispatcher = JEventDispatcher::getInstance();
 		$results = $dispatcher->trigger('onUserAuthorisation', array($response, $options));
 		return $results;


### PR DESCRIPTION
*Apologies if this has been done incorrectly - this is my first ever pull request.

I think the authorise method is suppose to importPlugin() - I can't see any point in using getPlugin() as this will return plug-in data (which isn't captured anyway) and doesn't import them for the dispatcher.

Also, when calling the authorise method, you have to import both plug-in groups manually which seems pointless:
JPluginHelper::importPlugin('user');
JPluginHelper::importPlugin('authentication');
$authorisations = JAuthentication::authorise($response, $options);
