### PR TITLE
Move JGrid to its own package and allow JHtml to use the autoloader again.

### DIFF
--- a/libraries/joomla/grid/grid.php
+++ b/libraries/joomla/grid/grid.php
@@ -3,7 +3,7 @@
  * JGrid class to dynamically generate HTML tables
  *
  * @package     Joomla.Platform
- * @subpackage  HTML
+ * @subpackage  Grid
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * JGrid class to dynamically generate HTML tables
  *
  * @package     Joomla.Platform
- * @subpackage  HTML
+ * @subpackage  Grid
  * @since       11.3
  */
 class JGrid

--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -108,14 +108,14 @@ abstract class JHtml
 
 		$className = $prefix . ucfirst($file);
 
-		if (!class_exists($className, false))
+		if (!class_exists($className))
 		{
 			$path = JPath::find(self::$includePaths, strtolower($file) . '.php');
 			if ($path)
 			{
 				require_once $path;
 
-				if (!class_exists($className, false))
+				if (!class_exists($className))
 				{
 					throw new InvalidArgumentException(sprintf('%s not found.', $className), 500);
 				}

--- a/tests/suites/unit/joomla/grid/JGridTest.php
+++ b/tests/suites/unit/joomla/grid/JGridTest.php
@@ -1,20 +1,17 @@
 <?php
 /**
  * @package     Joomla.UnitTest
- * @subpackage  HTML
+ * @subpackage  Grid
  *
  * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
-jimport('joomla.html.grid');
-
-
 /**
  * General inspector class for JGrid.
  *
  * @package Joomla.UnitTest
- * @subpackage HTML
+ * @subpackage Grid
  * @since 11.3
  */
 class JGridInspector extends JGrid


### PR DESCRIPTION
This is required for the CMS, since it relies on the autoloader for JHtml classes.
