### PR TITLE
Correct confusion between required and validate messages

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1833,7 +1833,7 @@ class JForm
 
 		if ($required)
 		{
-		// If the field is required and the value is empty return an error message.
+			// If the field is required and the value is empty return an error message.
 			if (($value === '') || ($value === null))
 			{
 				if ($element['label'])

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1833,26 +1833,18 @@ class JForm
 
 		if ($required)
 		{
-			// If the field is required and the value is empty return an error message.
+		// If the field is required and the value is empty return an error message.
 			if (($value === '') || ($value === null))
 			{
-				// Does the field have a defined error message?
-				if ($element['message'])
+				if ($element['label'])
 				{
-					$message = JText::_($element['message']);
+					$message = JText::_($element['label']);
 				}
 				else
 				{
-					if ($element['label'])
-					{
-						$message = JText::_($element['label']);
-					}
-					else
-					{
-						$message = JText::_($element['name']);
-					}
-					$message = JText::sprintf('JLIB_FORM_VALIDATE_FIELD_REQUIRED', $message);
+					$message = JText::_($element['name']);
 				}
+				$message = JText::sprintf('JLIB_FORM_VALIDATE_FIELD_REQUIRED', $message);
 
 				return new RuntimeException($message);
 			}


### PR DESCRIPTION
When a field contains both a required and a validate element, we get a confusion for the error messages.
This patch takes element['message'] out of the required conditional as, in this case, the label or the name can be used for the error.
(Patch also ready for the CMS with fields and strings changes)
