### PR TITLE
Solve parse_url issues

### DIFF
--- a/libraries/joomla/form/rules/url.php
+++ b/libraries/joomla/form/rules/url.php
@@ -62,7 +62,7 @@ class JFormRuleUrl extends JFormRule
 		 * accurately without a scheme.
 		 * @see http://php.net/manual/en/function.parse-url.php
 		 */
-		if (!array_key_exists('scheme', $urlParts))
+		if ($urlParts && !array_key_exists('scheme', $urlParts))
 		{
 			return false;
 		}

--- a/libraries/joomla/form/rules/url.php
+++ b/libraries/joomla/form/rules/url.php
@@ -43,7 +43,7 @@ class JFormRuleUrl extends JFormRule
 		{
 			return true;
 		}
-		$urlParts = JString::parse_url($value);
+		$urlParts = parse_url($value);
 
 		// See http://www.w3.org/Addressing/URL/url-spec.txt
 		// Use the full list or optionally specify a list of permitted schemes.

--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -958,6 +958,8 @@ abstract class JString
 	 *
 	 * @see     http://us3.php.net/manual/en/function.parse-url.php
 	 * @since   11.1
+	 *
+	 * @deprecated  12.3
 	 */
 	public static function parse_url($url)
 	{

--- a/libraries/joomla/uri/uri.php
+++ b/libraries/joomla/uri/uri.php
@@ -338,7 +338,7 @@ class JUri
 		// Parse the URI and populate the object fields. If URI is parsed properly,
 		// set method return value to true.
 
-		$parts = JString::parse_url($uri);
+		$parts = parse_url($uri);
 
 		$retval = ($parts) ? true : false;
 


### PR DESCRIPTION
Because the parse_url method from JString has issues and the parse_url from PHP has no longer the UTF8 problem, I have replaced all JString::parse_url with parse_url from PHP and marked the parse_url from JString as deprecated.
