### PR TITLE
Route Query String Fix and Raw Route

### DIFF
--- a/libraries/joomla/application/web/router/base.php
+++ b/libraries/joomla/application/web/router/base.php
@@ -132,7 +132,7 @@ class JApplicationWebRouterBase extends JApplicationWebRouter
 		$controller = false;
 
 		// Trim the query string off.
-		$route = preg_replace('/([^?]*).*/', '\1', $route);
+		$route = preg_replace('/([^?]*).*/u', '\1', $route);
 
 		// Sanitize and explode the route.
 		$route = trim(parse_url($route, PHP_URL_PATH), ' /');

--- a/libraries/joomla/application/web/router/base.php
+++ b/libraries/joomla/application/web/router/base.php
@@ -131,6 +131,9 @@ class JApplicationWebRouterBase extends JApplicationWebRouter
 		// Initialize variables.
 		$controller = false;
 
+		// Trim the query string off.
+		$route = preg_replace('/([^?]*).*/', '\1', $route);
+
 		// Sanitize and explode the route.
 		$route = trim(parse_url($route, PHP_URL_PATH), ' /');
 
@@ -157,6 +160,8 @@ class JApplicationWebRouterBase extends JApplicationWebRouter
 					// Don't forget to do an explicit set on the GET superglobal.
 					$this->input->get->def($var, $matches[$i + 1]);
 				}
+
+				$this->input->def('_rawRoute', $route);
 
 				break;
 			}

--- a/tests/suites/unit/joomla/application/web/router/JApplicationWebRouterBaseTest.php
+++ b/tests/suites/unit/joomla/application/web/router/JApplicationWebRouterBaseTest.php
@@ -42,18 +42,18 @@ class JApplicationWebRouterBaseTest extends TestCase
 			array('', false, 'home', array(), 1),
 			array('articles/4', true, 'home', array(), 1),
 			array('', false, 'index', array(), 2),
-			array('login', false, 'login', array(), 2),
-			array('articles', false, 'articles', array(), 2),
-			array('articles/4', false, 'article', array('article_id' => 4), 2),
+			array('login', false, 'login', array('_rawRoute' => 'login'), 2),
+			array('articles', false, 'articles', array('_rawRoute' => 'articles'), 2),
+			array('articles/4', false, 'article', array('article_id' => 4, '_rawRoute' => 'articles/4'), 2),
 			array('articles/4/crap', true, '', array(), 2),
 			array('test', true, '', array(), 2),
 			array('test/foo', true, '', array(), 2),
 			array('test/foo/path', true, '', array(), 2),
-			array('test/foo/path/bar', false, 'test', array('seg1' => 'foo', 'seg2' => 'bar'), 2),
-			array('content/article-1/*', false, 'content', array(), 2),
-			array('content/cat-1/article-1', false, 'article', array('category' => 'cat-1', 'article' => 'article-1'), 2),
-			array('content/cat-1/cat-2/article-1', false, 'article', array('category' => 'cat-1/cat-2', 'article' => 'article-1'), 2),
-			array('content/cat-1/cat-2/cat-3/article-1', false, 'article', array('category' => 'cat-1/cat-2/cat-3', 'article' => 'article-1'), 2)
+			array('test/foo/path/bar', false, 'test', array('seg1' => 'foo', 'seg2' => 'bar', '_rawRoute' => 'test/foo/path/bar'), 2),
+			array('content/article-1/*', false, 'content', array('_rawRoute' => 'content/article-1/*'), 2),
+			array('content/cat-1/article-1', false, 'article', array('category' => 'cat-1', 'article' => 'article-1', '_rawRoute' => 'content/cat-1/article-1'), 2),
+			array('content/cat-1/cat-2/article-1', false, 'article', array('category' => 'cat-1/cat-2', 'article' => 'article-1', '_rawRoute' => 'content/cat-1/cat-2/article-1'), 2),
+			array('content/cat-1/cat-2/cat-3/article-1', false, 'article', array('category' => 'cat-1/cat-2/cat-3', 'article' => 'article-1', '_rawRoute' => 'content/cat-1/cat-2/cat-3/article-1'), 2)
 		);
 	}
 


### PR DESCRIPTION
This pull request fixes an issue where if a query string contained a colon in it (e.g. ?filters=content_id:20) that PHP's parse_url function would get confused. This meant that it would fail to properly process the path resulting in the first path segment being truncated erroneously and no match found for the route. This pull request preprocesses the route to remove the query string before parse_url function so that it will work reliably.

The second change is pushing into the input the raw route for the request. This is to permit direct access to the route segments in the controller should it wish to make further decisions based on the route segments. A use case is multiple hard coded mappings where the last segment is not variable however may have meaning to the individual controller (e.g. there are limited options available that can be reasonably elaborated).
