### PR TITLE
Joomla CMS [#28741] E_STRICT: JArrayHelper::pivot should be declared as static

### DIFF
--- a/libraries/joomla/utilities/arrayhelper.php
+++ b/libraries/joomla/utilities/arrayhelper.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Utilities
  * @since       11.1
  */
-class JArrayHelper
+abstract class JArrayHelper
 {
 	/**
 	 * Option to perform case-sensitive sorts.
@@ -366,7 +366,7 @@ class JArrayHelper
 	 *
 	 * @since   11.3
 	 */
-	public function pivot($source, $key = null)
+	public static function pivot($source, $key = null)
 	{
 		$result = array();
 		$counter = array();


### PR DESCRIPTION
See http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28741
