### PR TITLE
Don't have JFactory depend on SimplePie and move the code related to it to legacy.

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -341,36 +341,18 @@ abstract class JFactory
 	 * @return  mixed  SimplePie parsed object on success, false on failure.
 	 *
 	 * @since   11.1
+	 * @deprecated  13.3  Use JSimplepieFactory::getFeedParser() instead.
 	 */
 	public static function getFeedParser($url, $cache_time = 0)
 	{
-		jimport('simplepie.simplepie');
-
-		$cache = self::getCache('feed_parser', 'callback');
-
-		if ($cache_time > 0)
+		if (!class_exists('JSimplepieFactory'))
 		{
-			$cache->setLifeTime($cache_time);
+			throw new BadMethodCallException('JSimplepieFactory not found');
 		}
 
-		$simplepie = new SimplePie(null, null, 0);
+		JLog::add(__METHOD__ . ' is deprecated.   Use JSimplepieFactory::getFeedParser() instead.', JLog::WARNING, 'deprecated');
 
-		$simplepie->enable_cache(false);
-		$simplepie->set_feed_url($url);
-		$simplepie->force_feed(true);
-
-		$contents = $cache->get(array($simplepie, 'init'), null, false, false);
-
-		if ($contents)
-		{
-			return $simplepie;
-		}
-		else
-		{
-			JLog::add(JText::_('JLIB_UTIL_ERROR_LOADING_FEED_DATA'), JLog::WARNING, 'jerror');
-		}
-
-		return false;
+		return JSimplepieFactory::getFeedParser($url, $cache_time);
 	}
 
 	/**
@@ -441,6 +423,8 @@ abstract class JFactory
 		{
 			throw new BadMethodCallException('JEditor not found');
 		}
+
+		JLog::add(__METHOD__ . ' is deprecated. Use JEditor directly.', JLog::WARNING, 'deprecated');
 
 		// Get the editor configuration setting
 		if (is_null($editor))

--- a/libraries/legacy/simplepie/factory.php
+++ b/libraries/legacy/simplepie/factory.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @package     Joomla.Legacy
+ * @subpackage  Simplepie
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+jimport('simplepie.simplepie');
+
+/**
+ * Class to maintain a pathway.
+ *
+ * The user's navigated path within the application.
+ *
+ * @package     Joomla.Legacy
+ * @subpackage  Simplepie
+ * @since       12.2
+ */
+class JSimplepieFactory
+{
+	/**
+	 * Get a parsed XML Feed Source
+	 *
+	 * @param   string   $url         Url for feed source.
+	 * @param   integer  $cache_time  Time to cache feed for (using internal cache mechanism).
+	 *
+	 * @return  mixed  SimplePie parsed object on success, false on failure.
+	 *
+	 * @since   12.2
+	 * @deprecated  12.3  Will be dropped without replacement.
+	 */
+	public static function getFeedParser($url, $cache_time = 0)
+	{
+		$cache = JFactory::getCache('feed_parser', 'callback');
+
+		if ($cache_time > 0)
+		{
+			$cache->setLifeTime($cache_time);
+		}
+
+		$simplepie = new SimplePie(null, null, 0);
+
+		$simplepie->enable_cache(false);
+		$simplepie->set_feed_url($url);
+		$simplepie->force_feed(true);
+
+		$contents = $cache->get(array($simplepie, 'init'), null, false, false);
+
+		if ($contents)
+		{
+			return $simplepie;
+		}
+
+		JLog::add(JText::_('JLIB_UTIL_ERROR_LOADING_FEED_DATA'), JLog::WARNING, 'jerror');
+
+		return false;
+	}
+}


### PR DESCRIPTION
SimplePie ist outdated and throws way too many E_STRICT errors. These changes allow us to eventually remove it. The different versions for the @deprecated tags are for backwards compatibility for the CMS. The CMS can take JSimplepieFactory but we need the method in JFactory for the next cycle.
