### PR TITLE
Changing error messages into ErrorException

### DIFF
--- a/libraries/import.php
+++ b/libraries/import.php
@@ -6,6 +6,17 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
+// Change error messages into ErrorException
+set_error_handler(
+	function($errno, $errstr, $errfile, $errline)
+	{
+		if (($errno & error_reporting()) === $errno)
+		{
+			throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
+		}
+	}
+);
+
 // Set the platform root path as a constant if necessary.
 if (!defined('JPATH_PLATFORM'))
 {

--- a/tests/suites/unit/JImportTest.php
+++ b/tests/suites/unit/JImportTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Test class for import.php.
+ *
+ * @package	 Joomla.UnitTest
+ * @since    12.2
+ */
+class JImportTest extends PHPUnit_Framework_TestCase
+{
+	/**
+	 * Tests the error handler when throwing an ErrorException.
+	 *
+	 * @return  void
+	 *
+	 * @expectedException ErrorException
+	 *
+	 * @since   12.2
+	 */
+	public function testErrorException()
+	{
+		$a = $b;
+	}
+
+	/**
+	 * Tests the error handler when being silent.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.2
+	 */
+	public function testErrorControlOperator()
+	{
+		ob_start();
+		$a = @$b;
+		$out = ob_get_clean();
+		$this->assertThat(
+			$out,
+			$this->equalTo('')
+		);
+	}
+}

--- a/tests/suites/unit/joomla/database/database/JDatabaseExporterMySqlTest.php
+++ b/tests/suites/unit/joomla/database/database/JDatabaseExporterMySqlTest.php
@@ -489,7 +489,7 @@ class JDatabaseExporterMySqlTest extends PHPUnit_Framework_TestCase
 		{
 			$instance->setDbo(new stdClass);
 		}
-		catch (PHPUnit_Framework_Error $e)
+		catch (ErrorException $e)
 		{
 			// Expecting the error, so just ignore it.
 			return;

--- a/tests/suites/unit/joomla/database/database/JDatabaseExporterMySqliTest.php
+++ b/tests/suites/unit/joomla/database/database/JDatabaseExporterMySqliTest.php
@@ -135,7 +135,7 @@ class JDatabaseExporterMySQLiTest extends PHPUnit_Framework_TestCase
 		{
 			$instance->setDbo(new stdClass);
 		}
-		catch (PHPUnit_Framework_Error $e)
+		catch (ErrorException $e)
 		{
 			// Expecting the error, so just ignore it.
 			return;

--- a/tests/suites/unit/joomla/database/database/JDatabaseExporterPostgresqlTest.php
+++ b/tests/suites/unit/joomla/database/database/JDatabaseExporterPostgresqlTest.php
@@ -587,7 +587,7 @@ class JDatabaseExporterPostgresqlTest extends PHPUnit_Framework_TestCase
 		{
 			$instance->setDbo(new stdClass);
 		}
-		catch (PHPUnit_Framework_Error $e)
+		catch (ErrorException $e)
 		{
 			// Expecting the error, so just ignore it.
 			return;

--- a/tests/suites/unit/joomla/database/database/JDatabaseImporterMySqlTest.php
+++ b/tests/suites/unit/joomla/database/database/JDatabaseImporterMySqlTest.php
@@ -765,7 +765,7 @@ class JDatabaseImporterMySqlTest extends PHPUnit_Framework_TestCase
 		{
 			$instance->setDbo(new stdClass);
 		}
-		catch (PHPUnit_Framework_Error $e)
+		catch (ErrorException $e)
 		{
 			// Expecting the error, so just ignore it.
 			return;

--- a/tests/suites/unit/joomla/database/database/JDatabaseImporterMySqliTest.php
+++ b/tests/suites/unit/joomla/database/database/JDatabaseImporterMySqliTest.php
@@ -135,7 +135,7 @@ class JDatabaseImporterMySQLiTest extends PHPUnit_Framework_TestCase
 		{
 			$instance->setDbo(new stdClass);
 		}
-		catch (PHPUnit_Framework_Error $e)
+		catch (ErrorException $e)
 		{
 			// Expecting the error, so just ignore it.
 			return;

--- a/tests/suites/unit/joomla/database/database/JDatabaseImporterPostgresqlTest.php
+++ b/tests/suites/unit/joomla/database/database/JDatabaseImporterPostgresqlTest.php
@@ -974,7 +974,7 @@ class JDatabaseImporterPostgresqlTest extends PHPUnit_Framework_TestCase
 		{
 			$instance->setDbo(new stdClass);
 		}
-		catch (PHPUnit_Framework_Error $e)
+		catch (ErrorException $e)
 		{
 			// Expecting the error, so just ignore it.
 			return;

--- a/tests/suites/unit/joomla/form/JFormFieldTest.php
+++ b/tests/suites/unit/joomla/form/JFormFieldTest.php
@@ -290,7 +290,7 @@ class JFormFieldTest extends TestCase
 	 * Test an invalid argument for the JFormField::setup method
 	 *
 	 * @covers JFormField::setup
-	 * @expectedException PHPUnit_Framework_Error
+	 * @expectedException ErrorException
 	 */
 	public function testSetupInvalidElement()
 	{


### PR DESCRIPTION
This will allow to not use the silent operator @ for php function that emit error message such as fopen, ...

i.e.

instead of doing

```
$handle = @fopen('/path/to/file', 'w');
```

we could do

```
try
{
    $handle = fopen('/path/to/file', 'w');
}
catch (ErrorException $e)
{
    // Deal with error
}
```
