### PR TITLE
Some additional preparations for lazy sessions.

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -1049,13 +1049,6 @@ class JApplicationWeb extends JApplicationBase
 			$session->restart();
 		}
 
-		// If the session is new, load the user and registry objects.
-		if ($session->isNew())
-		{
-			$session->set('registry', new JRegistry);
-			$session->set('user', new JUser);
-		}
-
 		// Set the session object.
 		$this->session = $session;
 

--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -1056,13 +1056,6 @@ class JApplication extends JApplicationBase
 			{
 				jexit($e->getMessage());
 			}
-
-			// Session doesn't exist yet, so create session variables
-			if ($session->isNew())
-			{
-				$session->set('registry', new JRegistry('session'));
-				$session->set('user', new JUser);
-			}
 		}
 	}
 


### PR DESCRIPTION
This is mostly small clean up, we need access to the store name to make some decisions based on whether the database is used as the store or not. This way we don't have to rely on the configuration for that.

The interesting part here is https://github.com/joomla/joomla-platform/pull/1349/files#L1R591. This code is kinda specific to the Joomla-Platform and used in several places, it does limit the ability of using our session system without our user system for example. The question is where else to put it. Any suggestions?
