### PR TITLE
JFactory::getUser(0) returns null if session doesn't have JUser object

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -220,7 +220,7 @@ abstract class JFactory
 				$instance = JUser::getInstance();
 			}
 		}
-		elseif ($instance->id != $id)
+		elseif (!($instance instanceof JUser) || $instance->id != $id)
 		{
 			$instance = JUser::getInstance($id);
 		}


### PR DESCRIPTION
We have had some bug reports like this:

```
Fatal Error: Call to a member function authorisedLevels() on a non-object
```

after running following code:

```
$user = JFactory::getUser($userid);
$accesslevels = (array) $user->authorisedLevels();
```

More details from the bug can be found from here:
http://www.kunena.org/forum/K-2-0-Support/123824-500-Internal-Server-Error

After some inspection I found out that the function indeed returns NULL when $id = 0 and $instance = NULL. Please see my comments in the code below:

``` php
    public static function getUser($id = null)          // assume $id = 0
    {
        $instance = self::getSession()->get('user');    // assume $instance = null

        if (is_null($id))                               // (is_null(0)) === false
        {
            if (!($instance instanceof JUser))
            {
                $instance = JUser::getInstance();
            }
        }
        elseif ($instance->id != $id)                   // Notice: Trying to get property of non-object
                                                        // (NULL != 0) === false
        {
            $instance = JUser::getInstance($id);
        }

        return $instance;                               // $instance === null
    }
```

I know that this can happen if session was broken, but can it happen in core if the session is valid, for example when user logs out?
