### PR TITLE
PDO does not support serialization

### DIFF
--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -934,4 +934,15 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 
 		return false;
 	}
+
+	/**
+	 * PDO does not support serialize
+	 *
+	 * @return  array
+	 * @since   12.3
+	 */
+	public function __sleep()
+	{
+		return array();
+	}
 }

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -939,6 +939,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	 * PDO does not support serialize
 	 *
 	 * @return  array
+	 *
 	 * @since   12.3
 	 */
 	public function __sleep()

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -956,8 +956,8 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 
 		foreach ($properties as $key => $property)
 		{
-			// Do not serialize connection (may be PDO) and static properties
-			if (strcmp($property->name, 'connection') !== 0 && !array_key_exists($property->name, $staticProperties))
+			// Do not serialize properties that are PDO
+			if ($property->isStatic() == false && !($this->{$property->name} instanceof PDO))
 			{
 				array_push($serializedProperties, $property->name);
 			}

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -947,10 +947,16 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		$serializedProperties = array();
 
 		$reflect = new ReflectionClass($this);
+
+		// Get properties of the current class
 		$properties = $reflect->getProperties();
+
+		// Static properties of the current class
 		$staticProperties = $reflect->getStaticProperties();
+
 		foreach ($properties as $key => $property)
 		{
+			// Do not serialize connection (may be PDO) and static properties
 			if (strcmp($property->name, 'connection') !== 0 && !array_key_exists($property->name, $staticProperties))
 			{
 				array_push($serializedProperties, $property->name);
@@ -969,6 +975,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	 */
 	public function __wakeup()
 	{
+		// Get connection back
 		$this->__construct($this->options);
 	}
 }

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -944,6 +944,31 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	 */
 	public function __sleep()
 	{
-		return array();
+		$serializedProperties = array();
+
+		$reflect = new ReflectionClass($this);
+		$properties = $reflect->getProperties();
+		$staticProperties = $reflect->getStaticProperties();
+		foreach ($properties as $key => $property)
+		{
+			if (strcmp($property->name, 'connection') !== 0 && !array_key_exists($property->name, $staticProperties))
+			{
+				array_push($serializedProperties, $property->name);
+			}
+		}
+
+		return $serializedProperties;
+	}
+
+	/**
+	 * Wake up after serialization
+	 *
+	 * @return  array
+	 *
+	 * @since   12.3
+	 */
+	public function __wakeup()
+	{
+		$this->__construct($this->options);
 	}
 }


### PR DESCRIPTION
PDO does not support serialization, so I think it should not be serialized. Adding the __sleep method would prevent serializing properties that are instances of PDO.

The connection is established again on __wakeup.
