### PR TITLE
Correct use of setLocation

### DIFF
--- a/libraries/joomla/installer/adapters/component.php
+++ b/libraries/joomla/installer/adapters/component.php
@@ -1256,7 +1256,17 @@ class JInstallerComponent extends JAdapterInstance
 			$data['img'] = ((string) $menuElement->attributes()->img) ? (string) $menuElement->attributes()->img : 'class:component';
 			$data['home'] = 0;
 
-			if (!$table->setLocation(1, 'last-child') || !$table->bind($data) || !$table->check() || !$table->store())
+			try
+			{
+				$table->setLocation(1, 'last-child');
+			}
+			catch (InvalidArgumentException $e)
+			{
+				JLog::add($e->getMessage(), JLog::WARNING, 'jerror');
+				return false;
+			}
+
+			if (!$table->bind($data) || !$table->check() || !$table->store())
 			{
 				// Install failed, warn user and rollback changes
 				JLog::add($table->getError(), JLog::WARNING, 'jerror');
@@ -1285,7 +1295,17 @@ class JInstallerComponent extends JAdapterInstance
 			$data['img'] = 'class:component';
 			$data['home'] = 0;
 
-			if (!$table->setLocation(1, 'last-child') || !$table->bind($data) || !$table->check() || !$table->store())
+			try
+			{
+				$table->setLocation(1, 'last-child');
+			}
+			catch (InvalidArgumentException $e)
+			{
+				JLog::add($e->getMessage(), JLog::WARNING, 'jerror');
+				return false;
+			}
+
+			if (!$table->bind($data) || !$table->check() || !$table->store())
 			{
 				// Install failed, warn user and rollback changes
 				JLog::add($table->getError(), JLog::WARNING, 'jerror');
@@ -1369,7 +1389,16 @@ class JInstallerComponent extends JAdapterInstance
 
 			$table = JTable::getInstance('menu');
 
-			if (!$table->setLocation($parent_id, 'last-child') || !$table->bind($data) || !$table->check() || !$table->store())
+			try
+			{
+				$table->setLocation($parent_id, 'last-child');
+			}
+			catch (InvalidArgumentException $e)
+			{
+				return false;
+			}
+
+			if (!$table->bind($data) || !$table->check() || !$table->store())
 			{
 				// Install failed, rollback changes
 				return false;


### PR DESCRIPTION
Since the API for JTableNested::setLocation changed to not return a boolean value, its use in the component install adapter needs to be corrected.  As is, component menu items are not created because of the use of the old API.
