### PR TITLE
Build multi-key update support for JDatabaseDriver::updateObject.

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -1598,7 +1598,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 *
 	 * @param   string   $table    The name of the database table to update.
 	 * @param   object   &$object  A reference to an object whose public properties match the table fields.
-	 * @param   string   $key      The name of the primary key.
+	 * @param   array    $key      The name of the primary key.
 	 * @param   boolean  $nulls    True to update null fields or false to ignore them.
 	 *
 	 * @return  boolean  True on success.
@@ -1610,7 +1610,17 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	{
 		// Initialise variables.
 		$fields = array();
-		$where = '';
+		$where = array();
+
+		if (is_string($key))
+		{
+			$key = array($key);
+		}
+
+		if (is_object($key))
+		{
+			$key = (array) $key;
+		}
 
 		// Create the base update statement.
 		$statement = 'UPDATE ' . $this->quoteName($table) . ' SET %s WHERE %s';
@@ -1625,9 +1635,9 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 			}
 
 			// Set the primary key to the WHERE clause instead of a field to update.
-			if ($k == $key)
+			if (in_array($k, $key))
 			{
-				$where = $this->quoteName($k) . '=' . $this->quote($v);
+				$where[] = $this->quoteName($k) . '=' . $this->quote($v);
 				continue;
 			}
 
@@ -1662,7 +1672,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 		}
 
 		// Set the query and execute the update.
-		$this->setQuery(sprintf($statement, implode(",", $fields), $where));
+		$this->setQuery(sprintf($statement, implode(",", $fields), implode(' AND ', $where)));
 		return $this->execute();
 	}
 


### PR DESCRIPTION
This pull request provides support for providing an array as the key to the JDatabaseDriver::updateObject method. This permits updating objects where there is more than a single key for the given table. JDatabaseDriver::insertObject does not require this because it can directly insert without worrying about providing a where clause which is required for the update statement to work properly. This change is backwards compatible and will map the `$key` from a string to array if a string is provided. Support is also provided for re-mapping an object into an array for using objects as well for the key.
