### PR TITLE
Some additional changes since memory_get_usage() is now always available.

### DIFF
--- a/libraries/joomla/profiler/profiler.php
+++ b/libraries/joomla/profiler/profiler.php
@@ -106,23 +106,16 @@ class JProfiler
 		$current = self::getmicrotime() - $this->start;
 		$currentMem = 0;
 
-		if (function_exists('memory_get_usage'))
-		{
-			$currentMem = memory_get_usage() / 1048576;
-			$mark = sprintf(
-				'<code>%s %.3f seconds (+%.3f); %0.2f MB (%s%0.3f) - %s</code>',
-				$this->prefix,
-				$current,
-				$current - $this->previousTime,
-				$currentMem,
-				($currentMem > $this->previousMem) ? '+' : '', $currentMem - $this->previousMem,
-				$label
-			);
-		}
-		else
-		{
-			$mark = sprintf('<code>%s %.3f seconds (+%.3f) - %s</code>', $this->prefix, $current, $current - $this->previousTime, $label);
-		}
+		$currentMem = memory_get_usage() / 1048576;
+		$mark = sprintf(
+			'<code>%s %.3f seconds (+%.3f); %0.2f MB (%s%0.3f) - %s</code>',
+			$this->prefix,
+			$current,
+			$current - $this->previousTime,
+			$currentMem,
+			($currentMem > $this->previousMem) ? '+' : '', $currentMem - $this->previousMem,
+			$label
+		);
 
 		$this->previousTime = $current;
 		$this->previousMem = $currentMem;
@@ -152,6 +145,7 @@ class JProfiler
 	 *
 	 * @link    PHP_MANUAL#memory_get_usage
 	 * @since   11.1
+	 * @deprecated  12.3  Use PHP's native memory_get_usage()
 	 */
 	public function getMemory()
 	{


### PR DESCRIPTION
No addition to the deprecated log because I felt JProfiler should remain without dependencies on other classes.
