### PR TITLE
Update Oracle driver to set timestamp format as well as date format

### DIFF
--- a/libraries/joomla/database/driver/oracle.php
+++ b/libraries/joomla/database/driver/oracle.php
@@ -411,24 +411,25 @@ class JDatabaseDriverOracle extends JDatabaseDriverPdo
      * that matches the MySQL one used within most Joomla
      * tables.
      *
-     * @param   string  $dateformat  Oracle Date Format String
+     * @param   string  $dateFormat  Oracle Date Format String
      *
      * @return boolean
      *
      * @since  12.1
      */
-	public function setDateFormat($dateformat = 'DD-MON-RR')
+	public function setDateFormat($dateFormat = 'DD-MON-RR')
 	{
 		$this->connect();
 
-		$this->setQuery("alter session set nls_date_format = '$dateformat'");
+		$this->setQuery("ALTER SESSION SET NLS_DATE_FORMAT = '$dateFormat'");
+		$this->setQuery("ALTER SESSION SET NLS_TIMESTAMP_FORMAT = '$dateFormat'");
 
 		if (!$this->execute())
 		{
 			return false;
 		}
 
-		$this->dateformat = $dateformat;
+		$this->dateformat = $dateFormat;
 
 		return true;
 	}


### PR DESCRIPTION
This pull request updates the Oracle driver to set the timestamp format to match the date format which is the Joomla! standard. This means that instead of getting Oracle's default timestamp formatting, timestamp fields are returned with Joomla!'s preferred date formatting.
