### PR TITLE
Fix problem with JLoader prefixes

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -296,7 +296,8 @@ abstract class JLoader
 	{
 		foreach (self::$prefixes as $prefix => $lookup)
 		{
-			if (strpos($class, $prefix) === 0)
+			$chr = strlen($prefix) < strlen($class) ? $class[strlen($prefix)] : 0;
+			if (strpos($class, $prefix) === 0 && ($chr === strtoupper($chr)))
 			{
 				return self::_load(substr($class, strlen($prefix)), $lookup);
 			}


### PR DESCRIPTION
When registering a custom prefix that has more than a single uppercase character, JLoader searches the wrong path. For example, registering

``` php
JLoader::registerPrefix('Jcms', JPATH_PLATFORM . '/cms');
```

will cause it to look for, say, JcmsViewHtml in libraries/cms/cms/view/html.php because the "cms" part of the prefix is mistakenly interpreted as a path segment. 

This patch will make sure the whole first segment of a CamelCasedWord is used as the loader prefix.
