### PR TITLE
Add a more complex truncation method to JHtmlString (with tests)

### DIFF
--- a/libraries/joomla/html/html/string.php
+++ b/libraries/joomla/html/html/string.php
@@ -182,8 +182,8 @@ abstract class JHtmlString
 		for ($maxLength; $maxLength < $baseLength;)
 		{
 			// We need to trim the ellipsis that truncate adds.
-
 			$ptString = rtrim($ptString,'.');
+
 			// Now get the truncated string if HTML is allowed.
 			$htmlString = JHtml::_('string.truncate', $html, $maxLength, $noSplit, $allowHtml = true);
 			$htmlString = rtrim($htmlString,'.');
@@ -200,6 +200,7 @@ abstract class JHtmlString
 				{
 					return $htmlString;
 				}
+
 				// Otherwise, put back the ellipsis
 				return $htmlString . '...';
 			}

--- a/libraries/joomla/html/html/string.php
+++ b/libraries/joomla/html/html/string.php
@@ -166,7 +166,7 @@ abstract class JHtmlString
 		$baseLength = strlen($html);
 		$diffLength = 0;
 
-		// Deal with maximum lenth of 1 directly
+		// Deal with maximum length of 1 directly
 		if ($maxLength == 1 && substr($html, 0, 1) == '<')
 		{
 			$endTagPos = strlen(strstr($html,'>',true));
@@ -195,7 +195,12 @@ abstract class JHtmlString
 			// If the new plain text string matches the original plain text string we are done.
 			if ($ptString == $htmlStringToPtString)
 			{
-				// Put back the ellipsis
+				// If the HTML string includes the whole input string, we don't need an ellipsis.
+				if ($baseLength == strlen(trim($htmlString)))
+				{
+					return $htmlString;
+				}
+				// Otherwise, put back the ellipsis
 				return $htmlString . '...';
 			}
 

--- a/libraries/joomla/html/html/string.php
+++ b/libraries/joomla/html/html/string.php
@@ -155,11 +155,13 @@ abstract class JHtmlString
 	* The goal is to get the proper length plain text string with as much of 
 	* the html intact as possible with all tags properly closed.
 	* 
-	* @param string   $html       The content of the introtext to be truncated
-	* @param integer  $maxLength  The maximum number of characters to render
-	* @param   boolean  $noSplit    Don't split a word if that is where the cutoff occurs (default: true).
+	* @param  string   $html       The content of the introtext to be truncated
+	* @param  integer  $maxLength  The maximum number of characters to render
+	* @param  boolean  $noSplit    Don't split a word if that is where the cutoff occurs (default: true).
 	* 
 	* @return  string  The truncated string
+	* 
+	* @since   12.2
 	*/
 	public static function truncateComplex($html, $maxLength = 0, $noSplit = true)
 	{

--- a/libraries/joomla/html/html/string.php
+++ b/libraries/joomla/html/html/string.php
@@ -65,7 +65,7 @@ abstract class JHtmlString
 			{
 					return '...';
 			}
-
+echo 'tm'; var_dump($tmp);
 			// $noSplit true means that we do not allow splitting of words.
 			if ($noSplit)
 			{
@@ -173,8 +173,14 @@ abstract class JHtmlString
 			$endTagPos = strlen(strstr($html, '>', true));
 			$tag = substr($html, 1, $endTagPos);
 
-			$l = $endTagPos + 2;
-			return substr($html, 0, $l) . '</' . $tag;
+			$l = $endTagPos + 1;
+			if ($noSplit)
+			{
+				return substr($html, 0, $l) . '</' . $tag . '...';
+			}
+			$character = substr(strip_tags($html), 0, 1);
+
+			return substr($html, 0, $l) .  $character . '</' . $tag . '...';			
 		}
 
 		// First get the truncated plain text string. This is the rendered text we want to end up with.
@@ -187,6 +193,7 @@ abstract class JHtmlString
 
 			// Now get the truncated string if HTML is allowed.
 			$htmlString = JHtml::_('string.truncate', $html, $maxLength, $noSplit, $allowHtml = true);
+
 			$htmlString = rtrim($htmlString, '.');
 
 			// Now get the plain text from the HTML string.

--- a/libraries/joomla/html/html/string.php
+++ b/libraries/joomla/html/html/string.php
@@ -87,7 +87,7 @@ abstract class JHtmlString
 				}
 
 				// Offset is calculated from 0 so to use it for length we need to adjust it.
-				$offset += 1;
+				$offset = $offset + 1;
 				$tmp = JString::substr($tmp, 0, $offset);
 
 				// If we don't have 3 characters of room, go to the second space within the limit.
@@ -170,11 +170,11 @@ abstract class JHtmlString
 		// Deal with maximum length of 1 directly
 		if ($maxLength == 1 && substr($html, 0, 1) == '<')
 		{
-			$endTagPos = strlen(strstr($html,'>',true));
+			$endTagPos = strlen(strstr($html, '>', true));
 			$tag = substr($html, 1, $endTagPos);
 
 			$l = $endTagPos + 2;
-			return substr($html, 0, $l) . '</'. $tag;
+			return substr($html, 0, $l) . '</' . $tag;
 		}
 
 		// First get the truncated plain text string. This is the rendered text we want to end up with.
@@ -183,7 +183,7 @@ abstract class JHtmlString
 		for ($maxLength; $maxLength < $baseLength;)
 		{
 			// We need to trim the ellipsis that truncate adds.
-			$ptString = rtrim($ptString,'.');
+			$ptString = rtrim($ptString, '.');
 
 			// Now get the truncated string if HTML is allowed.
 			$htmlString = JHtml::_('string.truncate', $html, $maxLength, $noSplit, $allowHtml = true);

--- a/libraries/joomla/html/html/string.php
+++ b/libraries/joomla/html/html/string.php
@@ -117,6 +117,57 @@ abstract class JHtmlString
 	}
 
 	/**
+	* Method to extend the truncate method to more complex situations 
+	* 
+	* The goal is to get the proper length plain text string with as much of 
+	* the html intact as possible with all tags properly closed.
+	* 
+	* @param string   $html       The content of the introtext to be truncated
+	* @param integer  $maxLength  The maximum number of charactes to render
+	* 
+	* @return  string  The truncated string
+	*/
+	public static function truncateComplex($html, $maxLength = 0)
+	{
+		$baseLength = strlen($html);
+		$diffLength = 0;
+
+		// First get the truncated plain text string. This is the rendered text we want to end up with.
+		$ptString = JHtml::_('string.truncate', $html, $maxLength, $noSplit = true, $allowHtml = false);
+
+		for ($maxLength; $maxLength < $baseLength;)
+		{
+			// Now get the truncated string if HTML is allowed.
+			$htmlString = JHtml::_('string.truncate', $html, $maxLength, $noSplit = true, $allowHtml = true);
+
+			// Now get the plain text from the html string.
+			$htmlStringToPtString = JHtml::_('string.truncate', $htmlString, $maxLength, $noSplit = true, $allowHtml = false);
+
+			// If the new plain text string matches the original plain text string we are done.
+			if ($ptString == $htmlStringToPtString)
+			{
+				return $htmlString;
+			}
+
+			// Get the number of HTML tag characters in the first $maxLength characters
+			$diffLength = strlen($ptString) - strlen($htmlStringToPtString);
+
+			// Set new $maxlength that adjusts for the html tags
+			$maxLength += $diffLength;
+
+			// Check to see if we are done, if not repeat.
+			if ($baseLength <= $maxLength || $diffLength <= 0)
+			{
+				return $htmlString;
+			}
+		}
+		
+		// If the original HTML string is shorter than the $maxLength do nothing and return that.
+		return $html;
+	}
+
+
+	/**
 	 * Abridges text strings over the specified character limit. The
 	 * behavior will insert an ellipsis into the text replacing a section
 	 * of variable size to ensure the string does not exceed the defined

--- a/libraries/joomla/html/html/string.php
+++ b/libraries/joomla/html/html/string.php
@@ -87,8 +87,8 @@ abstract class JHtmlString
 				}
 
 				// Offset is calculated from 0 so to use it for length we need to adjust it.
-				$offset = $offset + 1;
-				$tmp = JString::substr($tmp, 0, $offset);
+				$newoffset = $offset + 1;
+				$tmp = JString::substr($tmp, 0, $newoffset);
 
 				// If we don't have 3 characters of room, go to the second space within the limit.
 				if (JString::strlen($tmp) > $length - 3)

--- a/libraries/joomla/html/html/string.php
+++ b/libraries/joomla/html/html/string.php
@@ -71,7 +71,7 @@ abstract class JHtmlString
 			{
 				// Find the position of the last space within the allowed length.
 				$offset = JString::strrpos($tmp, ' ');
-				$tmp = JString::substr($tmp, 0, $offset+1);
+				$tmp = JString::substr($tmp, 0, $offset + 1);
 
 				// If there are no spaces and the string is longer than the maximum
 				// we need to just use the ellipsis. In that case we are done.
@@ -158,7 +158,7 @@ abstract class JHtmlString
 	*/
 	public static function truncateComplex($html, $maxLength = 0, $noSplit = true)
 	{
-		//Start with some basic rules.
+		// Start with some basic rules.
 		$baseLength = strlen($html);
 
 		// If the original HTML string is shorter than the $maxLength do nothing and return that.
@@ -168,11 +168,11 @@ abstract class JHtmlString
 		}
 
 		// Take care of short simple cases.
-		if ($maxLength <= 3 && substr($html, 0, 1) != '<' && strpos(substr($html, 0, $maxLength-1), '<') === false && $baseLength > $maxLength)
+		if ($maxLength <= 3 && substr($html, 0, 1) != '<' && strpos(substr($html, 0, $maxLength - 1), '<') === false && $baseLength > $maxLength)
 		{
 			return '...';
 		}
-		
+
 		// Deal with maximum length of 1 where the string starts with a tag.
 		if ($maxLength == 1 && substr($html, 0, 1) == '<')
 		{
@@ -186,18 +186,17 @@ abstract class JHtmlString
 			}
 			$character = substr(strip_tags($html), 0, 1);
 
-			return substr($html, 0, $l) . '</' . $tag . '...';			
+			return substr($html, 0, $l) . '</' . $tag . '...';
 		}
 
 		// First get the truncated plain text string. This is the rendered text we want to end up with.
 		$ptString = JHtml::_('string.truncate', $html, $maxLength, $noSplit, $allowHtml = false);
 
 		// It's all HTML, just return it.
-		if (strlen($ptString) == 0) 
+		if (strlen($ptString) == 0)
 		{
 				return $html;
 		}
-
 
 		// If the plain text is shorter than the max length the variable will not end in ...
 		// In that case we use the whole string.

--- a/libraries/joomla/html/html/string.php
+++ b/libraries/joomla/html/html/string.php
@@ -65,7 +65,7 @@ abstract class JHtmlString
 			{
 					return '...';
 			}
-			
+
 			// $noSplit true means that we do not allow splitting of words.
 			if ($noSplit)
 			{
@@ -78,8 +78,8 @@ abstract class JHtmlString
 				{
 					return '...';
 				}
-				
-				// If the last open tag is after the last close tag we need to adjust the offset to 
+
+				// If the last open tag is after the last close tag we need to adjust the offset to
 				// exclude it. We assume a < is part of a tag.
 				if (!empty($tmp) && JString::strrpos($tmp, '<') > JString::strrpos($tmp, '>'))
 				{
@@ -134,7 +134,6 @@ abstract class JHtmlString
 						unset($closedTags[array_search($openedTags[$i], $closedTags)]);
 					}
 				}
-				
 			}
 			if (strlen($text) > $tmp || $tmp === false)
 			{
@@ -143,7 +142,7 @@ abstract class JHtmlString
 			else
 			{
 				$text = $tmp;
-			}	
+			}
 		}
 
 		return $text;
@@ -155,9 +154,9 @@ abstract class JHtmlString
 	* The goal is to get the proper length plain text string with as much of 
 	* the html intact as possible with all tags properly closed.
 	* 
-	* @param  string   $html       The content of the introtext to be truncated
-	* @param  integer  $maxLength  The maximum number of characters to render
-	* @param  boolean  $noSplit    Don't split a word if that is where the cutoff occurs (default: true).
+	* @param   string   $html       The content of the introtext to be truncated
+	* @param   integer  $maxLength  The maximum number of characters to render
+	* @param   boolean  $noSplit    Don't split a word if that is where the cutoff occurs (default: true).
 	* 
 	* @return  string  The truncated string
 	* 
@@ -172,10 +171,10 @@ abstract class JHtmlString
 		if ($maxLength == 1 && substr($html, 0, 1) == '<')
 		{
 			$endTagPos = strlen(strstr($html,'>',true));
-			$tag = substr($html,1,$endTagPos);
-			
+			$tag = substr($html, 1, $endTagPos);
+
 			$l = $endTagPos + 2;
-			return substr($html,0,$l) . '</'. $tag;
+			return substr($html, 0, $l) . '</'. $tag;
 		}
 
 		// First get the truncated plain text string. This is the rendered text we want to end up with.
@@ -188,11 +187,11 @@ abstract class JHtmlString
 
 			// Now get the truncated string if HTML is allowed.
 			$htmlString = JHtml::_('string.truncate', $html, $maxLength, $noSplit, $allowHtml = true);
-			$htmlString = rtrim($htmlString,'.');
+			$htmlString = rtrim($htmlString, '.');
 
 			// Now get the plain text from the HTML string.
 			$htmlStringToPtString = JHtml::_('string.truncate', $htmlString, $maxLength, $noSplit, $allowHtml = false);
-			$htmlStringToPtString = rtrim($htmlStringToPtString,'.');
+			$htmlStringToPtString = rtrim($htmlStringToPtString, '.');
 
 			// If the new plain text string matches the original plain text string we are done.
 			if ($ptString == $htmlStringToPtString)
@@ -220,7 +219,7 @@ abstract class JHtmlString
 				return $htmlString;
 			}
 		}
-		
+
 		// If the original HTML string is shorter than the $maxLength do nothing and return that.
 		return $html;
 	}

--- a/tests/suites/unit/joomla/html/html/JHtmlStringTest.php
+++ b/tests/suites/unit/joomla/html/html/JHtmlStringTest.php
@@ -75,14 +75,14 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 			),
 			'Plain text over the limit by two words' => array(
 				'Plain text test',
-				12,
+				7,
 				true,
 				true,
 				'Plain...',
 			),
 			'Plain text over the limit by one word' => array(
 				'Plain text test',
-				13,
+				14,
 				true,
 				true,
 				'Plain text...',
@@ -97,7 +97,7 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 			'Plain text over the limit splitting first word' => array(
 				'Plain text',
 				3,
-				true,
+				false,
 				true,
 				'Pla...',
 			),
@@ -136,19 +136,28 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 				true,
 				'<span>Plain</span>...',
 			),
+			// Don't return invalid HTML
 			'Plain html over the limit splitting first word' => array(
 				'<span>Plain text</span>',
-				10,
+				1,
+				false,
 				true,
+				'...',
+			),
+			// Don't return invalid HTML
+			'Plain html over the limit splitting first word' => array(
+				'<span>Plain text</span>',
+				4,
+				false,
 				true,
-				'<span>Plai</span>...',
+				'...',
 			),
 			'Complex html over the limit' => array(
 				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
 				37,
 				true,
 				true,
-				'<div><span><i>Plain</i></span></div>...',
+				'<div><span><i>Plain</i> <b>text</b></span></div>...',
 			),
 			'Complex html over the limit 2' => array(
 				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
@@ -166,10 +175,10 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 			),
 			'HTML not allowed, no split' => array(
 				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
-				8,
+				4,
 				true,
 				false,
-				'Plain...',
+				'...',
 			),
 		);
 	}
@@ -180,34 +189,30 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 	 *
 	 * @since   11.3
 	 */
-	function getTestComplexTruncateData()
+	function getTestTruncateComplexData()
 	{
-		return array(
+/*		return array(
 			'No change case' => array(
 				'Plain text',
-				0,
+				10,
 				true,
-				true,
-				'Plain text',
+				'Plain text'
 			),
 			'Plain text under the limit' => array(
 				'Plain text',
 				100,
 				true,
-				true,
-				'Plain text',
+				'Plain text'
 			),
 			'Plain text at the limit' => array(
 				'Plain text',
 				10,
 				true,
-				true,
 				'Plain text',
 			),
 			'Plain text over the limit by two words' => array(
 				'Plain text test',
-				12,
-				true,
+				6,
 				true,
 				'Plain...',
 			),
@@ -215,34 +220,29 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 				'Plain text test',
 				13,
 				true,
-				true,
 				'Plain text...',
 			),
 			'Plain text over the limit with short trailing words' => array(
 				'Plain text a b c d',
 				13,
 				true,
-				true,
 				'Plain text...',
 			),
 			'Plain text over the limit splitting first word' => array(
 				'Plain text',
 				3,
-				true,
-				true,
+				false,
 				'Pla...',
 			),
 			'Plain text with word split' => array(
 				'Plain split-less',
 				7,
-				false,
-				false,
-				'Plain s...',
+				true,
+				'Plain...',
 			),
 			'Plain html under the limit' => array(
 				'<span>Plain text</span>',
 				100,
-				true,
 				true,
 				'<span>Plain text</span>',
 			),
@@ -250,13 +250,11 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 				'<span>Plain text</span>',
 				23,
 				true,
-				true,
 				'<span>Plain text</span>',
 			),
 			'Plain html over the limit' => array(
 				'<span>Plain text</span>',
 				22,
-				true,
 				true,
 				'<span>Plain text</span>...',
 			),
@@ -264,45 +262,51 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 				'<span>Plain text</span>',
 				5,
 				true,
-				true,
 				'<span>Plain</span>...',
 			),
 			'Plain html over the limit splitting first word' => array(
 				'<span>Plain text</span>',
 				4,
-				true,
-				true,
+				false,
 				'<span>Plai</span>...',
 			),
+			'Plain html over the limit splitting first word' => array(
+				'<span>Plain text</span>',
+				1,
+				false,
+				'<span>P</span>',
+			),			
+			'Plain html over the limit splitting first word' => array(
+				'<span>Plain text</span>',
+				4,
+				false,
+				'<span>Plai</span>',
+			),	
 			'Complex html over the limit' => array(
 				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
-				5,
+				37,
 				true,
-				true,
-				'<div><span><i>Plain</i></span></div>...',
+				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
 			),
 			'Complex html over the limit 2' => array(
 				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
-				5,
+				38,
 				true,
-				true,
-				'<div><span><i>Plain</i> <b>text</b></span></div>...',
+				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
 			),
 			'Split words' => array(
 				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
 				8,
 				false,
-				false,
-				'<div><span><i>Plain te</i></span></div>...',
+				'<div><span><i>Plain</i> <b>te</b></span></div>...',
 			),
 			'No split' => array(
 				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
-				8,
+				4,
 				true,
-				false,
 				'<div><span><i>Plain</i></span></div>...',
 			),
-		);
+		);*/
 	}
 
 	/**
@@ -347,4 +351,25 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 			$this->equalTo($expected)
 		);
 	}
+
+	/**
+	 * Tests the JHtmlString::truncateComplex method.
+	 *
+	 * @param   string   $text      The text to truncate.
+	 * @param   integer  $length    The maximum length of the text.
+	 * @param   boolean  $noSplit    Don't split a word if that is where the cutoff occurs (default: true).
+	 * @param   string   $expected   The expected result.
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider  getTestTruncateComplexData
+	 * @since   11.3
+	 */
+/*	public function testTruncateComplex($html, $maxLength, $noSplit, $expected)
+	{
+		$this->assertThat(
+			JHtmlString::truncateComplex($html, $maxLength, $noSplit),
+			$this->equalTo($expected)
+		);
+	}*/
 }

--- a/tests/suites/unit/joomla/html/html/JHtmlStringTest.php
+++ b/tests/suites/unit/joomla/html/html/JHtmlStringTest.php
@@ -188,11 +188,11 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 	 *
 	 * @return  array
 	 *
-	 * @since   11.3
+	 * @since   12.2
 	 */
 	function getTestTruncateComplexData()
 	{
-/*		return array(
+		return array(
 			'No change case' => array(
 				'Plain text',
 				10,
@@ -215,7 +215,7 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 				'Plain text test',
 				6,
 				true,
-				'Plain...',
+				'...',
 			),
 			'Plain text over the limit by one word' => array(
 				'Plain text test',
@@ -257,11 +257,12 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 				'<span>Plain text</span>',
 				22,
 				true,
-				'<span>Plain text</span>...',
+				'<span>Plain text</span>',
 			),
+				
 			'Plain html over the limit by one word' => array(
 				'<span>Plain text</span>',
-				5,
+				8,
 				true,
 				'<span>Plain</span>...',
 			),
@@ -281,7 +282,7 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 				'<span>Plain text</span>',
 				4,
 				false,
-				'<span>Plai</span>',
+				'<span>Plai</span>...',
 			),	
 			'Complex html over the limit' => array(
 				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
@@ -303,11 +304,11 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 			),
 			'No split' => array(
 				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
-				4,
+				8,
 				true,
-				'<div><span><i>Plain</i></span></div>...',
+				'<div><span><i>Plain</i> </span></div>...',
 			),
-		);*/
+		);
 	}
 
 	/**
@@ -364,13 +365,13 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 	 * @return  void
 	 *
 	 * @dataProvider  getTestTruncateComplexData
-	 * @since   11.3
+	 * @since   12.2
 	 */
-/*	public function testTruncateComplex($html, $maxLength, $noSplit, $expected)
+	public function testTruncateComplex($html, $maxLength, $noSplit, $expected)
 	{
 		$this->assertThat(
 			JHtmlString::truncateComplex($html, $maxLength, $noSplit),
 			$this->equalTo($expected)
 		);
-	}*/
+	}
 }

--- a/tests/suites/unit/joomla/html/html/JHtmlStringTest.php
+++ b/tests/suites/unit/joomla/html/html/JHtmlStringTest.php
@@ -129,12 +129,13 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 				true,
 				'<span>Plain text</span>...',
 			),
+			// The tags by themselves make the string too long.
 			'Plain html over the limit by one word' => array(
 				'<span>Plain text</span>',
 				12,
 				true,
 				true,
-				'<span>Plain</span>...',
+				'...',
 			),
 			// Don't return invalid HTML
 			'Plain html over the limit splitting first word' => array(

--- a/tests/suites/unit/joomla/html/html/JHtmlStringTest.php
+++ b/tests/suites/unit/joomla/html/html/JHtmlStringTest.php
@@ -127,7 +127,7 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 				22,
 				true,
 				true,
-				'<span>Plain text</span>...',
+				'<span>Plain</span>...',
 			),
 			// The tags by themselves make the string too long.
 			'Plain html over the limit by one word' => array(
@@ -199,7 +199,7 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 				'<div><span><i>Plain</i></span></div>',
 				5,
 				true,
-				true.
+				true,
 				'...',
 			),
 			'HTML not allowed, no split' => array(
@@ -221,6 +221,7 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 	function getTestTruncateComplexData()
 	{
 		return array(
+
 			'No change case' => array(
 				'Plain text',
 				10,
@@ -237,123 +238,142 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 				'Plain text',
 				10,
 				true,
-				'Plain text',
+				'Plain text'
 			),
 			'Plain text over the limit by two words' => array(
 				'Plain text test',
 				6,
 				true,
-				'...',
+				'...'
 			),
 			'Plain text over the limit by one word' => array(
 				'Plain text test',
 				13,
 				true,
-				'Plain text...',
+				'Plain text...'
 			),
 			'Plain text over the limit with short trailing words' => array(
 				'Plain text a b c d',
 				13,
 				true,
-				'Plain text...',
+				'Plain text...'
 			),
 			'Plain text over the limit splitting first word' => array(
 				'Plain text',
 				3,
 				false,
-				'Pla...',
+				'...'
 			),
 			'Plain text with word split' => array(
 				'Plain split-less',
 				7,
 				true,
-				'Plain...',
+				'Plain...'
+			),
+			'Plain text under a short limit' => array(
+				'Hi',
+				3,
+				true,
+				'Hi'
+			),
+			'Plain text with length 1 and a limit of 1' => array(
+				'H',
+				1,
+				true,
+				'H'
 			),
 			'Plain html under the limit' => array(
 				'<span>Plain text</span>',
 				100,
 				true,
-				'<span>Plain text</span>',
+				'<span>Plain text</span>'
 			),
 			'Plain html at the limit' => array(
 				'<span>Plain text</span>',
 				23,
 				true,
-				'<span>Plain text</span>',
+				'<span>Plain text</span>'
 			),
-			'Plain html over the limit' => array(
+			'Plain html over the limit but under the text limit' => array(
 				'<span>Plain text</span>',
 				22,
 				true,
-				'<span>Plain text</span>',
+				'<span>Plain text</span>'
 			),
 				
 			'Plain html over the limit by one word' => array(
 				'<span>Plain text</span>',
 				8,
 				true,
-				'<span>Plain</span>...',
+				'<span>Plain</span>...'
 			),
 			'Plain html over the limit splitting first word' => array(
 				'<span>Plain text</span>',
 				4,
 				false,
-				'<span>Plai</span>...',
+				'<span>P</span>...'
 			),
 			'Plain html over the limit splitting first word' => array(
 				'<span>Plain text</span>',
 				1,
 				false,
-				'<span>P</span>',
+				'<span></span>...'
 			),			
-			'Plain html over the limit splitting first word' => array(
-				'<span>Plain text</span>',
-				4,
-				false,
-				'<span>Plai</span>...',
-			),	
-			'Complex html over the limit' => array(
+			'Complex html over the limit but under the text limit' => array(
 				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
 				37,
 				true,
-				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
+				'<div><span><i>Plain</i> <b>text</b> foo</span></div>'
 			),
 			'Complex html over the limit 2' => array(
 				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
 				38,
 				true,
-				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
+				'<div><span><i>Plain</i> <b>text</b> foo</span></div>'
 			),
 			'Split words' => array(
 				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
 				8,
 				false,
-				'<div><span><i>Plain</i> <b>te</b></span></div>...',
+				'<div><span><i>Plain</i> <b>te</b></span></div>...'
 			),
 			'No split' => array(
 				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
 				8,
 				true,
-				'<div><span><i>Plain</i> </span></div>...',
+				'<div><span><i>Plain</i></span></div>...'
 			),
 				'First character is < with a maximum length of 1, no split' => array(
 				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
 				1,
 				true,
-				'<div></div>...',
+				'<div></div>...'
 			),
 				'First character is < with a maximum length of 1, split' => array(
 				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
 				1,
 				false,
-				'<div>P</div>...',
+				'<div></div>...'
 			),
-				'Text is the same as maxLength, no split' => array(
+				'Text is the same as maxLength, Complex HTML, no split' => array(
 				'<div><span><i>Plain</i></span></div>',
 				5,
 				true,
-				'<div><span><i>Plain</i></span></div>',
+				'<div><span><i>Plain</i></span></div>'
 			),
+				'Text is all HTML' => array(
+				'<img src="myimage.jpg" />',
+				5,
+				true,
+				'<img src="myimage.jpg" />'
+			),
+				'Text with no spaces, split, maxlength 3' => array(
+				'thisistextwithnospace',
+				3,
+				false,
+				'...'
+			),
+
 		);
 	}
 
@@ -403,9 +423,11 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 	/**
 	 * Tests the JHtmlString::truncateComplex method.
 	 *
-	 * @param   string   $text      The text to truncate.
-	 * @param   integer  $length    The maximum length of the text.
-	 * @param   boolean  $noSplit    Don't split a word if that is where the cutoff occurs (default: true).
+	 * @param   string   $html       The text to truncate.
+	 * @param   integer  $maxLength     The maximum length of the text.
+	 * @param   boolean  $noSplit    Don't split a word if that is where the cutoff occurs (default: true)
+	 * @param   boolean  $allowHtml  Allow HTML, always true for truncateComplex. Needed for 
+	 *                               compatibility with truncate tests.
 	 * @param   string   $expected   The expected result.
 	 *
 	 * @return  void

--- a/tests/suites/unit/joomla/html/html/JHtmlStringTest.php
+++ b/tests/suites/unit/joomla/html/html/JHtmlStringTest.php
@@ -181,6 +181,34 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 				false,
 				'...',
 			),
+				'First character is < with a maximum length of 1' => array(
+				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
+				1,
+				true,
+				false,
+				'...',
+			),
+			'HTML not allowed, no split' => array(
+				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
+				5,
+				true,
+				false,
+				'...',
+			),
+			'Text is the same as maxLength, no split, HTML allowed' => array(
+				'<div><span><i>Plain</i></span></div>',
+				5,
+				true,
+				true.
+				'...',
+			),
+			'HTML not allowed, no split' => array(
+				'<div><span><i>Plain</i></span></div>',
+				5,
+				true,
+				false,
+				'Plain',
+			),
 		);
 	}
 	/**
@@ -307,6 +335,24 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 				8,
 				true,
 				'<div><span><i>Plain</i> </span></div>...',
+			),
+				'First character is < with a maximum length of 1, no split' => array(
+				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
+				1,
+				true,
+				'<div></div>...',
+			),
+				'First character is < with a maximum length of 1, split' => array(
+				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
+				1,
+				false,
+				'<div>P</div>...',
+			),
+				'Text is the same as maxLength, no split' => array(
+				'<div><span><i>Plain</i></span></div>',
+				5,
+				true,
+				'<div><span><i>Plain</i></span></div>',
 			),
 		);
 	}

--- a/tests/suites/unit/joomla/html/html/JHtmlStringTest.php
+++ b/tests/suites/unit/joomla/html/html/JHtmlStringTest.php
@@ -173,6 +173,137 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 			),
 		);
 	}
+	/**
+	 * Test cases for complex truncate.
+	 *
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	function getTestComplexTruncateData()
+	{
+		return array(
+			'No change case' => array(
+				'Plain text',
+				0,
+				true,
+				true,
+				'Plain text',
+			),
+			'Plain text under the limit' => array(
+				'Plain text',
+				100,
+				true,
+				true,
+				'Plain text',
+			),
+			'Plain text at the limit' => array(
+				'Plain text',
+				10,
+				true,
+				true,
+				'Plain text',
+			),
+			'Plain text over the limit by two words' => array(
+				'Plain text test',
+				12,
+				true,
+				true,
+				'Plain...',
+			),
+			'Plain text over the limit by one word' => array(
+				'Plain text test',
+				13,
+				true,
+				true,
+				'Plain text...',
+			),
+			'Plain text over the limit with short trailing words' => array(
+				'Plain text a b c d',
+				13,
+				true,
+				true,
+				'Plain text...',
+			),
+			'Plain text over the limit splitting first word' => array(
+				'Plain text',
+				3,
+				true,
+				true,
+				'Pla...',
+			),
+			'Plain text with word split' => array(
+				'Plain split-less',
+				7,
+				false,
+				false,
+				'Plain s...',
+			),
+			'Plain html under the limit' => array(
+				'<span>Plain text</span>',
+				100,
+				true,
+				true,
+				'<span>Plain text</span>',
+			),
+			'Plain html at the limit' => array(
+				'<span>Plain text</span>',
+				23,
+				true,
+				true,
+				'<span>Plain text</span>',
+			),
+			'Plain html over the limit' => array(
+				'<span>Plain text</span>',
+				22,
+				true,
+				true,
+				'<span>Plain text</span>...',
+			),
+			'Plain html over the limit by one word' => array(
+				'<span>Plain text</span>',
+				5,
+				true,
+				true,
+				'<span>Plain</span>...',
+			),
+			'Plain html over the limit splitting first word' => array(
+				'<span>Plain text</span>',
+				4,
+				true,
+				true,
+				'<span>Plai</span>...',
+			),
+			'Complex html over the limit' => array(
+				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
+				5,
+				true,
+				true,
+				'<div><span><i>Plain</i></span></div>...',
+			),
+			'Complex html over the limit 2' => array(
+				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
+				5,
+				true,
+				true,
+				'<div><span><i>Plain</i> <b>text</b></span></div>...',
+			),
+			'Split words' => array(
+				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
+				8,
+				false,
+				false,
+				'<div><span><i>Plain te</i></span></div>...',
+			),
+			'No split' => array(
+				'<div><span><i>Plain</i> <b>text</b> foo</span></div>',
+				8,
+				true,
+				false,
+				'<div><span><i>Plain</i></span></div>...',
+			),
+		);
+	}
 
 	/**
 	 * Tests the JHtmlString::abridge method.


### PR DESCRIPTION
This method allows you to truncate a string of html to a fixed number of characters of text not counting html tags. It builds on the existing string.truncate method.
