### PR TITLE
Check that $wpoption['modulemode'] == 1, not just that it is set.

### DIFF
--- a/libraries/joomla/cache/controller/callback.php
+++ b/libraries/joomla/cache/controller/callback.php
@@ -144,7 +144,7 @@ class JCacheControllerCallback extends JCacheController
 			if (isset($woptions['modulemode']) && $woptions['modulemode'] == 1)
 			{
 				$document = JFactory::getDocument();
-				$coptions['modulemode'] = $woptions['modulemode'];
+				$coptions['modulemode'] = 1;
 				$coptions['headerbefore'] = $document->getHeadData();
 			}
 			else

--- a/libraries/joomla/cache/controller/callback.php
+++ b/libraries/joomla/cache/controller/callback.php
@@ -141,7 +141,7 @@ class JCacheControllerCallback extends JCacheController
 				$locktest = $this->cache->lock($id);
 			}
 
-			if (isset($woptions['modulemode']))
+			if (isset($woptions['modulemode']) && $woptions['modulemode'] == 1)
 			{
 				$document = JFactory::getDocument();
 				$coptions['modulemode'] = $woptions['modulemode'];


### PR DESCRIPTION
This is a fix for this bug:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28676
