### PR TITLE
Have the session fire an event after it is started and use this to populate the session with some default objects.

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -1038,25 +1038,41 @@ class JApplicationWeb extends JApplicationBase
 			'force_ssl' => $this->get('force_ssl')
 		);
 
+		$this->registerEvent('onAfterSessionStart', array($this, 'afterSessionStart'));
+
 		// Instantiate the session object.
 		$session = JSession::getInstance($handler, $options);
-		$session->initialise($this->input);
+		$session->initialise($this->input, $this->dispatcher);
 		if ($session->getState() == 'expired')
 		{
 			$session->restart();
 		}
-
-		// If the session is new, load the user and registry objects.
-		if ($session->isNew())
+		else
 		{
-			$session->set('registry', new JRegistry);
-			$session->set('user', new JUser);
+			$session->start();
 		}
 
 		// Set the session object.
 		$this->session = $session;
 
 		return $this;
+	}
+
+	/**
+	 * After the session has been started we need to populate it with some default values.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.2
+	 */
+	public function afterSessionStart()
+	{
+		$session = JFactory::getSession();
+		if ($session->isNew())
+		{
+			$session->set('registry', new JRegistry('session'));
+			$session->set('user', new JUser);
+		}
 	}
 
 	/**

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -92,6 +92,14 @@ class JSession implements IteratorAggregate
 	private $_input = null;
 
 	/**
+	 * Holds the event dispatcher object
+	 *
+	 * @var    JEventDispatcher
+	 * @since  12.2
+	 */
+	private $_dispatcher = null;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   string  $store    The type of storage for the session.
@@ -433,15 +441,17 @@ class JSession implements IteratorAggregate
 	/**
 	 * Check whether this session is currently created
 	 *
-	 * @param   JInput  $input  JInput object for the session to use.
+	 * @param   JInput            $input       JInput object for the session to use.
+	 * @param   JEventDispatcher  $dispatcher  Dispatcher object for the session to use.
 	 *
 	 * @return  void.
 	 *
 	 * @since   12.2
 	 */
-	public function initialise(JInput $input)
+	public function initialise(JInput $input, JEventDispatcher $dispatcher = null)
 	{
-		$this->_input = $input;
+		$this->_input      = $input;
+		$this->_dispatcher = $dispatcher;
 	}
 
 	/**
@@ -589,6 +599,11 @@ class JSession implements IteratorAggregate
 
 		// Perform security checks
 		$this->_validate();
+
+		if ($this->_dispatcher instanceof JEventDispatcher)
+		{
+			$this->_dispatcher->trigger('onAfterSessionStart');
+		}
 	}
 
 	/**

--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -961,8 +961,10 @@ class JApplication extends JApplicationBase
 				break;
 		}
 
+		$this->registerEvent('onAfterSessionStart', array($this, 'afterSessionStart'));
+
 		$session = JFactory::getSession($options);
-		$session->initialise($this->input);
+		$session->initialise($this->input, $this->dispatcher);
 		$session->start();
 
 		// TODO: At some point we need to get away from having session data always in the db.
@@ -1053,13 +1055,23 @@ class JApplication extends JApplicationBase
 			{
 				jexit($e->getMessage());
 			}
+		}
+	}
 
-			// Session doesn't exist yet, so create session variables
-			if ($session->isNew())
-			{
-				$session->set('registry', new JRegistry('session'));
-				$session->set('user', new JUser);
-			}
+	/**
+	 * After the session has been started we need to populate it with some default values.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.2
+	 */
+	public function afterSessionStart()
+	{
+		$session = JFactory::getSession();
+		if ($session->isNew())
+		{
+			$session->set('registry', new JRegistry('session'));
+			$session->set('user', new JUser);
 		}
 	}
 


### PR DESCRIPTION
This is an alternative approach to #1349 that doesn't cause JSession to depend on JUser and JRegistry.
