### PR TITLE
JRegistryFormatINI::stringToObject() preg_match key validation

### DIFF
--- a/libraries/joomla/registry/format/ini.php
+++ b/libraries/joomla/registry/format/ini.php
@@ -137,7 +137,7 @@ class JRegistryFormatINI extends JRegistryFormat
 			list ($key, $value) = explode('=', $line, 2);
 
 			// Validate the key.
-			if (preg_match('/[^A-Z0-9_]/i', $key))
+			if (!preg_match('/[^A-Z0-9_]/i', $key))
 			{
 				// Maybe throw exception?
 				continue;


### PR DESCRIPTION
Fix an actually non-relevant but potential bug reported by eaxs in joomla-cms.

// Validate the key.
if (preg_match('/[^A-Z0-9_]/i', $key))
{
    // Maybe throw exception?
    continue;
}

Issue 267 reported by eaxs in joomla-cms
https://github.com/joomla/joomla-cms/issues/267
