### PR TITLE
Joomla doesn't cache modules for logged users

### DIFF
--- a/libraries/legacy/module/helper.php
+++ b/libraries/legacy/module/helper.php
@@ -416,8 +416,8 @@ abstract class JModuleHelper
 		$cache = JFactory::getCache($cacheparams->cachegroup, 'callback');
 		$conf = JFactory::getConfig();
 
-		// Turn cache off for internal callers if parameters are set to off and for all logged in users
-		if ($moduleparams->get('owncache', null) === '0' || $conf->get('caching') == 0 || $user->get('id'))
+		// Turn cache off for internal callers if parameters are set to off
+		if ($moduleparams->get('owncache', null) === '0' || $conf->get('caching') == 0)
 		{
 			$cache->setCaching(false);
 		}


### PR DESCRIPTION
This is a big issue since 2.5.0, modules should be cached for logged users also.
