### PR TITLE
[CMS #28823] Re-add isError into the JError legacy class

### DIFF
--- a/libraries/legacy/error/error.php
+++ b/libraries/legacy/error/error.php
@@ -62,23 +62,19 @@ abstract class JError
 	protected static $stack = array();
 
 	/**
-	 * Method to determine if a value is an exception object.  This check supports
-	 * both JException and PHP5 Exception objects
+	 * Method to determine if a value is an exception object.
 	 *
-	 * @param   mixed  &$object  Object to check
+	 * @param   mixed  $object  Object to check.
 	 *
 	 * @return  boolean  True if argument is an exception, false otherwise.
 	 *
-	 * @since   11.1
-	 *
 	 * @deprecated  12.1
+	 * @since   11.1
 	 */
-	public static function isError(& $object)
+	public static function isError($object)
 	{
-		// Deprecation warning.
 		JLog::add('JError::isError() is deprecated.', JLog::WARNING, 'deprecated');
 
-		// Supports PHP 5 exception handling
 		return $object instanceof Exception;
 	}
 

--- a/libraries/legacy/error/error.php
+++ b/libraries/legacy/error/error.php
@@ -62,6 +62,27 @@ abstract class JError
 	protected static $stack = array();
 
 	/**
+	 * Method to determine if a value is an exception object.  This check supports
+	 * both JException and PHP5 Exception objects
+	 *
+	 * @param   mixed  &$object  Object to check
+	 *
+	 * @return  boolean  True if argument is an exception, false otherwise.
+	 *
+	 * @since   11.1
+	 *
+	 * @deprecated  12.1
+	 */
+	public static function isError(& $object)
+	{
+		// Deprecation warning.
+		JLog::add('JError::isError() is deprecated.', JLog::WARNING, 'deprecated');
+
+		// Supports PHP 5 exception handling
+		return $object instanceof Exception;
+	}
+
+	/**
 	 * Method for retrieving the last exception object in the error stack
 	 *
 	 * @param   boolean  $unset  True to remove the error from the stack.


### PR DESCRIPTION
Not sure the reason for the removal of isError() from the JError legacy class in J3.0 Alpha 1 - https://github.com/joomla/joomla-platform/pull/802 ?

I understand its old and "instanceof Exception" is the better way... but it just seems like this removal might break any extensions that use it (including my old code).

If we have a legacy class, we may as well keep it all in tact.

http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28823
