### PR TITLE
Handling msg object in adapter uninstall

### DIFF
--- a/libraries/joomla/installer/adapters/file.php
+++ b/libraries/joomla/installer/adapters/file.php
@@ -485,6 +485,11 @@ class JInstallerFile extends JAdapterInstance
 			$msg = ob_get_contents();
 			ob_end_clean();
 
+			if ($msg != '')
+			{
+				$this->parent->set('extension_message', $msg);
+			}
+
 			// Let's run the uninstall queries for the extension
 			$result = $this->parent->parseSQLFiles($this->manifest->uninstall->sql);
 

--- a/libraries/joomla/installer/adapters/module.php
+++ b/libraries/joomla/installer/adapters/module.php
@@ -798,6 +798,11 @@ class JInstallerModule extends JAdapterInstance
 		$msg = ob_get_contents();
 		ob_end_clean();
 
+		if ($msg != '')
+		{
+			$this->parent->set('extension_message', $msg);
+		}
+
 		if (!($this->manifest instanceof SimpleXMLElement))
 		{
 			// Make sure we delete the folders

--- a/libraries/joomla/installer/adapters/package.php
+++ b/libraries/joomla/installer/adapters/package.php
@@ -451,6 +451,11 @@ class JInstallerPackage extends JAdapterInstance
 		$msg = ob_get_contents();
 		ob_end_clean();
 
+		if ($msg != '')
+		{
+			$this->parent->set('extension_message', $msg);
+		}
+
 		$error = false;
 		foreach ($manifest->filelist as $extension)
 		{

--- a/libraries/joomla/installer/adapters/plugin.php
+++ b/libraries/joomla/installer/adapters/plugin.php
@@ -633,10 +633,6 @@ class JInstallerPlugin extends JAdapterInstance
 			}
 		}
 
-		// Create msg object; first use here
-		$msg = ob_get_contents();
-		ob_end_clean();
-
 		// Let's run the queries for the plugin
 		$utfresult = $this->parent->parseSQLFiles($this->manifest->uninstall->sql);
 		if ($utfresult === false)
@@ -678,7 +674,7 @@ class JInstallerPlugin extends JAdapterInstance
 		// Remove the plugin's folder
 		JFolder::delete($this->parent->getPath('extension_root'));
 
-		if ($msg)
+		if ($msg != '')
 		{
 			$this->parent->set('extension_message', $msg);
 		}


### PR DESCRIPTION
1) Presently, a PHP Notice "ob_end_clean(): failed to delete buffer. No buffer to delete in /libraries/joomla/installer/adapters/plugin.php on line 638" is thrown during plugin uninstall because a `$msg` object is created before the `ob_start()` command is issued.  This instance is not necessary since the object is set at the correct time after the custom uninstall method.

2) In the file, module, and package adapters, the `$msg` object wasn't registered to extension_message, contradictory in behavior to the component and plugin adapters.  This is corrected.
