### PR TITLE
Code Style in Jhtmltest plus fix places where files are created twice causing errors

### DIFF
--- a/tests/suites/unit/joomla/html/JHtmlTest.php
+++ b/tests/suites/unit/joomla/html/JHtmlTest.php
@@ -61,10 +61,14 @@ class JHtmlTest extends TestCase
 		JHtml::addIncludePath(array(__DIR__ . '/html/testfiles'));
 
 		// Test the class method was called and the arguments passed correctly.
-		$this->assertThat(JHtml::_('inspector.method1', 'argument1', 'argument2'), $this->equalTo('JHtmlInspector::method1'),
+		$this->assertThat(
+			JHtml::_('inspector.method1', 'argument1', 'argument2'),
+			$this->equalTo('JHtmlInspector::method1'),
 			'JHtmlInspector::method1 could not be called.');
 
-		$this->assertThat(JHtmlInspector::$arguments[0], $this->equalTo(array('argument1', 'argument2')),
+		$this->assertThat(
+			JHtmlInspector::$arguments[0],
+			$this->equalTo(array('argument1', 'argument2')),
 			'The arguments where not correctly passed to JHtmlInspector::method1.');
 	}
 
@@ -83,7 +87,10 @@ class JHtmlTest extends TestCase
 
 		// Test a class that doesn't exist.
 		$this->setExpectedException('InvalidArgumentException');
-		$this->assertThat(JHtml::_('empty.anything'), $this->isFalse());
+
+		$this->assertThat(
+			JHtml::_('empty.anything'),
+			$this->isFalse());
 	}
 
 	/**
@@ -101,7 +108,10 @@ class JHtmlTest extends TestCase
 
 		// Test a file that doesn't exist.
 		$this->setExpectedException('InvalidArgumentException');
-		$this->assertThat(JHtml::_('nofile.anything'), $this->isFalse());
+
+		$this->assertThat(
+			JHtml::_('nofile.anything'),
+			$this->isFalse());
 	}
 
 	/**
@@ -119,7 +129,10 @@ class JHtmlTest extends TestCase
 
 		// Test a method that doesn't exist.
 		$this->setExpectedException('InvalidArgumentException');
-		$this->assertThat(JHtml::_('inspector.nomethod'), $this->isFalse());
+
+		$this->assertThat(
+			JHtml::_('inspector.nomethod'),
+			$this->isFalse());
 	}
 
 	/**
@@ -135,7 +148,9 @@ class JHtmlTest extends TestCase
 		$registered = $this->getMock('MyHtmlClass', array('mockFunction'));
 
 		// test that we can register the method
-		$this->assertThat(JHtml::register('prefix.register.testfunction', array($registered, 'mockFunction')), $this->isTrue(),
+		$this->assertThat(
+			JHtml::register('prefix.register.testfunction', array($registered, 'mockFunction')),
+			$this->isTrue(),
 			'The class method did not register properly.');
 
 		// test that calling _ actually calls the function
@@ -144,7 +159,9 @@ class JHtmlTest extends TestCase
 
 		JHtml::_('prefix.register.testfunction');
 
-		$this->assertThat(JHtml::register('prefix.register.missingtestfunction', array($registered, 'missingFunction')), $this->isFalse(),
+		$this->assertThat(
+			JHtml::register('prefix.register.missingtestfunction', array($registered, 'missingFunction')),
+			$this->isFalse(),
 			'Registering a missing method should fail.');
 	}
 
@@ -163,9 +180,15 @@ class JHtmlTest extends TestCase
 
 		JHtml::register('prefix.unregister.testfunction', array($registered, 'mockFunction'));
 
-		$this->assertThat(JHtml::unregister('prefix.unregister.testfunction'), $this->isTrue(), 'The method was not unregistered.');
+		$this->assertThat(
+			JHtml::unregister('prefix.unregister.testfunction'),
+			$this->isTrue(),
+			'The method was not unregistered.');
 
-		$this->assertThat(JHtml::unregister('prefix.unregister.testkeynotthere'), $this->isFalse(), 'Unregistering a missing method should fail.');
+		$this->assertThat(
+			JHtml::unregister('prefix.unregister.testkeynotthere'),
+			$this->isFalse(),
+			'Unregistering a missing method should fail.');
 	}
 
 	/**
@@ -180,12 +203,17 @@ class JHtmlTest extends TestCase
 	{
 		$registered = $this->getMock('MyHtmlClass', array('mockFunction'));
 
-		// test that we can register the method
+		// Test that we can register the method.
 		JHtml::register('prefix.isregistered.method', array($registered, 'mockFunction'));
 
-		$this->assertThat(JHtml::isRegistered('prefix.isregistered.method'), $this->isTrue(), 'Calling isRegistered on a valid method should pass.');
+		$this->assertThat(
+			JHtml::isRegistered('prefix.isregistered.method'),
+			$this->isTrue(),
+			'Calling isRegistered on a valid method should pass.');
 
-		$this->assertThat(JHtml::isRegistered('prefix.isregistered.nomethod'), $this->isFalse(),
+		$this->assertThat(
+			JHtml::isRegistered('prefix.isregistered.nomethod'),
+			$this->isFalse(),
 			'Calling isRegistered on a missing method should fail.');
 	}
 
@@ -198,7 +226,7 @@ class JHtmlTest extends TestCase
 	 */
 	public function dataTestLink()
 	{
-		// $url, $text, $attribs, $expected, $msg
+		// The array includes $url, $text, $attribs, $expected, $msg
 		return array(
 			// Standard link with string attribs failed
 			array(
@@ -249,21 +277,21 @@ class JHtmlTest extends TestCase
 			$_SERVER = array();
 		}
 
-		// we save the state of $_SERVER for later and set it to appropriate values
+		// We save the state of $_SERVER for later and set it to appropriate values.
 		$http_host = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : null;
 		$script_name = isset($_SERVER['SCRIPT_NAME']) ? $_SERVER['SCRIPT_NAME'] : null;
 		$_SERVER['HTTP_HOST'] = 'example.com';
 		$_SERVER['SCRIPT_NAME'] = '/index.php';
 
-		// these are some paths to pass to JHtml for testing purposes
+		// These are some paths to pass to JHtml for testing purposes.
 		$urlpath = 'test1/';
 		$urlfilename = 'image1.jpg';
 
-		// we generate a random template name so that we don't collide or hit anything
+		// We generate a random template name so that we don't collide or hit anything.
 		$template = 'mytemplate' . rand(1, 10000);
 
-		// we create a stub (not a mock because we don't enforce whether it is called or not)
-		// to return a value from getTemplate
+		// We create a stub (not a mock because we don't enforce whether it is called or not)
+		// to return a value from getTemplate.
 		$mock = $this->getMock('myMockObject', array('getTemplate'));
 		$mock->expects($this->any())
 			->method('getTemplate')
@@ -271,17 +299,22 @@ class JHtmlTest extends TestCase
 
 		JFactory::$application = $mock;
 
-		// we create the file that JHtml::image will look for
-		mkdir(JPATH_THEMES . '/' . $template . '/images/' . $urlpath, 0777, true);
+		// We create the file that JHtml::image will look for.
+		if (!is_dir(JPATH_THEMES . '/' . $template . '/images/' . $urlpath))
+		{
+			mkdir(JPATH_THEMES . '/' . $template . '/images/' . $urlpath, 0777, true);
+		}
 		file_put_contents(JPATH_THEMES . '/' . $template . '/images/' . $urlpath . $urlfilename, 'test');
 
-		// we do a test for the case that the image is in the templates directory
-		$this->assertThat(JHtml::image($urlpath . $urlfilename, 'My Alt Text', null, true),
+		// We do a test for the case that the image is in the templates directory.
+		$this->assertThat(
+			JHtml::image($urlpath . $urlfilename, 'My Alt Text', null, true),
 			$this->equalTo(
 				'<img src="' . JURI::base(true) . '/templates/' . $template . '/images/' . $urlpath . $urlfilename . '" alt="My Alt Text"  />'),
 			'JHtml::image failed when we should get it from the templates directory');
 
-		$this->assertThat(JHtml::image($urlpath . $urlfilename, 'My Alt Text', null, true, true),
+		$this->assertThat(
+			JHtml::image($urlpath . $urlfilename, 'My Alt Text', null, true, true),
 			$this->equalTo(JURI::base(true) . '/templates/' . $template . '/images/' . $urlpath . $urlfilename),
 			'JHtml::image failed in URL only mode when it should come from the templates directory');
 
@@ -290,19 +323,21 @@ class JHtmlTest extends TestCase
 		rmdir(JPATH_THEMES . '/' . $template . '/images');
 		rmdir(JPATH_THEMES . '/' . $template);
 
-		// we create the file that JHtml::image will look for
+		// We create the file that JHtml::image will look for.
 		if (!is_dir(dirname(JPATH_ROOT . '/media/' . $urlpath . 'images/' . $urlfilename)))
 		{
 			mkdir(dirname(JPATH_ROOT . '/media/' . $urlpath . 'images/' . $urlfilename), 0777, true);
 		}
 		file_put_contents(JPATH_ROOT . '/media/' . $urlpath . 'images/' . $urlfilename, 'test');
 
-		// we do a test for the case that the image is in the media directory
-		$this->assertThat(JHtml::image($urlpath . $urlfilename, 'My Alt Text', null, true),
+		// We do a test for the case that the image is in the media directory.
+		$this->assertThat(
+			JHtml::image($urlpath . $urlfilename, 'My Alt Text', null, true),
 			$this->equalTo('<img src="' . JURI::base(true) . '/media/' . $urlpath . 'images/' . $urlfilename . '" alt="My Alt Text"  />'),
 			'JHtml::image failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::image($urlpath . $urlfilename, 'My Alt Text', null, true, true),
+		$this->assertThat(
+			JHtml::image($urlpath . $urlfilename, 'My Alt Text', null, true, true),
 			$this->equalTo(JURI::base(true) . '/media/' . $urlpath . 'images/' . $urlfilename),
 			'JHtml::image failed when we should get it from the media directory in path only mode');
 
@@ -310,27 +345,33 @@ class JHtmlTest extends TestCase
 		rmdir(JPATH_ROOT . '/media/' . $urlpath . 'images');
 		rmdir(JPATH_ROOT . '/media/' . $urlpath);
 
-		// we create the file that JHtml::image will look for
+		// We create the file that JHtml::image will look for.
 		if (!is_dir(dirname(JPATH_ROOT . '/media/system/images/' . $urlfilename)))
 		{
 			mkdir(dirname(JPATH_ROOT . '/media/system/images/' . $urlfilename), 0777, true);
 		}
 		file_put_contents(JPATH_ROOT . '/media/system/images/' . $urlfilename, 'test');
 
-		$this->assertThat(JHtml::image($urlpath . $urlfilename, 'My Alt Text', null, true),
+		$this->assertThat(
+			JHtml::image($urlpath . $urlfilename, 'My Alt Text', null, true),
 			$this->equalTo('<img src="' . JURI::base(true) . '/media/system/images/' . $urlfilename . '" alt="My Alt Text"  />'),
 			'JHtml::image failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::image($urlpath . $urlfilename, 'My Alt Text', null, true, true),
+		$this->assertThat(
+			JHtml::image($urlpath . $urlfilename, 'My Alt Text', null, true, true),
 			$this->equalTo(JURI::base(true) . '/media/system/images/' . $urlfilename),
 			'JHtml::image failed when we should get it from the media directory in path only mode');
 
 		unlink(JPATH_ROOT . '/media/system/images/' . $urlfilename);
 
-		$this->assertThat(JHtml::image($urlpath . $urlfilename, 'My Alt Text', null, true), $this->equalTo('<img src="" alt="My Alt Text"  />'),
+		$this->assertThat(
+			JHtml::image($urlpath . $urlfilename, 'My Alt Text', null, true),
+			$this->equalTo('<img src="" alt="My Alt Text"  />'),
 			'JHtml::image failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::image($urlpath . $urlfilename, 'My Alt Text', null, true, true), $this->equalTo(null),
+		$this->assertThat(
+			JHtml::image($urlpath . $urlfilename, 'My Alt Text', null, true, true),
+			$this->equalTo(null),
 			'JHtml::image failed when we should get it from the media directory in path only mode');
 
 		$extension = 'testextension';
@@ -341,15 +382,18 @@ class JHtmlTest extends TestCase
 		mkdir(JPATH_ROOT . '/media/' . $extension . '/' . $element . '/images/' . $urlpath, 0777, true);
 		file_put_contents(JPATH_ROOT . '/media/' . $extension . '/' . $element . '/images/' . $urlpath . $urlfilename, 'test');
 
-		$this->assertThat(JHtml::image($extension . '/' . $element . '/' . $urlpath . $urlfilename, 'My Alt Text', null, true),
+		$this->assertThat(
+			JHtml::image($extension . '/' . $element . '/' . $urlpath . $urlfilename, 'My Alt Text', null, true),
 			$this->equalTo(
 				'<img src="' . JURI::base(true) . '/media/' . $extension . '/' . $element . '/images/' . $urlpath . $urlfilename .
-					 '" alt="My Alt Text"  />'), 'JHtml::image failed when we should get it from the media directory, with the plugin fix');
+					 '" alt="My Alt Text"  />'),
+				'JHtml::image failed when we should get it from the media directory, with the plugin fix');
 
 		$this->assertThat(JHtml::image($extension . '/' . $element . '/' . $urlpath . $urlfilename, 'My Alt Text', null, true, true),
 			$this->equalTo(JURI::base(true) . '/media/' . $extension . '/' . $element . '/images/' . $urlpath . $urlfilename),
 			'JHtml::image failed when we should get it from the media directory, with the plugin fix path only mode');
-		// we remove the file from the media directory
+			
+		// We remove the file from the media directory.
 		unlink(JPATH_ROOT . '/media/' . $extension . '/' . $element . '/images/' . $urlpath . $urlfilename);
 		rmdir(JPATH_ROOT . '/media/' . $extension . '/' . $element . '/images/' . $urlpath);
 		rmdir(JPATH_ROOT . '/media/' . $extension . '/' . $element . '/images');
@@ -359,12 +403,14 @@ class JHtmlTest extends TestCase
 		mkdir(JPATH_ROOT . '/media/' . $extension . '/images/' . $element . '/' . $urlpath, 0777, true);
 		file_put_contents(JPATH_ROOT . '/media/' . $extension . '/images/' . $element . '/' . $urlpath . $urlfilename, 'test');
 
-		$this->assertThat(JHtml::image($extension . '/' . $element . '/' . $urlpath . $urlfilename, 'My Alt Text', null, true),
+		$this->assertThat(
+			JHtml::image($extension . '/' . $element . '/' . $urlpath . $urlfilename, 'My Alt Text', null, true),
 			$this->equalTo(
 				'<img src="' . JURI::base(true) . '/media/' . $extension . '/images/' . $element . '/' . $urlpath . $urlfilename .
 					 '" alt="My Alt Text"  />'));
 
-		$this->assertThat(JHtml::image($extension . '/' . $element . '/' . $urlpath . $urlfilename, 'My Alt Text', null, true, true),
+		$this->assertThat(
+			JHtml::image($extension . '/' . $element . '/' . $urlpath . $urlfilename, 'My Alt Text', null, true, true),
 			$this->equalTo(JURI::base(true) . '/media/' . $extension . '/images/' . $element . '/' . $urlpath . $urlfilename));
 
 		unlink(JPATH_ROOT . '/media/' . $extension . '/images/' . $element . '/' . $urlpath . $urlfilename);
@@ -376,25 +422,32 @@ class JHtmlTest extends TestCase
 		mkdir(JPATH_ROOT . '/media/system/images/' . $element . '/' . $urlpath, 0777, true);
 		file_put_contents(JPATH_ROOT . '/media/system/images/' . $element . '/' . $urlpath . $urlfilename, 'test');
 
-		$this->assertThat(JHtml::image($extension . '/' . $element . '/' . $urlpath . $urlfilename, 'My Alt Text', null, true),
+		$this->assertThat(
+			JHtml::image($extension . '/' . $element . '/' . $urlpath . $urlfilename, 'My Alt Text', null, true),
 			$this->equalTo(
 				'<img src="' . JURI::base(true) . '/media/system/images/' . $element . '/' . $urlpath . $urlfilename . '" alt="My Alt Text"  />'));
 
-		$this->assertThat(JHtml::image($extension . '/' . $element . '/' . $urlpath . $urlfilename, 'My Alt Text', null, true, true),
+		$this->assertThat(
+			JHtml::image($extension . '/' . $element . '/' . $urlpath . $urlfilename,
+				'My Alt Text', null, true, true),
 			$this->equalTo(JURI::base(true) . '/media/system/images/' . $element . '/' . $urlpath . $urlfilename));
 
 		unlink(JPATH_ROOT . '/media/system/images/' . $element . '/' . $urlpath . $urlfilename);
 		rmdir(JPATH_ROOT . '/media/system/images/' . $element . '/' . $urlpath);
 		rmdir(JPATH_ROOT . '/media/system/images/' . $element);
 
-		$this->assertThat(JHtml::image($extension . '/' . $element . '/' . $urlpath . $urlfilename, 'My Alt Text', null, true),
+		$this->assertThat(
+			JHtml::image($extension . '/' . $element . '/' . $urlpath . $urlfilename, 'My Alt Text', null, true),
 			$this->equalTo('<img src="" alt="My Alt Text"  />'));
 
-		$this->assertThat(JHtml::image($extension . '/' . $element . '/' . $urlpath . $urlfilename, 'My Alt Text', null, true, true),
+		$this->assertThat(
+			JHtml::image($extension . '/' . $element . '/' . $urlpath . $urlfilename, 'My Alt Text',
+				null, true, true),
 			$this->equalTo(null));
 
 		$this->assertThat(
-			JHtml::image('http://www.example.com/test/image.jpg', 'My Alt Text', array('width' => 150, 'height' => 150)),
+			JHtml::image('http://www.example.com/test/image.jpg', 'My Alt Text', array('width' => 150,
+				'height' => 150)),
 			$this->equalTo('<img src="http://www.example.com/test/image.jpg" alt="My Alt Text" width="150" height="150" />'),
 			'JHtml::image with an absolute path');
 
@@ -404,6 +457,7 @@ class JHtmlTest extends TestCase
 			JHtml::image('test/image.jpg', 'My Alt Text', array('width' => 150, 'height' => 150), false),
 			$this->equalTo('<img src="' . JURI::root(true) . '/test/image.jpg" alt="My Alt Text" width="150" height="150" />'),
 			'JHtml::image with an absolute path, URL does not start with http');
+
 		unlink(JPATH_ROOT . '/test/image.jpg');
 		rmdir(JPATH_ROOT . '/test');
 
@@ -426,7 +480,7 @@ class JHtmlTest extends TestCase
 	public function dataTestIFrame()
 	{
 		return array(
-			// Iframe with text attribs, no noframes text failed
+			// Iframe with text attribs, no noframes text failed.
 			array(
 				'http://www.example.com',
 				'Link Text',
@@ -434,7 +488,7 @@ class JHtmlTest extends TestCase
 				'',
 				'<iframe src="http://www.example.com" title="My Link Title" name="Link Text"></iframe>'),
 
-			// Iframe with array attribs failed
+			// Iframe with array attribs failed.
 			array(
 				'http://www.example.com',
 				'Link Text',
@@ -460,7 +514,9 @@ class JHtmlTest extends TestCase
 	 */
 	public function testIframe($url, $name, $attribs, $noFrames, $expected)
 	{
-		$this->assertThat(JHtml::iframe($url, $name, $attribs, $noFrames), $this->equalTo($expected));
+		$this->assertThat(
+			JHtml::iframe($url, $name, $attribs, $noFrames),
+			$this->equalTo($expected));
 	}
 
 	/**
@@ -484,15 +540,15 @@ class JHtmlTest extends TestCase
 		$_SERVER['HTTP_HOST'] = 'example.com';
 		$_SERVER['SCRIPT_NAME'] = '/index.php';
 
-		// these are some paths to pass to JHtml for testing purposes
+		// These are some paths to pass to JHtml for testing purposes.
 		$urlpath = 'test1/';
 		$urlfilename = 'script1.js';
 
-		// we generate a random template name so that we don't collide or hit anything
+		// We generate a random template name so that we don't collide or hit anything.
 		$template = 'mytemplate' . rand(1, 10000);
 
-		// we create a stub (not a mock because we don't enforce whether it is called or not)
-		// to return a value from getTemplate
+		// We create a stub (not a mock because we don't enforce whether it is called or not)
+		// to return a value from getTemplate.
 		$mock = $this->getMock('myMockObject', array('getTemplate'));
 		$mock->expects($this->any())
 			->method('getTemplate')
@@ -504,12 +560,16 @@ class JHtmlTest extends TestCase
 		mkdir(JPATH_THEMES . '/' . $template . '/js/' . $urlpath, 0777, true);
 		file_put_contents(JPATH_THEMES . '/' . $template . '/js/' . $urlpath . $urlfilename, 'test');
 
-		// we do a test for the case that the js is in the templates directory
+		// We do a test for the case that the js is in the templates directory.
 		JHtml::script($urlpath . $urlfilename, false, true);
-		$this->assertArrayHasKey('/templates/' . $template . '/js/' . $urlpath . $urlfilename, JFactory::$document->_scripts,
+
+		$this->assertArrayHasKey(
+			'/templates/' . $template . '/js/' . $urlpath . $urlfilename,
+			JFactory::$document->_scripts,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the templates directory');
 
-		$this->assertThat(JHtml::script($urlpath . $urlfilename, false, true, true),
+		$this->assertThat(
+			JHtml::script($urlpath . $urlfilename, false, true, true),
 			$this->equalTo(JURI::base(true) . '/templates/' . $template . '/js/' . $urlpath . $urlfilename),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the templates directory');
 
@@ -519,16 +579,19 @@ class JHtmlTest extends TestCase
 		rmdir(JPATH_THEMES . '/' . $template . '/js');
 		rmdir(JPATH_THEMES . '/' . $template);
 
-		// we create the file that JHtml::script will look for
+		// We create the file that JHtml::script will look for.
 		if (!is_dir(dirname(JPATH_ROOT . '/media/' . $urlpath . 'js/' . $urlfilename)))
 		{
 			mkdir(dirname(JPATH_ROOT . '/media/' . $urlpath . 'js/' . $urlfilename), 0777, true);
 		}
 		file_put_contents(JPATH_ROOT . '/media/' . $urlpath . 'js/' . $urlfilename, 'test');
 
-		// we do a test for the case that the js is in the media directory
+		// We do a test for the case that the js is in the media directory.
 		JHtml::script($urlpath . $urlfilename, false, true);
-		$this->assertArrayHasKey('/media/' . $urlpath . 'js/' . $urlfilename, JFactory::$document->_scripts,
+
+		$this->assertArrayHasKey(
+			'/media/' . $urlpath . 'js/' . $urlfilename,
+			JFactory::$document->_scripts,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
 		$this->assertThat(JHtml::script($urlpath . $urlfilename, false, true, true),
@@ -540,32 +603,40 @@ class JHtmlTest extends TestCase
 		rmdir(JPATH_ROOT . '/media/' . $urlpath . 'js');
 		rmdir(JPATH_ROOT . '/media/' . $urlpath);
 
-		// we create the file that JHtml::script will look for
+		// We create the file that JHtml::script will look for.
 		if (!is_dir(dirname(JPATH_ROOT . '/media/system/js/' . $urlfilename)))
 		{
 			mkdir(dirname(JPATH_ROOT . '/media/system/js/' . $urlfilename), 0777, true);
 		}
 		file_put_contents(JPATH_ROOT . '/media/system/js/' . $urlfilename, 'test');
 
-		// we do a test for the case that the js is in the media directory
+		// We do a test for the case that the js is in the media directory.
 		JHtml::script($urlpath . $urlfilename, false, true);
-		$this->assertArrayHasKey('/media/system/js/' . $urlfilename, JFactory::$document->_scripts,
+
+		$this->assertArrayHasKey(
+			'/media/system/js/' . $urlfilename,
+			JFactory::$document->_scripts,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::script($urlpath . $urlfilename, false, true, true),
+		$this->assertThat(
+			JHtml::script($urlpath . $urlfilename, false, true, true),
 			$this->equalTo(JURI::base(true) . '/media/system/js/' . $urlfilename),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
 		JFactory::$document->_scripts = array();
 		unlink(JPATH_ROOT . '/media/system/js/' . $urlfilename);
 
-		// we do a test for the case that the js is in the media directory
+		// We do a test for the case that the js is in the media directory.
 		JHtml::script($urlpath . $urlfilename, false, true);
-		$this->assertThat(JFactory::$document->_scripts,
+
+		$this->assertThat(
+			JFactory::$document->_scripts,
 			$this->logicalNot($this->arrayHasKey('/media/system/js/' . $urlfilename)),
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::script($urlpath . $urlfilename, false, true, true), $this->equalTo(''),
+		$this->assertThat(
+			JHtml::script($urlpath . $urlfilename, false, true, true),
+			$this->equalTo(''),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
 		$extension = 'testextension';
@@ -573,14 +644,18 @@ class JHtmlTest extends TestCase
 		$urlpath = 'path1/';
 		$urlfilename = 'script1.js';
 
+		
 		mkdir(JPATH_ROOT . '/media/' . $extension . '/' . $element . '/js/' . $urlpath, 0777, true);
+
 		file_put_contents(JPATH_ROOT . '/media/' . $extension . '/' . $element . '/js/' . $urlpath . $urlfilename, 'test');
 
 		JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true);
-		$this->assertArrayHasKey('/media/' . $extension . '/' . $element . '/js/' . $urlpath . $urlfilename, JFactory::$document->_scripts,
+		$this->assertArrayHasKey(
+			'/media/' . $extension . '/' . $element . '/js/' . $urlpath . $urlfilename, JFactory::$document->_scripts,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, true),
+		$this->assertThat(
+			JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, true),
 			$this->equalTo(JURI::base(true) . '/media/' . $extension . '/' . $element . '/js/' . $urlpath . $urlfilename),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
@@ -594,12 +669,15 @@ class JHtmlTest extends TestCase
 
 		mkdir(JPATH_ROOT . '/media/' . $extension . '/js/' . $element . '/' . $urlpath, 0777, true);
 		file_put_contents(JPATH_ROOT . '/media/' . $extension . '/js/' . $element . '/' . $urlpath . $urlfilename, 'test');
-
 		JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true);
-		$this->assertArrayHasKey('/media/' . $extension . '/js/' . $element . '/' . $urlpath . $urlfilename, JFactory::$document->_scripts,
+
+		$this->assertArrayHasKey(
+			'/media/' . $extension . '/js/' . $element . '/' . $urlpath . $urlfilename,
+			JFactory::$document->_scripts,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, true),
+		$this->assertThat(
+			JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, true),
 			$this->equalTo(JURI::base(true) . '/media/' . $extension . '/js/' . $element . '/' . $urlpath . $urlfilename),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
@@ -617,7 +695,8 @@ class JHtmlTest extends TestCase
 		$this->assertArrayHasKey('/media/system/js/' . $element . '/' . $urlpath . $urlfilename, JFactory::$document->_scripts,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, true),
+		$this->assertThat(
+			JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, true),
 			$this->equalTo(JURI::base(true) . '/media/system/js/' . $element . '/' . $urlpath . $urlfilename),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
@@ -627,11 +706,15 @@ class JHtmlTest extends TestCase
 		rmdir(JPATH_ROOT . '/media/system/js/' . $element);
 
 		JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true);
-		$this->assertThat(JFactory::$document->_scripts,
+
+		$this->assertThat(
+			JFactory::$document->_scripts,
 			$this->logicalNot($this->arrayHasKey('/media/system/js/' . $urlfilename)),
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, true), $this->equalTo(''),
+		$this->assertThat(
+			JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, true),
+			$this->equalTo(''),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
 		mkdir(JPATH_ROOT . '/media/system/js/' . $element . '/' . $urlpath, 0777, true);
@@ -642,9 +725,15 @@ class JHtmlTest extends TestCase
 		JBrowser::getInstance()->setBrowser('mybrowser');
 
 		JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true);
-		$this->assertArrayHasKey('/media/system/js/' . $element . '/' . $urlpath . $urlfilename, JFactory::$document->_scripts,
+
+		$this->assertArrayHasKey(
+			'/media/system/js/' . $element . '/' . $urlpath . $urlfilename,
+			JFactory::$document->_scripts,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
-		$this->assertArrayHasKey('/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser.js', JFactory::$document->_scripts,
+
+		$this->assertArrayHasKey(
+			'/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser.js',
+			JFactory::$document->_scripts,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
 		$this->assertThat(JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, true),
@@ -656,7 +745,8 @@ class JHtmlTest extends TestCase
 					JURI::base(true) . '/media/system/js/' . $element . '/' . $urlpath . 'script1_mybrowser_0_0.js')),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
-		$this->assertThat(JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, true, false),
+		$this->assertThat(
+			JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, true, false),
 			$this->equalTo(JURI::base(true) . '/media/system/js/' . $element . '/' . $urlpath . $urlfilename),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
@@ -675,52 +765,76 @@ class JHtmlTest extends TestCase
 		JFactory::getConfig()->set('debug', 1);
 		JFactory::$document->_scripts = array();
 		JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true);
-		$this->assertArrayHasKey('/media/system/js/' . $element . '/' . $urlpath . 'script1-uncompressed.js', JFactory::$document->_scripts,
+
+		$this->assertArrayHasKey(
+			'/media/system/js/' . $element . '/' . $urlpath . 'script1-uncompressed.js',
+			JFactory::$document->_scripts,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
-		$this->assertThat(JFactory::$document->_scripts,
+
+		$this->assertThat(
+			JFactory::$document->_scripts,
 			$this->logicalNot($this->arrayHasKey('/media/system/js/' . $element . '/' . $urlpath . $urlfilename)),
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, true),
+		$this->assertThat(
+			JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, true),
 			$this->equalTo(JURI::base(true) . '/media/system/js/' . $element . '/' . $urlpath . 'script1-uncompressed.js'),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
 		JFactory::getConfig()->set('debug', 0);
 		JFactory::$document->_scripts = array();
 		JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true);
-		$this->assertArrayHasKey('/media/system/js/' . $element . '/' . $urlpath . $urlfilename, JFactory::$document->_scripts,
+
+		$this->assertArrayHasKey(
+			'/media/system/js/' . $element . '/' . $urlpath . $urlfilename,
+			JFactory::$document->_scripts,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
-		$this->assertThat(JFactory::$document->_scripts,
+
+		$this->assertThat(
+			JFactory::$document->_scripts,
 			$this->logicalNot($this->arrayHasKey('/media/system/js/' . $element . '/' . $urlpath . 'script1-uncompressed.js')),
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, true),
+		$this->assertThat(
+			JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, true),
 			$this->equalTo(JURI::base(true) . '/media/system/js/' . $element . '/' . $urlpath . 'script1.js'),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
 		JFactory::getConfig()->set('debug', 1);
 		JFactory::$document->_scripts = array();
 		JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, false, true, false);
-		$this->assertArrayHasKey('/media/system/js/' . $element . '/' . $urlpath . $urlfilename, JFactory::$document->_scripts,
+
+		$this->assertArrayHasKey(
+			'/media/system/js/' . $element . '/' . $urlpath . $urlfilename,
+			JFactory::$document->_scripts,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
-		$this->assertThat(JFactory::$document->_scripts,
+
+		$this->assertThat(
+			JFactory::$document->_scripts,
 			$this->logicalNot($this->arrayHasKey('/media/system/js/' . $element . '/' . $urlpath . 'script1-uncompressed.js')),
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, true, true, false),
+		$this->assertThat(
+			JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true,
+				true, true, false),
 			$this->equalTo(JURI::base(true) . '/media/system/js/' . $element . '/' . $urlpath . $urlfilename),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
 		JFactory::getConfig()->set('debug', 0);
 		JFactory::$document->_scripts = array();
 		JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, false, true, false);
-		$this->assertArrayHasKey('/media/system/js/' . $element . '/' . $urlpath . $urlfilename, JFactory::$document->_scripts,
+
+		$this->assertArrayHasKey('/media/system/js/' . $element . '/' . $urlpath . $urlfilename,
+			JFactory::$document->_scripts,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
+
 		$this->assertThat(JFactory::$document->_scripts,
 			$this->logicalNot($this->arrayHasKey('/media/system/js/' . $element . '/' . $urlpath . 'script1-uncompressed.js')),
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true, true, true, false),
+		$this->assertThat(
+			JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, 
+				false, true, true, true, false),
 			$this->equalTo(JURI::base(true) . '/media/system/js/' . $element . '/' . $urlpath . 'script1.js'),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
@@ -761,21 +875,21 @@ class JHtmlTest extends TestCase
 			$_SERVER = array();
 		}
 
-		// we save the state of $_SERVER for later and set it to appropriate values
+		// We save the state of $_SERVER for later and set it to appropriate values.
 		$http_host = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : null;
 		$script_name = isset($_SERVER['SCRIPT_NAME']) ? $_SERVER['SCRIPT_NAME'] : null;
 		$_SERVER['HTTP_HOST'] = 'example.com';
 		$_SERVER['SCRIPT_NAME'] = '/index.php';
 
-		// these are some paths to pass to JHtml for testing purposes
+		// These are some paths to pass to JHtml for testing purposes.
 		$urlpath = 'test1/';
 		$urlfilename = 'style1.css';
 
-		// we generate a random template name so that we don't collide or hit anything
+		// We generate a random template name so that we don't collide or hit anything.
 		$template = 'mytemplate' . rand(1, 10000);
 
-		// we create a stub (not a mock because we don't enforce whether it is called or not)
-		// to return a value from getTemplate
+		// We create a stub (not a mock because we don't enforce whether it is called or not)
+		// to return a value from getTemplate.
 		$mock = $this->getMock('myMockObject', array('getTemplate'));
 		$mock->expects($this->any())
 			->method('getTemplate')
@@ -783,16 +897,19 @@ class JHtmlTest extends TestCase
 
 		JFactory::$application = $mock;
 
-		// we create the file that JHtml::image will look for
+		// We create the file that JHtml::image will look for.
 		mkdir(JPATH_THEMES . '/' . $template . '/css/' . $urlpath, 0777, true);
 		file_put_contents(JPATH_THEMES . '/' . $template . '/css/' . $urlpath . $urlfilename, 'test');
 
-		// we do a test for the case that the css is in the templates directory
+		// We do a test for the case that the css is in the templates directory
 		JHtml::stylesheet($urlpath . $urlfilename, array(), true);
-		$this->assertArrayHasKey('/templates/' . $template . '/css/' . $urlpath . $urlfilename, JFactory::$document->_styleSheets,
+		$this->assertArrayHasKey(
+			'/templates/' . $template . '/css/' . $urlpath . $urlfilename,
+			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the templates directory');
 
-		$this->assertThat(JHtml::stylesheet($urlpath . $urlfilename, array(), true, true),
+		$this->assertThat(
+			JHtml::stylesheet($urlpath . $urlfilename, array(), true, true),
 			$this->equalTo(JURI::base(true) . '/templates/' . $template . '/css/' . $urlpath . $urlfilename),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the templates directory');
 
@@ -802,19 +919,22 @@ class JHtmlTest extends TestCase
 		rmdir(JPATH_THEMES . '/' . $template . '/css');
 		rmdir(JPATH_THEMES . '/' . $template);
 
-		// we create the file that JHtml::script will look for
+		// We create the file that JHtml::script will look for
 		if (!is_dir(dirname(JPATH_ROOT . '/media/' . $urlpath . 'css/' . $urlfilename)))
 		{
 			mkdir(dirname(JPATH_ROOT . '/media/' . $urlpath . 'css/' . $urlfilename), 0777, true);
 		}
 		file_put_contents(JPATH_ROOT . '/media/' . $urlpath . 'css/' . $urlfilename, 'test');
 
-		// we do a test for the case that the css is in the media directory
+		// We do a test for the case that the css is in the media directory.
 		JHtml::stylesheet($urlpath . $urlfilename, array(), true);
-		$this->assertArrayHasKey('/media/' . $urlpath . 'css/' . $urlfilename, JFactory::$document->_styleSheets,
+		$this->assertArrayHasKey(
+			'/media/' . $urlpath . 'css/' . $urlfilename,
+			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::stylesheet($urlpath . $urlfilename, array(), true, true),
+		$this->assertThat(
+			JHtml::stylesheet($urlpath . $urlfilename, array(), true, true),
 			$this->equalTo(JURI::base(true) . '/media/' . $urlpath . 'css/' . $urlfilename),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
@@ -823,32 +943,40 @@ class JHtmlTest extends TestCase
 		rmdir(JPATH_ROOT . '/media/' . $urlpath . 'css');
 		rmdir(JPATH_ROOT . '/media/' . $urlpath);
 
-		// we create the file that JHtml::script will look for
+		// We create the file that JHtml::script will look for.
 		if (!is_dir(dirname(JPATH_ROOT . '/media/system/css/' . $urlfilename)))
 		{
 			mkdir(dirname(JPATH_ROOT . '/media/system/css/' . $urlfilename), 0777, true);
 		}
 		file_put_contents(JPATH_ROOT . '/media/system/css/' . $urlfilename, 'test');
 
-		// we do a test for the case that the css is in the media directory
+		// We do a test for the case that the css is in the media directory.
 		JHtml::stylesheet($urlpath . $urlfilename, array(), true);
-		$this->assertArrayHasKey('/media/system/css/' . $urlfilename, JFactory::$document->_styleSheets,
+
+		$this->assertArrayHasKey(
+			'/media/system/css/' . $urlfilename,
+			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::stylesheet($urlpath . $urlfilename, array(), true, true),
+		$this->assertThat(
+			JHtml::stylesheet($urlpath . $urlfilename, array(), true, true),
 			$this->equalTo(JURI::base(true) . '/media/system/css/' . $urlfilename),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
 		JFactory::$document->_styleSheets = array();
 		unlink(JPATH_ROOT . '/media/system/css/' . $urlfilename);
 
-		// we do a test for the case that the css is in the media directory
+		// We do a test for the case that the css is in the media directory.
 		JHtml::stylesheet($urlpath . $urlfilename, array(), true);
-		$this->assertThat(JFactory::$document->_styleSheets,
+
+		$this->assertThat(
+			JFactory::$document->_styleSheets,
 			$this->logicalNot($this->arrayHasKey('/media/system/css/' . $urlfilename)),
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::stylesheet($urlpath . $urlfilename, array(), true, true), $this->equalTo(''),
+		$this->assertThat(
+			JHtml::stylesheet($urlpath . $urlfilename, array(), true, true),
+			$this->equalTo(''),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
 		$extension = 'testextension';
@@ -858,12 +986,15 @@ class JHtmlTest extends TestCase
 
 		mkdir(JPATH_ROOT . '/media/' . $extension . '/' . $element . '/css/' . $urlpath, 0777, true);
 		file_put_contents(JPATH_ROOT . '/media/' . $extension . '/' . $element . '/css/' . $urlpath . $urlfilename, 'test');
-
 		JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true);
-		$this->assertArrayHasKey('/media/' . $extension . '/' . $element . '/css/' . $urlpath . $urlfilename, JFactory::$document->_styleSheets,
+
+		$this->assertArrayHasKey(
+			'/media/' . $extension . '/' . $element . '/css/' . $urlpath . $urlfilename,
+			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true),
+		$this->assertThat(
+			JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true),
 			$this->equalTo(JURI::base(true) . '/media/' . $extension . '/' . $element . '/css/' . $urlpath . $urlfilename),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
@@ -877,12 +1008,15 @@ class JHtmlTest extends TestCase
 
 		mkdir(JPATH_ROOT . '/media/' . $extension . '/css/' . $element . '/' . $urlpath, 0777, true);
 		file_put_contents(JPATH_ROOT . '/media/' . $extension . '/css/' . $element . '/' . $urlpath . $urlfilename, 'test');
-
 		JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true);
-		$this->assertArrayHasKey('/media/' . $extension . '/css/' . $element . '/' . $urlpath . $urlfilename, JFactory::$document->_styleSheets,
+
+		$this->assertArrayHasKey(
+			'/media/' . $extension . '/css/' . $element . '/' . $urlpath . $urlfilename, 
+			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true),
+		$this->assertThat(
+			JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true),
 			$this->equalTo(JURI::base(true) . '/media/' . $extension . '/css/' . $element . '/' . $urlpath . $urlfilename),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
@@ -893,14 +1027,21 @@ class JHtmlTest extends TestCase
 		rmdir(JPATH_ROOT . '/media/' . $extension . '/css');
 		rmdir(JPATH_ROOT . '/media/' . $extension);
 
-		mkdir(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath, 0777, true);
+		if (!is_dir(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath))
+		{
+			mkdir(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath, 0777, true);
+		}
 		file_put_contents(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . $urlfilename, 'test');
 
 		JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true);
-		$this->assertArrayHasKey('/media/system/css/' . $element . '/' . $urlpath . $urlfilename, JFactory::$document->_styleSheets,
+
+		$this->assertArrayHasKey(
+			'/media/system/css/' . $element . '/' . $urlpath . $urlfilename,
+			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true),
+		$this->assertThat(
+			JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true),
 			$this->equalTo(JURI::base(true) . '/media/system/css/' . $element . '/' . $urlpath . $urlfilename),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
@@ -910,14 +1051,21 @@ class JHtmlTest extends TestCase
 		rmdir(JPATH_ROOT . '/media/system/css/' . $element);
 
 		JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true);
-		$this->assertThat(JFactory::$document->_styleSheets,
+
+		$this->assertThat(
+			JFactory::$document->_styleSheets,
 			$this->logicalNot($this->arrayHasKey('/media/system/css/' . $urlfilename)),
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true), $this->equalTo(''),
+		$this->assertThat(
+			JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true), 
+			$this->equalTo(''),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
-		mkdir(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath, 0777, true);
+		if (!is_dir(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath))
+		{
+			mkdir(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath, 0777, true);
+		}
 		file_put_contents(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . $urlfilename, 'test');
 		file_put_contents(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser.css', 'test');
 		file_put_contents(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser_0.css', 'test');
@@ -925,12 +1073,18 @@ class JHtmlTest extends TestCase
 		JBrowser::getInstance()->setBrowser('mybrowser');
 
 		JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true);
-		$this->assertArrayHasKey('/media/system/css/' . $element . '/' . $urlpath . $urlfilename, JFactory::$document->_styleSheets,
-			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
-		$this->assertArrayHasKey('/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser.css', JFactory::$document->_styleSheets,
+		$this->assertArrayHasKey(
+			'/media/system/css/' . $element . '/' . $urlpath . $urlfilename,
+			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true),
+		$this->assertArrayHasKey(
+			'/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser.css',
+			JFactory::$document->_styleSheets,
+			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
+
+		$this->assertThat(
+			JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true),
 			$this->equalTo(
 				array(
 					JURI::base(true) . '/media/system/css/' . $element . '/' . $urlpath . $urlfilename,
@@ -939,7 +1093,8 @@ class JHtmlTest extends TestCase
 					JURI::base(true) . '/media/system/css/' . $element . '/' . $urlpath . 'style1_mybrowser_0_0.css')),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
-		$this->assertThat(JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true, false),
+		$this->assertThat(
+			JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true, false),
 			$this->equalTo(JURI::base(true) . '/media/system/css/' . $element . '/' . $urlpath . $urlfilename),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
@@ -958,48 +1113,71 @@ class JHtmlTest extends TestCase
 		JFactory::getConfig()->set('debug', 1);
 		JFactory::$document->_styleSheets = array();
 		JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true);
-		$this->assertArrayHasKey('/media/system/css/' . $element . '/' . $urlpath . 'style1-uncompressed.css', JFactory::$document->_styleSheets,
+
+		$this->assertArrayHasKey(
+			'/media/system/css/' . $element . '/' . $urlpath . 'style1-uncompressed.css',
+			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
-		$this->assertThat(JFactory::$document->_styleSheets,
+
+		$this->assertThat(
+			JFactory::$document->_styleSheets,
 			$this->logicalNot($this->arrayHasKey('/media/system/css/' . $element . '/' . $urlpath . $urlfilename)),
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true),
+		$this->assertThat(
+			JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true),
 			$this->equalTo(JURI::base(true) . '/media/system/css/' . $element . '/' . $urlpath . 'style1-uncompressed.css'),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
 		JFactory::getConfig()->set('debug', 0);
 		JFactory::$document->_styleSheets = array();
 		JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, false, true);
-		$this->assertArrayHasKey('/media/system/css/' . $element . '/' . $urlpath . $urlfilename, JFactory::$document->_styleSheets,
+
+		$this->assertArrayHasKey(
+			'/media/system/css/' . $element . '/' . $urlpath . $urlfilename,
+			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
-		$this->assertThat(JFactory::$document->_styleSheets,
+
+		$this->assertThat(
+			JFactory::$document->_styleSheets,
 			$this->logicalNot($this->arrayHasKey('/media/system/css/' . $element . '/' . $urlpath . 'style1-uncompressed.css')),
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true),
+		$this->assertThat(
+			JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true),
 			$this->equalTo(JURI::base(true) . '/media/system/css/' . $element . '/' . $urlpath . 'style1.css'),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
 		JFactory::getConfig()->set('debug', 1);
 		JFactory::$document->_styleSheets = array();
 		JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, false, true, false);
-		$this->assertArrayHasKey('/media/system/css/' . $element . '/' . $urlpath . $urlfilename, JFactory::$document->_styleSheets,
+
+		$this->assertArrayHasKey(
+			'/media/system/css/' . $element . '/' . $urlpath . $urlfilename,
+			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
-		$this->assertThat(JFactory::$document->_styleSheets,
+
+		$this->assertThat(
+			JFactory::$document->_styleSheets,
 			$this->logicalNot($this->arrayHasKey('/media/system/css/' . $element . '/' . $urlpath . 'style1-uncompressed.css')),
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertThat(JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true, true, false),
+		$this->assertThat(
+			JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true, true, false),
 			$this->equalTo(JURI::base(true) . '/media/system/css/' . $element . '/' . $urlpath . $urlfilename),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 
 		JFactory::getConfig()->set('debug', 0);
 		JFactory::$document->_styleSheets = array();
 		JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, false, true, false);
-		$this->assertArrayHasKey('/media/system/css/' . $element . '/' . $urlpath . $urlfilename, JFactory::$document->_styleSheets,
+
+		$this->assertArrayHasKey(
+			'/media/system/css/' . $element . '/' . $urlpath . $urlfilename,
+			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
-		$this->assertThat(JFactory::$document->_styleSheets,
+
+		$this->assertThat(
+			JFactory::$document->_styleSheets,
 			$this->logicalNot($this->arrayHasKey('/media/system/css/' . $element . '/' . $urlpath . 'style1-uncompressed.css')),
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
@@ -1017,10 +1195,15 @@ class JHtmlTest extends TestCase
 		file_put_contents(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . $urlfilename, 'test');
 
 		JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array('media' => 'print, screen'), true);
-		$this->assertArrayHasKey('/media/system/css/' . $element . '/' . $urlpath . $urlfilename, JFactory::$document->_styleSheets,
+
+		$this->assertArrayHasKey(
+			'/media/system/css/' . $element . '/' . $urlpath . $urlfilename,
+			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
+
 		$this->assertEquals(JFactory::$document->_styleSheets['/media/system/css/' . $element . '/' . $urlpath . $urlfilename]['attribs'],
-			array('media' => 'print, screen'), 'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
+			array('media' => 'print, screen'),
+			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
 		JFactory::$document->_styleSheets = array();
 		unlink(JPATH_ROOT . '/media/system/css/' . $element . '/' . $urlpath . $urlfilename);

--- a/tests/suites/unit/joomla/html/JHtmlTest.php
+++ b/tests/suites/unit/joomla/html/JHtmlTest.php
@@ -392,7 +392,7 @@ class JHtmlTest extends TestCase
 		$this->assertThat(JHtml::image($extension . '/' . $element . '/' . $urlpath . $urlfilename, 'My Alt Text', null, true, true),
 			$this->equalTo(JURI::base(true) . '/media/' . $extension . '/' . $element . '/images/' . $urlpath . $urlfilename),
 			'JHtml::image failed when we should get it from the media directory, with the plugin fix path only mode');
-			
+
 		// We remove the file from the media directory.
 		unlink(JPATH_ROOT . '/media/' . $extension . '/' . $element . '/images/' . $urlpath . $urlfilename);
 		rmdir(JPATH_ROOT . '/media/' . $extension . '/' . $element . '/images/' . $urlpath);
@@ -644,7 +644,6 @@ class JHtmlTest extends TestCase
 		$urlpath = 'path1/';
 		$urlfilename = 'script1.js';
 
-		
 		mkdir(JPATH_ROOT . '/media/' . $extension . '/' . $element . '/js/' . $urlpath, 0777, true);
 
 		file_put_contents(JPATH_ROOT . '/media/' . $extension . '/' . $element . '/js/' . $urlpath . $urlfilename, 'test');

--- a/tests/suites/unit/joomla/html/JHtmlTest.php
+++ b/tests/suites/unit/joomla/html/JHtmlTest.php
@@ -1200,7 +1200,8 @@ class JHtmlTest extends TestCase
 			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
-		$this->assertEquals(JFactory::$document->_styleSheets['/media/system/css/' . $element . '/' . $urlpath . $urlfilename]['attribs'],
+		$this->assertEquals(
+			JFactory::$document->_styleSheets['/media/system/css/' . $element . '/' . $urlpath . $urlfilename]['attribs'],
 			array('media' => 'print, screen'),
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 


### PR DESCRIPTION
There were a bunch of tests that had corrupted unit test results because JHtmlTest was having problems in testStylesheet  when it was attempting to create a file with the same name as a file created earlier.
