### PR TITLE
Fix issue with cURL confusing itself with 100 Continue headers.

### DIFF
--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -131,6 +131,10 @@ class JHttpTransportCurl implements JHttpTransport
 		// Return it... echoing it would be tacky.
 		$options[CURLOPT_RETURNTRANSFER] = true;
 
+		// Override the Expect header to prevent cURL from confusing itself in it's own stupidity.
+		// @see http://the-stickman.com/web-development/php-and-curl-disabling-100-continue-header/
+		$options[CURLOPT_HTTPHEADER][] = 'Expect:';
+
 		// Set the cURL options.
 		curl_setopt_array($ch, $options);
 


### PR DESCRIPTION
cURL has an issue handling 100 Continue headers. It sends an Expect for 100 Continue however when it was given a 100 Continue header, it uses that and populates it with no header information and then puts the expected headers in with the rest of the body. This obviously makes life rather difficult to process the headers or make any assumptions about the contents of the body.
