### PR TITLE
Add a proxy for execute method

### DIFF
--- a/libraries/joomla/controller/base.php
+++ b/libraries/joomla/controller/base.php
@@ -50,6 +50,20 @@ abstract class JControllerBase implements JController
 	}
 
 	/**
+	 * Proxy to execute the controller.
+	 *
+	 * @return  boolean  True if controller finished execution, false if the controller did not
+	 *                   finish execution. A controller might return false if some precondition for
+	 *                   the controller to run has not been satisfied.
+	 *
+	 * @since   12.2
+	 */
+	public function __invoke()
+	{
+		return $this->execute();
+	}
+
+	/**
 	 * Get the application object.
 	 *
 	 * @return  JApplicationBase  The application object.


### PR DESCRIPTION
Since a controller is designed to be executed using the execute medhod, it could be a fancy and shorter way to call

```
$controller();
```

instead of

```
$controller->execute();
```
