### PR TITLE
JFactory::createDocument always creates HTML documents.

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -695,8 +695,8 @@ abstract class JFactory
 	{
 		$lang = self::getLanguage();
 
-		$jinput = JFactory::getApplication()->input;
-		$type = $jinput->get('format', 'html' , 'word');
+		$input = self::getApplication()->input;
+		$type = $input->get('format', 'html' , 'word');
 
 		$attributes = array('charset' => 'utf-8', 'lineend' => 'unix', 'tab' => '  ', 'language' => $lang->getTag(),
 			'direction' => $lang->isRTL() ? 'rtl' : 'ltr');

--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -695,10 +695,13 @@ abstract class JFactory
 	{
 		$lang = self::getLanguage();
 
+		$jinput = JFactory::getApplication()->input;
+		$type = $jinput->get('format', 'html' , 'word');
+
 		$attributes = array('charset' => 'utf-8', 'lineend' => 'unix', 'tab' => '  ', 'language' => $lang->getTag(),
 			'direction' => $lang->isRTL() ? 'rtl' : 'ltr');
 
-		return JDocument::getInstance('html', $attributes);
+		return JDocument::getInstance($type, $attributes);
 	}
 
 	/**

--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -696,7 +696,7 @@ abstract class JFactory
 		$lang = self::getLanguage();
 
 		$input = self::getApplication()->input;
-		$type = $input->get('format', 'html' , 'word');
+		$type = $input->get('format', 'html', 'word');
 
 		$attributes = array('charset' => 'utf-8', 'lineend' => 'unix', 'tab' => '  ', 'language' => $lang->getTag(),
 			'direction' => $lang->isRTL() ? 'rtl' : 'ltr');

--- a/tests/suites/unit/joomla/JFactoryTest.php
+++ b/tests/suites/unit/joomla/JFactoryTest.php
@@ -111,7 +111,7 @@ class JFactoryTest extends TestCase
 				'This test has not been implemented completely yet.'
 		);
 	}
-	
+
 	/**
 	 * Tests the JFactory::getDocument method.
 	 *
@@ -124,11 +124,15 @@ class JFactoryTest extends TestCase
 	 */
 	function testGetDocument()
 	{
+		JFactory::$application = TestMockApplication::create($this);
+
 		$this->assertInstanceOf(
 			'JDocument',
 			JFactory::getDocument(),
 			'Line: '.__LINE__
 		);
+
+		JFactory::$application = null;
 
 		$this->markTestIncomplete(
 				'This test has not been implemented completely yet.'

--- a/tests/suites/unit/joomla/html/JHtmlTest.php
+++ b/tests/suites/unit/joomla/html/JHtmlTest.php
@@ -554,6 +554,9 @@ class JHtmlTest extends TestCase
 			->method('getTemplate')
 			->will($this->returnValue($template));
 
+		// @todo We need to mock this.
+		$mock->input = new JInput;
+
 		JFactory::$application = $mock;
 
 		// we create the file that JHtml::image will look for
@@ -832,7 +835,7 @@ class JHtmlTest extends TestCase
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
 		$this->assertThat(
-			JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename, 
+			JHtml::script($extension . '/' . $element . '/' . $urlpath . $urlfilename,
 				false, true, true, true, false),
 			$this->equalTo(JURI::base(true) . '/media/system/js/' . $element . '/' . $urlpath . 'script1.js'),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
@@ -893,6 +896,9 @@ class JHtmlTest extends TestCase
 		$mock->expects($this->any())
 			->method('getTemplate')
 			->will($this->returnValue($template));
+
+		// @todo We need to mock this.
+		$mock->input = new JInput;
 
 		JFactory::$application = $mock;
 
@@ -1010,7 +1016,7 @@ class JHtmlTest extends TestCase
 		JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true);
 
 		$this->assertArrayHasKey(
-			'/media/' . $extension . '/css/' . $element . '/' . $urlpath . $urlfilename, 
+			'/media/' . $extension . '/css/' . $element . '/' . $urlpath . $urlfilename,
 			JFactory::$document->_styleSheets,
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
@@ -1057,7 +1063,7 @@ class JHtmlTest extends TestCase
 			'Line:' . __LINE__ . ' JHtml::script failed when we should get it from the media directory');
 
 		$this->assertThat(
-			JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true), 
+			JHtml::stylesheet($extension . '/' . $element . '/' . $urlpath . $urlfilename, array(), true, true),
 			$this->equalTo(''),
 			'Line:' . __LINE__ . ' JHtml::script failed in URL only mode when it should come from the media directory');
 

--- a/tests/suites/unit/joomla/html/html/JHtmlBehaviorTest.php
+++ b/tests/suites/unit/joomla/html/html/JHtmlBehaviorTest.php
@@ -115,6 +115,10 @@ class JHtmlBehaviorTest extends TestCase
 		$mock->expects($this->any())
 			->method('getTemplate')
 			->will($this->returnValue($template));
+
+		// @todo We need to mock this.
+		$mock->input = new JInput;
+
 		JFactory::$application = $mock;
 
 		JHtmlBehaviorInspector::resetLoaded();
@@ -159,6 +163,10 @@ class JHtmlBehaviorTest extends TestCase
 		$mock->expects($this->any())
 			->method('getTemplate')
 			->will($this->returnValue($template));
+
+		// @todo We need to mock this.
+		$mock->input = new JInput;
+
 		JFactory::$application = $mock;
 
 		JHtmlBehaviorInspector::resetLoaded();
@@ -187,6 +195,10 @@ class JHtmlBehaviorTest extends TestCase
 		$mock->expects($this->any())
 			->method('getTemplate')
 			->will($this->returnValue($template));
+
+		// @todo We need to mock this.
+		$mock->input = new JInput;
+
 		JFactory::$application = $mock;
 
 		JHtmlBehaviorInspector::resetLoaded();
@@ -215,6 +227,10 @@ class JHtmlBehaviorTest extends TestCase
 		$mock->expects($this->any())
 			->method('getTemplate')
 			->will($this->returnValue($template));
+
+		// @todo We need to mock this.
+		$mock->input = new JInput;
+
 		JFactory::$application = $mock;
 
 		JHtmlBehaviorInspector::resetLoaded();
@@ -243,6 +259,10 @@ class JHtmlBehaviorTest extends TestCase
 		$mock->expects($this->any())
 			->method('getTemplate')
 			->will($this->returnValue($template));
+
+		// @todo We need to mock this.
+		$mock->input = new JInput;
+
 		JFactory::$application = $mock;
 
 		JHtmlBehaviorInspector::resetLoaded();
@@ -312,6 +332,10 @@ class JHtmlBehaviorTest extends TestCase
 		$mock->expects($this->any())
 			->method('getTemplate')
 			->will($this->returnValue($template));
+
+		// @todo We need to mock this.
+		$mock->input = new JInput;
+
 		JFactory::$application = $mock;
 
 		JHtmlBehaviorInspector::resetLoaded();
@@ -381,6 +405,10 @@ class JHtmlBehaviorTest extends TestCase
 		$mock->expects($this->any())
 			->method('getTemplate')
 			->will($this->returnValue($template));
+
+		// @todo We need to mock this.
+		$mock->input = new JInput;
+
 		JFactory::$application = $mock;
 
 		JHtmlBehaviorInspector::resetLoaded();
@@ -436,6 +464,10 @@ class JHtmlBehaviorTest extends TestCase
 		$mock->expects($this->any())
 			->method('getTemplate')
 			->will($this->returnValue($template));
+
+		// @todo We need to mock this.
+		$mock->input = new JInput;
+
 		JFactory::$application = $mock;
 
 		JHtmlBehaviorInspector::resetLoaded();
@@ -491,6 +523,10 @@ class JHtmlBehaviorTest extends TestCase
 		$mock->expects($this->any())
 			->method('getTemplate')
 			->will($this->returnValue($template));
+
+		// @todo We need to mock this.
+		$mock->input = new JInput;
+
 		JFactory::$application = $mock;
 
 		JHtmlBehaviorInspector::resetLoaded();
@@ -540,6 +576,10 @@ class JHtmlBehaviorTest extends TestCase
 		$mock->expects($this->any())
 			->method('getTemplate')
 			->will($this->returnValue($template));
+
+		// @todo We need to mock this.
+		$mock->input = new JInput;
+
 		JFactory::$application = $mock;
 
 		JHtmlBehaviorInspector::resetLoaded();
@@ -568,6 +608,10 @@ class JHtmlBehaviorTest extends TestCase
 		$mock->expects($this->any())
 			->method('getTemplate')
 			->will($this->returnValue($template));
+
+		// @todo We need to mock this.
+		$mock->input = new JInput;
+
 		JFactory::$application = $mock;
 
 		JHtmlBehaviorInspector::resetLoaded();
@@ -596,6 +640,10 @@ class JHtmlBehaviorTest extends TestCase
 		$mock->expects($this->any())
 			->method('getTemplate')
 			->will($this->returnValue($template));
+
+		// @todo We need to mock this.
+		$mock->input = new JInput;
+
 		JFactory::$application = $mock;
 
 		JHtmlBehaviorInspector::resetLoaded();
@@ -624,6 +672,10 @@ class JHtmlBehaviorTest extends TestCase
 		$mock->expects($this->any())
 			->method('getTemplate')
 			->will($this->returnValue($template));
+
+		// @todo We need to mock this.
+		$mock->input = new JInput;
+
 		JFactory::$application = $mock;
 
 		JHtmlBehaviorInspector::resetLoaded();
@@ -652,6 +704,10 @@ class JHtmlBehaviorTest extends TestCase
 		$mock->expects($this->any())
 			->method('getTemplate')
 			->will($this->returnValue($template));
+
+		// @todo We need to mock this.
+		$mock->input = new JInput;
+
 		JFactory::$application = $mock;
 
 		JHtmlBehaviorInspector::resetLoaded();


### PR DESCRIPTION
Fixing the "format" URL parameter. Bug was introduced when the depreceated "no_html" was removed.
Now it is no longer possible to create other document types using "&format=raw".
This PR brings back this function but doesn't reintroduce the "no_html" parameter.
