### PR TITLE
Namespace support for JLoader (with tests)

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -17,6 +17,14 @@ defined('JPATH_PLATFORM') or die;
 abstract class JLoader
 {
 	/**
+	 * Container for namespace => path map.
+	 *
+	 * @var    array
+	 * @since  12.2
+	 */
+	protected static $namespaces = array();
+
+	/**
 	 * Container for already imported library paths.
 	 *
 	 * @var    array
@@ -103,6 +111,18 @@ abstract class JLoader
 	public static function getClassList()
 	{
 		return self::$classes;
+	}
+
+	/**
+	 * Method to get the list of registered namespaces.
+	 *
+	 * @return  array  The array of namespace => path values for the autoloader.
+	 *
+	 * @since   12.2
+	 */
+	public static function getNamespaces()
+	{
+		return self::$namespaces;
 	}
 
 	/**
@@ -202,6 +222,62 @@ abstract class JLoader
 	}
 
 	/**
+	 * Load a class based on namespace.
+	 *
+	 * @param   string  $class  The class (including namespace) to be loaded.
+	 *
+	 * @return  boolean  True on success, false otherwise.
+	 *
+	 * @since   12.2
+	 */
+	public static function loadByNamespace($class)
+	{
+		// If the class already exists do nothing.
+		if (class_exists($class))
+		{
+			return true;
+		}
+
+		foreach (self::$namespaces as $namespace => $basePath)
+		{
+			// If we find the class namespace.
+			if (strpos($class, $namespace) !== false)
+			{
+				foreach ($basePath as $bPath)
+				{
+					// Remove the namespace from the class.
+					$path = str_replace($namespace, '', $class);
+
+					// Replace the namespace separator by the directory separator.
+					$path = str_replace('\\', '/', $path);
+
+					// Create a path for low case file and directory names.
+					$lowerPath = $bPath . strtolower($path) . '.php';
+
+					// Create a path for directory and file names matching the namespace case.
+					$upperPath = $bPath . $path . '.php';
+
+					// Try to include the low case path.
+					if (file_exists($lowerPath))
+					{
+						include $lowerPath;
+						return true;
+					}
+
+					// Try to include the path that may contains upper case letters.
+					if (file_exists($upperPath))
+					{
+						include $upperPath;
+						return true;
+					}
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Directly register a class to the autoload list.
 	 *
 	 * @param   string   $class  The class name to register.
@@ -264,6 +340,40 @@ abstract class JLoader
 	}
 
 	/**
+	 * Register a namespace to the autoloader.
+	 *
+	 * @param   string   $namespace  A case sensitive Namespace to register.
+	 * @param   string   $path       A case sensitive absolute file path to the library root where classes of the given namespace can be found.
+	 * @param   boolean  $reset      True to reset the namespace with only the given lookup path.
+	 *
+	 * @return  void
+	 *
+	 * @throws  RuntimeException
+	 *
+	 * @since   12.2
+	 */
+	public static function registerNamespace($namespace, $path, $reset = false)
+	{
+		// Verify the library path exists.
+		if (!file_exists($path))
+		{
+			throw new RuntimeException('Library path ' . $path . ' cannot be found.', 500);
+		}
+
+		// If the namespace is not yet registered or we have an explicit reset flag then set the path.
+		if (empty(self::$namespaces[$namespace]) || $reset)
+		{
+			self::$namespaces[$namespace] = array($path);
+		}
+
+		// Otherwise we want to simply add the path to the namespace.
+		else
+		{
+			self::$namespaces[$namespace][] = $path;
+		}
+	}
+
+	/**
 	 * Method to setup the autoloaders for the Joomla Platform.  Since the SPL autoloaders are
 	 * called in a queue we will add our explicit, class-registration based loader first, then
 	 * fall back on the autoloader based on conventions.  This will allow people to register a
@@ -281,6 +391,7 @@ abstract class JLoader
 		// Register the autoloader functions.
 		spl_autoload_register(array('JLoader', 'load'));
 		spl_autoload_register(array('JLoader', '_autoload'));
+		spl_autoload_register(array('JLoader', 'loadByNamespace'));
 	}
 
 	/**

--- a/tests/suites/unit/stubs/Color/Rgb/Red.php
+++ b/tests/suites/unit/stubs/Color/Rgb/Red.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Color\Rgb;
+
+class Red
+{
+
+}

--- a/tests/suites/unit/stubs/animal1/cat.php
+++ b/tests/suites/unit/stubs/animal1/cat.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace animal;
+
+class Cat
+{
+
+}

--- a/tests/suites/unit/stubs/animal2/dog.php
+++ b/tests/suites/unit/stubs/animal2/dog.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace animal;
+
+class Dog
+{
+
+}

--- a/tests/suites/unit/stubs/chess/piece/pawn.php
+++ b/tests/suites/unit/stubs/chess/piece/pawn.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Chess\Piece;
+
+class Pawn
+{
+
+}


### PR DESCRIPTION
This pull request adds support for class loading and autoloading based on namespaces.

If your class is located in :  `BASE_PATH/Chess/Piece/Pawn.php` :

``` php
<?php
namespace Chess\Piece;

class Pawn {} 
```

You can register it to the auto loader, by registering the ROOT namespace `Chess`:
`JLoader::registerNamespace('Chess', BASE_PATH . '/Chess');`

All classes respecting the naming convention in a given namespace  :
`namespace Folder\SubFolder;` for classes in `BASE_PATH/Folder/SubFolder/` will be autoloaded.

If you have lower case directory names and class names `BASE_PATH/folder/subfolder/`, you can either declarate the namespace with lower or camel cases, and it will work too.

But note that the first param of JLoader::registerNamespace is case sensitive and must match the namespace declaration case.

Examples: `namespace Chess;` `JLoader::registerNamespace('Chess', PATH_TO_CHESS);`

`namespace chess;` `JLoader::registerNamespace('chess', PATH_TO_CHESS);`

You can also register multiple lookup paths for a given namespace (like the prefix).
