### PR TITLE
Joomla CMS [#28633] JUserHelper getProfile method should be static

### DIFF
--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -193,7 +193,7 @@ abstract class JUserHelper
 	 *
 	 * @since   11.1
 	 */
-	public function getProfile($userId = 0)
+	public static function getProfile($userId = 0)
 	{
 		if ($userId == 0)
 		{


### PR DESCRIPTION
In no way a major issue; noticed while using JUserHelper::getProfile that it is
not declared as static:

public static function getProfile($userId = 0)

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28633

I don't believe there are backward compatibility issues.
