### PR TITLE
Joomla! throws error with valid xml string

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -407,7 +407,7 @@ abstract class JFactory
 			$xml = simplexml_load_string($data, 'JXMLElement');
 		}
 
-		if (empty($xml))
+		if ($xml === false)
 		{
 			JLog::add(JText::_('JLIB_UTIL_ERROR_XML_LOAD'), JLog::WARNING, 'jerror');
 


### PR DESCRIPTION
Test:

$xml = JFactory::getXML('&lt;foo /&gt;');

expected result:

No JError warning

actual result:

Joomla! calls a "JLIB_UTIL_ERROR_XML_LOAD" JError Warning

Solution:

Don't check for "empty()", use === false instead.
