### PR TITLE
Remove workarounds in JProfiler::getMemory() for when memory_get_usage() is not available. 

### DIFF
--- a/libraries/joomla/profiler/profiler.php
+++ b/libraries/joomla/profiler/profiler.php
@@ -155,32 +155,7 @@ class JProfiler
 	 */
 	public function getMemory()
 	{
-		if (function_exists('memory_get_usage'))
-		{
-			return memory_get_usage();
-		}
-		else
-		{
-			// Initialise variables.
-			$output = array();
-			$pid = getmypid();
-
-			if (IS_WIN)
-			{
-				// Windows workaround
-				@exec('tasklist /FI "PID eq ' . $pid . '" /FO LIST', $output);
-				if (!isset($output[5]))
-				{
-					$output[5] = null;
-				}
-				return substr($output[5], strpos($output[5], ':') + 1);
-			}
-			else
-			{
-				@exec("ps -o rss -p $pid", $output);
-				return $output[1] * 1024;
-			}
-		}
+		return memory_get_usage();
 	}
 
 	/**


### PR DESCRIPTION
According to the PHP documentation memory_get_usage() is always available since 5.2.1.
http://php.net/manual/de/function.memory-get-usage.php
