### PR TITLE
Unify the checking of the platform.

### DIFF
--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -57,6 +57,11 @@ JLoader::register('JRoute', JPATH_PLATFORM . '/joomla/application/route.php');
 // Register the folder for the moved JHtml classes
 JHtml::addIncludePath(JPATH_PLATFORM . '/legacy/html');
 
+// Add deprecated constants
+// @deprecated 12.3
+define('JPATH_ISWIN', IS_WIN);
+define('JPATH_ISMAC', IS_MAC);
+
 // Register classes where the names have been changed to fit the autoloader rules
 // @deprecated  12.3
 JLoader::register('JDatabaseQueryMySQL', JPATH_PLATFORM . '/joomla/database/query/mysql.php');

--- a/libraries/joomla/client/ftp.php
+++ b/libraries/joomla/client/ftp.php
@@ -89,12 +89,6 @@ class JClientFtp
 	private $_type = null;
 
 	/**
-	 * @var    string  Native OS Type
-	 * @since  12.1
-	 */
-	private $_OS = null;
-
-	/**
 	 * @var    array  Array to hold ascii format file extensions
 	 * @since   12.1
 	 */
@@ -150,19 +144,6 @@ class JClientFtp
 			$options['type'] = FTP_BINARY;
 		}
 		$this->setOptions($options);
-
-		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
-		{
-			$this->_OS = 'WIN';
-		}
-		elseif (strtoupper(substr(PHP_OS, 0, 3)) === 'MAC')
-		{
-			$this->_OS = 'MAC';
-		}
-		else
-		{
-			$this->_OS = 'UNIX';
-		}
 
 		if (FTP_NATIVE)
 		{
@@ -612,7 +593,7 @@ class JClientFtp
 		{
 			if (@ftp_site($this->_conn, 'CHMOD ' . $mode . ' ' . $path) === false)
 			{
-				if ($this->_OS != 'WIN')
+				if (!IS_WIN)
 				{
 					JLog::add(JText::_('JLIB_CLIENT_ERROR_JFTP_CHMOD_BAD_RESPONSE_NATIVE'), JLog::WARNING, 'jerror');
 				}
@@ -624,7 +605,7 @@ class JClientFtp
 		// Send change mode command and verify success [must convert mode from octal]
 		if (!$this->_putCmd('SITE CHMOD ' . $mode . ' ' . $path, array(200, 250)))
 		{
-			if ($this->_OS != 'WIN')
+			if (!IS_WIN)
 			{
 				JLog::add(JText::sprintf('JLIB_CLIENT_ERROR_JFTP_CHMOD_BAD_RESPONSE', $this->_response, $path, $mode), JLog::WARNING, 'jerror');
 			}
@@ -863,7 +844,17 @@ class JClientFtp
 		// Let's try to cleanup some line endings if it is ascii
 		if ($mode == FTP_ASCII)
 		{
-			$buffer = preg_replace("/" . CRLF . "/", $this->_lineEndings[$this->_OS], $buffer);
+			$os = 'UNIX';
+			if (IS_WIN)
+			{
+				$os = 'WIN';
+			}
+			elseif (IS_MAC)
+			{
+				$os = 'MAC';
+			}
+
+			$buffer = preg_replace("/" . CRLF . "/", $this->_lineEndings[$os], $buffer);
 		}
 
 		if (!$this->_verifyResponse(226))

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -221,7 +221,7 @@ abstract class JFolder
 			// If open_basedir is set we need to get the open_basedir that the path is in
 			if ($obd != null)
 			{
-				if (JPATH_ISWIN)
+				if (IS_WIN)
 				{
 					$obdSeparator = ";";
 				}

--- a/libraries/joomla/filesystem/path.php
+++ b/libraries/joomla/filesystem/path.php
@@ -9,12 +9,6 @@
 
 defined('JPATH_PLATFORM') or die;
 
-// Define a boolean constant as true if a Windows based host
-define('JPATH_ISWIN', (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN'));
-
-// Define a boolean constant as true if a Mac based host
-define('JPATH_ISMAC', (strtoupper(substr(PHP_OS, 0, 3)) === 'MAC'));
-
 if (!defined('JPATH_ROOT'))
 {
 	// Define a string constant for the root directory of the file system in native format

--- a/libraries/joomla/profiler/profiler.php
+++ b/libraries/joomla/profiler/profiler.php
@@ -50,12 +50,6 @@ class JProfiler
 	protected $previousMem = 0.0;
 
 	/**
-	 * @var    boolean  Boolean if the OS is Windows.
-	 * @since  12.1
-	 */
-	protected $isWin = false;
-
-	/**
 	 * @var    array  JProfiler instances container.
 	 * @since  11.3
 	 */
@@ -73,7 +67,6 @@ class JProfiler
 		$this->start = $this->getmicrotime();
 		$this->prefix = $prefix;
 		$this->buffer = array();
-		$this->isWin = (substr(PHP_OS, 0, 3) == 'WIN');
 	}
 
 	/**
@@ -172,7 +165,7 @@ class JProfiler
 			$output = array();
 			$pid = getmypid();
 
-			if ($this->isWin)
+			if (IS_WIN)
 			{
 				// Windows workaround
 				@exec('tasklist /FI "PID eq ' . $pid . '" /FO LIST', $output);

--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -1094,10 +1094,13 @@ class JApplication extends JApplicationBase
 	 * @return  boolean  True if Windows OS
 	 *
 	 * @since   11.1
+	 * @deprecated  13.3 Use the IS_WIN constant instead.
 	 */
 	public static function isWinOS()
 	{
-		return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+		JLog::add('JApplication::isWinOS() is deprecated. Use the IS_WIN constant instead.', JLog::WARNING, 'deprecated');
+
+		return IS_WIN;
 	}
 
 	/**


### PR DESCRIPTION
The standardizes everything on the IS_WIN/IS_MAC/IS_UNIX constants. JApplication::isWinOS() is only deprecated for legacy purposes.
