### PR TITLE
JUpdate load form XML - fixed empty response data

### DIFF
--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -310,7 +310,7 @@ class JUpdate extends JObject
 		xml_set_element_handler($this->xmlParser, '_startElement', '_endElement');
 		xml_set_character_data_handler($this->xmlParser, '_characterData');
 
-		if (!xml_parse($this->xmlParser, $response->data))
+		if (!xml_parse($this->xmlParser, $response->body))
 		{
 			die(
 				sprintf(


### PR DESCRIPTION
Hi,

the joomla update are getting a empty response from Http because use $response->data instead of $response->body.
