### PR TITLE
Improvements to install adapters

### DIFF
--- a/libraries/joomla/installer/adapters/component.php
+++ b/libraries/joomla/installer/adapters/component.php
@@ -1218,7 +1218,7 @@ class JInstallerComponent extends JAdapterInstance
 			// Remove existing menu items if overwrite has been enabled
 			if ($option)
 			{
-				// If something goes wrong, theres no way to rollback TODO: Search for better solution
+				// If something goes wrong, there's no way to rollback TODO: Search for better solution
 				$this->_removeAdminMenus($componentrow);
 			}
 

--- a/libraries/joomla/installer/adapters/language.php
+++ b/libraries/joomla/installer/adapters/language.php
@@ -131,17 +131,6 @@ class JInstallerLanguage extends JAdapterInstance
 			}
 		}
 
-		// Either we are installing a core pack or a core pack must exist for the language we are installing.
-		if (!$this->core)
-		{
-			if (!JFile::exists($this->parent->getPath('extension_site') . '/' . $this->get('tag') . '.xml'))
-			{
-				$this->parent
-					->abort(JText::sprintf('JLIB_INSTALLER_ABORT', JText::sprintf('JLIB_INSTALLER_ERROR_NO_CORE_LANGUAGE', $this->get('tag'))));
-				return false;
-			}
-		}
-
 		// If the language directory does not exist, let's create it
 		$created = false;
 		if (!file_exists($this->parent->getPath('extension_site')))
@@ -326,17 +315,6 @@ class JInstallerLanguage extends JAdapterInstance
 					$this->core = true;
 					break;
 				}
-			}
-		}
-
-		// Either we are installing a core pack or a core pack must exist for the language we are installing.
-		if (!$this->core)
-		{
-			if (!JFile::exists($this->parent->getPath('extension_site') . '/' . $this->get('tag') . '.xml'))
-			{
-				$this->parent
-					->abort(JText::sprintf('JLIB_INSTALLER_ABORT', JText::sprintf('JLIB_INSTALLER_ERROR_NO_CORE_LANGUAGE', $this->get('tag'))));
-				return false;
 			}
 		}
 

--- a/libraries/joomla/installer/adapters/module.php
+++ b/libraries/joomla/installer/adapters/module.php
@@ -324,7 +324,7 @@ class JInstallerModule extends JAdapterInstance
 		{
 			if ($this->parent->manifestClass->preflight($this->route, $this) === false)
 			{
-				// Install failed, rollback changes
+				// Preflight failed, rollback changes
 				$this->parent->abort(JText::_('JLIB_INSTALLER_ABORT_MOD_INSTALL_CUSTOM_INSTALL_FAILURE'));
 
 				return false;
@@ -581,7 +581,7 @@ class JInstallerModule extends JAdapterInstance
 		$this->parent->setUpgrade(true);
 
 		// Set the route for the install
-		$this->route = 'Update';
+		$this->route = 'update';
 
 		// Go to install which handles updates properly
 		return $this->install();

--- a/libraries/joomla/installer/adapters/template.php
+++ b/libraries/joomla/installer/adapters/template.php
@@ -21,10 +21,37 @@ jimport('joomla.base.adapterinstance');
  */
 class JInstallerTemplate extends JAdapterInstance
 {
+	/**
+	 * Copy of the XML manifest file
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	protected $manifest = null;
+
+	/**
+	 * Name of the extension
+	 *
+	 * @var    string
+	 * @since  11.1
+	 * */
 	protected $name = null;
 
+	/**
+	 * The unique identifier for the extension (e.g. mod_login)
+	 *
+	 * @var    string
+	 * @since  11.1
+	 * */
 	protected $element = null;
 
+	/**
+	 * Method of system
+	 *
+	 * @var    string
+	 *
+	 * @since  11.1
+	 */
 	protected $route = 'install';
 
 	/**
@@ -49,7 +76,6 @@ class JInstallerTemplate extends JAdapterInstance
 			);
 		}
 
-		$clientId = isset($this->parent->extension) ? $this->parent->extension->client_id : 0;
 		$this->manifest = $this->parent->getManifest();
 		$name = strtolower(JFilterInput::getInstance()->clean((string) $this->manifest->name, 'cmd'));
 		$client = (string) $this->manifest->attributes()->client;
@@ -322,6 +348,7 @@ class JInstallerTemplate extends JAdapterInstance
 	 */
 	public function update()
 	{
+		$this->route = 'update';
 		return $this->install();
 	}
 

--- a/libraries/joomla/installer/helper.php
+++ b/libraries/joomla/installer/helper.php
@@ -87,7 +87,7 @@ abstract class JInstallerHelper
 	 *
 	 * @param   string  $p_filename  The uploaded package filename or install directory
 	 *
-	 * @return  array  Two elements: extractdir and packagefile
+	 * @return  mixed  Array on success or boolean false on failure
 	 *
 	 * @since   11.1
 	 */
@@ -186,7 +186,7 @@ abstract class JInstallerHelper
 				continue;
 			}
 
-			if ($xml->getName() != 'install' && $xml->getName() != 'extension')
+			if ($xml->getName() != 'extension')
 			{
 				unset($xml);
 				continue;
@@ -266,9 +266,11 @@ abstract class JInstallerHelper
 	 * @return  array  Array of queries
 	 *
 	 * @since   11.1
+	 * @deprecated  13.3  Use JDatabaseDriver::splitSql() directly
 	 */
 	public static function splitSql($sql)
 	{
+		JLog::add('JInstallerHelper::splitSql() is deprecated. Use JDatabaseDriver::splitSql() instead.', JLog::WARNING, 'deprecated');
 		$db = JFactory::getDbo();
 		return $db->splitSql($sql);
 	}

--- a/libraries/joomla/installer/installer.php
+++ b/libraries/joomla/installer/installer.php
@@ -907,7 +907,7 @@ class JInstaller extends JAdapter
 				}
 
 				// Create an array of queries from the sql file
-				$queries = JInstallerHelper::splitSql($buffer);
+				$queries = JDatabaseDriver::splitSql($buffer);
 
 				if (count($queries) == 0)
 				{
@@ -1082,7 +1082,7 @@ class JInstaller extends JAdapter
 								}
 
 								// Create an array of queries from the sql file
-								$queries = JInstallerHelper::splitSql($buffer);
+								$queries = JDatabaseDriver::splitSql($buffer);
 
 								if (count($queries) == 0)
 								{


### PR DESCRIPTION
- Restored preflight method to plugin uninstall per @pasamio comments at https://github.com/joomla/joomla-platform/pull/1343#issuecomment-6798887
- Added check to package adapter install method to determine whether to use install or update route; subsequently changed later JInstaller::install trigger to use the route information
- Document class vars in template adapter
- Remove check for install root tag in JInstallerHelper::detectType()
- Deprecate JInstallerHelper::splitSql() in favor of JDatabaseDriver::splitSql() (which the deprecated method already proxies to)
- Remove obsolete code per @infograf768 as suggested at https://github.com/joomla/joomla-platform/pull/953#issuecomment-4316832
