### PR TITLE
Required and validate elements errors messages are not translatable (Regression).

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1839,7 +1839,7 @@ class JForm
 				// Does the field have a defined error message?
 				if ($element['message'])
 				{
-					$message = $element['message'];
+					$message = JText::_($element['message']);
 				}
 				else
 				{
@@ -1884,10 +1884,11 @@ class JForm
 		if ($valid === false)
 		{
 			// Does the field have a defined error message?
-			$message = (string) $element['message'];
+			$message = (string) ($element['message']);
 
 			if ($message)
 			{
+				$message = JText::_($element['message']);
 				return new UnexpectedValueException($message);
 			}
 			else

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1851,7 +1851,7 @@ class JForm
 					{
 						$message = JText::_($element['name']);
 					}
-					$message = JText::sprintf(JLIB_FORM_VALIDATE_FIELD_REQUIRED, $message);
+					$message = JText::sprintf('JLIB_FORM_VALIDATE_FIELD_REQUIRED', $message);
 				}
 
 				return new RuntimeException($message);
@@ -1894,7 +1894,7 @@ class JForm
 			else
 			{
 				$message = JText::_($element['label']);
-				$message = JText::sprintf(JLIB_FORM_VALIDATE_FIELD_INVALID, $message);
+				$message = JText::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', $message);
 				return new UnexpectedValueException($message);
 			}
 		}

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1851,7 +1851,7 @@ class JForm
 					{
 						$message = JText::_($element['name']);
 					}
-					$message = sprintf('Field required: %s', $message);
+					$message = JText::sprintf(JLIB_FORM_VALIDATE_FIELD_REQUIRED, $message);
 				}
 
 				return new RuntimeException($message);
@@ -1892,7 +1892,9 @@ class JForm
 			}
 			else
 			{
-				return new UnexpectedValueException((string) $element['label']);
+				$message = JText::_($element['label']);
+				$message = JText::sprintf(JLIB_FORM_VALIDATE_FIELD_INVALID, $message);
+				return new UnexpectedValueException($message);
 			}
 		}
 

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1884,7 +1884,7 @@ class JForm
 		if ($valid === false)
 		{
 			// Does the field have a defined error message?
-			$message = (string) ($element['message']);
+			$message = (string) $element['message'];
 
 			if ($message)
 			{

--- a/libraries/legacy/model/form.php
+++ b/libraries/legacy/model/form.php
@@ -272,7 +272,7 @@ abstract class JModelForm extends JModelLegacy
 			// Get the validation messages from the form.
 			foreach ($form->getErrors() as $message)
 			{
-				$this->setError(JText::_($message));
+				$this->setError($message);
 			}
 
 			return false;


### PR DESCRIPTION
Required and validate elements error messages are not translatable (Regression). + errors in front-end wrong display.
 See http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28827
