### PR TITLE
Corrections to JAccess when there is an invalid or missing asset or parenting is to root.

### DIFF
--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -98,7 +98,10 @@ class JAccess
 		// Default to the root asset node.
 		if (empty($asset))
 		{
-			$asset = 1;
+			$db = JFactory::getDbo();
+			$assets = JTable::getInstance('Asset', 'JTable', array('dbo' => $db));
+			$rootId = $assets->getRootId();
+			$asset = $rootId;
 		}
 
 		// Get the rules for the asset recursively to root if not already retrieved.
@@ -138,7 +141,9 @@ class JAccess
 		// Default to the root asset node.
 		if (empty($asset))
 		{
-			$asset = 1;
+			$db = JFactory::getDbo();
+			$assets = JTable::getInstance('Asset', 'JTable', array('dbo' => $db));
+			$rootId = $assets->getRootId();
 		}
 
 		// Get the rules for the asset recursively to root if not already retrieved.
@@ -225,12 +230,10 @@ class JAccess
 		// If the asset identifier is numeric assume it is a primary key, else lookup by name.
 		if (is_numeric($asset))
 		{
-			// Get the root even if the asset is not found
 			$query->where('(a.id = ' . (int) $asset . ')');
 		}
 		else
 		{
-			// Get the root even if the asset is not found
 			$query->where('(a.name = ' . $db->quote($asset) . ')');
 		}
 
@@ -246,16 +249,19 @@ class JAccess
 		$result = $db->loadColumn();
 
 		// Get the root even if the asset is not found and in recursive mode
-		if ($recursive && empty($result))
+		if (empty($result))
 		{
+			$db = JFactory::getDbo();
+			$assets = JTable::getInstance('Asset', 'JTable', array('dbo' => $db));
+			$rootId = $assets->getRootId();
 			$query = $db->getQuery(true);
 			$query->select('rules');
 			$query->from('#__assets');
-			$query->where('parent_id = 0');
+			$query->where('id = ' . $db->quote($rootId));
 			$db->setQuery($query);
-			$result = $db->loadColumn();
+			$result = $db->loadResult();
+			$result = array($result);
 		}
-
 		// Instantiate and return the JAccessRules object for the asset rules.
 		$rules = new JAccessRules;
 		$rules->mergeCollection($result);
@@ -455,9 +461,7 @@ class JAccess
 	 * @deprecated  12.3  Use JAccess::getActionsFromFile or JAccess::getActionsFromData instead.
 	 *
 	 * @codeCoverageIgnore
-	 *
-	 * @todo    Need to decouple this method from the CMS. Maybe check if $component is a
-	 *          valid file (or create a getActionsFromFile method).
+	 * 
 	 */
 	public static function getActions($component, $section = 'component')
 	{

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -278,7 +278,8 @@ abstract class JTable extends JObject
 
 	/**
 	 * Method to get the parent asset under which to register this one.
-	 * By default, all assets are registered to the ROOT node with ID 1.
+	 * By default, all assets are registered to the ROOT node with ID,
+	 * which will default to 1 if none exists.
 	 * The extended class can define a table and id to lookup.  If the
 	 * asset does not exist it will be created.
 	 *
@@ -292,9 +293,11 @@ abstract class JTable extends JObject
 	protected function _getAssetParentId($table = null, $id = null)
 	{
 		// For simple cases, parent to the asset root.
-		if (empty($table) || empty($id))
+		$assets = self::getInstance('Asset', 'JTable', array('dbo' => $this->getDbo()));
+		$rootId = $assets->getRootId();
+		if (!empty($rootId))
 		{
-			return 1;
+			return $rootId;
 		}
 
 		return 1;
@@ -570,6 +573,10 @@ abstract class JTable extends JObject
 	{
 		// Initialise variables.
 		$k = $this->_tbl_key;
+		if (!empty($this->asset_id))
+		{
+			$currentAssetId = $this->asset_id;
+		}
 
 		// The asset id field is managed privately by this class.
 		if ($this->_trackAssets)
@@ -642,7 +649,8 @@ abstract class JTable extends JObject
 			return false;
 		}
 
-		if (empty($this->asset_id))
+		// Create an asset_id or heal one that is corrupted.
+		if (empty($this->asset_id) || ($currentAssetId != $this->asset_id && !empty($this->asset_id)))
 		{
 			// Update the asset_id field in this table.
 			$this->asset_id = (int) $asset->id;

--- a/tests/suites/unit/joomla/access/JAccessTest.php
+++ b/tests/suites/unit/joomla/access/JAccessTest.php
@@ -148,7 +148,7 @@ class JAccessTest extends TestCaseDatabase
 	}
 
 	/**
-	 * Test cases for testCheck and testCheckGroups
+	 * Test cases for testCheck
 	 *
 	 * Each test case provides
 	 * - integer		userid	a user id
@@ -165,12 +165,12 @@ class JAccessTest extends TestCaseDatabase
 	function casesCheck()
 	{
 		return array(
-           'valid_superuser_site_login' => array(
-			   42, 'core.login.site', 3, true,
+           'valid_admin_site_login' => array(
+			   45, 'core.login.site', 3, true,
                'Line:'.__LINE__.' Administrator group can login to site'
                ),
             'valid_editor_site_login' => array(
-               42, 'core.login.site', 1, true,
+               46, 'core.login.site', 1, true,
                'Line:'.__LINE__.' Editor group'
                ),
             'valid_manager_admin_login' => array(
@@ -187,7 +187,7 @@ class JAccessTest extends TestCaseDatabase
               ),
             'super_user_admin' => array(
                42, 'core.admin', null, true,
-              'Line:'.__LINE__.' Null asset should default to 1'
+              'Line:'.__LINE__.' Null asset should default to root'
               ),
             'publisher_create_banner' => array(
               43, 'core.create', 3, false,
@@ -241,7 +241,7 @@ class JAccessTest extends TestCaseDatabase
 	}
 
 	/**
-	 * Test cases for testCheck and testCheckGroups
+	 * Test cases for testCheckGroups
 	 *
 	 * Each test case provides
 	 * - integer		userid	a user id
@@ -258,7 +258,7 @@ class JAccessTest extends TestCaseDatabase
 	function casesCheckGroup()
 	{
 		return array(
-           'valid_superuser_site_login' => array(
+           'valid_admin_site_login' => array(
 			   7, 'core.login.site', 3, true,
                'Line:'.__LINE__.' Administrator group can login to site'
                ),
@@ -339,7 +339,7 @@ class JAccessTest extends TestCaseDatabase
 	 *
 	 * @since   11.1
 	 */
-	public function testGetAssetRules()
+	public function testGetAssetRulesValidTrue()
 	{
 		$access = new JAccess();
 		$ObjArrayJrules = $access->getAssetRules(3, True);
@@ -347,39 +347,51 @@ class JAccessTest extends TestCaseDatabase
 		$this->assertThat(
 			(string)$ObjArrayJrules,
 			$this->equalTo($string1),
-			'Line: ' . __LINE__
+			'Recursive rules from a valid asset. Line: ' . __LINE__
 		);
-
+	}
+	public function testGetAssetRulesValidFalse()
+	{
+		$access = new JAccess();
 		$ObjArrayJrules = $access->getAssetRules(3, False);
 		$string1 = '{"core.admin":{"7":1},"core.manage":{"6":1},"core.create":{"4":0},"core.delete":{"4":0,"5":1},"core.edit":[],"core.edit.state":[]}';
 		$this->assertThat(
 			(string) $ObjArrayJrules,
 			$this->equalTo($string1),
-			'Line: ' . __LINE__
+			'Non recursive rules from a valid asset. Line: ' . __LINE__
 		);
-
+	}
+	public function testGetAssetRulesInvalidFalse()
+	{
+		$access = new JAccess();
 		$ObjArrayJrules = $access->getAssetRules(1550, False);
-		$string1 = '[]';
-		$this->assertThat(
-			(string)$ObjArrayJrules,
-			$this->equalTo($string1),
-			'Line: ' . __LINE__
-		);
-
-		$ObjArrayJrules = $access->getAssetRules('testasset', False);
-		$string1 = '[]';
-		$this->assertThat(
-			(string)$ObjArrayJrules,
-			$this->equalTo($string1),
-			'Line: ' . __LINE__
-		);
-
-		$ObjArrayJrules = $access->getAssetRules('testasset', true);
 		$string1 = '{"core.login.site":{"6":1,"2":1},"core.login.admin":{"6":1},"core.admin":{"8":1},"core.manage":{"7":1,"10":1},"core.create":{"6":1},"core.delete":{"6":1},"core.edit":{"6":1},"core.edit.state":{"6":1}}';
 		$this->assertThat(
 			(string)$ObjArrayJrules,
 			$this->equalTo($string1),
-			'Line: ' . __LINE__
+			'Invalid asset uses rule from root. Line: ' . __LINE__
+		);
+	}
+	public function testGetAssetRulesTextFalse()
+	{
+		$access = new JAccess();
+		$ObjArrayJrules = $access->getAssetRules('testasset', False);
+		$string1 = '{"core.login.site":{"6":1,"2":1},"core.login.admin":{"6":1},"core.admin":{"8":1},"core.manage":{"7":1,"10":1},"core.create":{"6":1},"core.delete":{"6":1},"core.edit":{"6":1},"core.edit.state":{"6":1}}';
+		$this->assertThat(
+			(string)$ObjArrayJrules,
+			$this->equalTo($string1),
+			'Invalid asset uses rule from root. Line: ' . __LINE__
+		);
+	}
+	public function testGetAssetRulesTextTrue()
+	{
+		$access = new JAccess();
+		$ObjArrayJrules = $access->getAssetRules('testasset', True);
+		$string1 = '{"core.login.site":{"6":1,"2":1},"core.login.admin":{"6":1},"core.admin":{"8":1},"core.manage":{"7":1,"10":1},"core.create":{"6":1},"core.delete":{"6":1},"core.edit":{"6":1},"core.edit.state":{"6":1}}';
+		$this->assertThat(
+			(string)$ObjArrayJrules,
+			$this->equalTo($string1),
+			'Invalid asset uses rule from root. Line: ' . __LINE__
 		);
 	}
 
@@ -390,26 +402,42 @@ class JAccessTest extends TestCaseDatabase
 	 *
 	 * @since   11.1
 	 */
-	public function testGetUsersByGroup()
+	public function testGetUsersByGroupSimple()
 	{
 		$access = new JAccess();
 		$array1 = array(
 			0	=> 42
 		);
 		$this->assertThat(
-			$array1,
-			$this->equalTo($access->getUsersByGroup(8, True))
+			$access->getUsersByGroup(8, True),
+			$this->equalTo($array1),
+			'Get one user. Line: ' . __LINE__
 		);
+	}
+	public function testGetUsersByGroupTwoUsers()
+	{
+		$access = new JAccess();
 
-		$this->assertThat(
-			$array1,
-			$this->equalTo($access->getUsersByGroup(7, True))
+		$array3 = array(
+			0	=> 42,
+			1	=> 45,
+			2	=> 47
 		);
+		$this->assertThat(
+			$access->getUsersByGroup(7, True),
+			$this->equalTo($array3),
+			'Get multiple users. Line: ' . __LINE__
+		);
+	}
+	public function testGetUsersByGroupInvalidGroup()
+	{
+		$access = new JAccess();
 
 		$array2 = array();
 		$this->assertThat(
-			$array2,
-			$this->equalTo($access->getUsersByGroup(7, False))
+			$access->getUsersByGroup(15, False),
+			$this->equalTo($array2),
+			'No group specified. Line: ' . __LINE__
 		);
 	}
 

--- a/tests/suites/unit/joomla/access/JRulesTest.php
+++ b/tests/suites/unit/joomla/access/JRulesTest.php
@@ -25,7 +25,46 @@ class JAccessRulesTest extends PHPUnit_Framework_TestCase
 	 * @covers  JAccessRules::__construct
 	 * @covers  JAccessRules::__toString
 	 */
-	public function test__construct()
+	public function test__constructString()
+	{
+		$array = array(
+			'edit' => array(
+				-42	=> 1,
+				2	=> 1,
+				3	=> 0
+			)
+		);
+
+		$string = json_encode($array);
+
+		// Test input as string.
+		$rules = new JAccessRules($string);
+		$this->assertThat(
+			(string) $rules,
+			$this->equalTo($string),
+			'Checks input as an string.'
+		);
+	}
+	public function test__constructArray()
+		{
+			$array = array(
+				'edit' => array(
+					-42	=> 1,
+					2	=> 1,
+					3	=> 0
+				)
+			);
+
+			$string = json_encode($array);
+
+			$rules = new JAccessRules($array);
+			$this->assertThat(
+				(string) $rules,
+				$this->equalTo($string),
+				'Checks input as an array.'
+			);
+	}
+	public function test__constructObject()
 	{
 		$array = array(
 			'edit' => array(
@@ -38,21 +77,6 @@ class JAccessRulesTest extends PHPUnit_Framework_TestCase
 		$string = json_encode($array);
 
 		$object = (object) $array;
-
-		// Test input as string.
-		$rules = new JAccessRules($string);
-		$this->assertThat(
-			(string) $rules,
-			$this->equalTo($string),
-			'Checks input as an string.'
-		);
-
-		$rules = new JAccessRules($array);
-		$this->assertThat(
-			(string) $rules,
-			$this->equalTo($string),
-			'Checks input as an array.'
-		);
 
 		$rules = new JAccessRules($object);
 		$this->assertThat(
@@ -167,15 +191,42 @@ class JAccessRulesTest extends PHPUnit_Framework_TestCase
 		$rules1 = new JAccessRules($string1);
 		$this->assertThat(
 			(string) $rules1,
-			$this->equalTo($string1)
+			$this->equalTo($string1),
+			'Input as a string'
 		);
+	}
+
+	public function testMergeArray()
+	{
+		$array1 = array(
+			'edit' => array(
+				-42	=> 1
+			),
+			'delete' => array(
+				-42	=> 0
+			)
+		);
+		$string1 = json_encode($array1);
 
 		// Test construction by array.
 		$rules1 = new JAccessRules($array1);
 		$this->assertThat(
 			(string) $rules1,
-			$this->equalTo($string1)
+			$this->equalTo($string1),
+			'Input as a array'
 		);
+	}
+	public function testMergeRulesNull()
+	{
+		$array1 = array(
+			'edit' => array(
+				-42	=> 1
+			),
+			'delete' => array(
+				-42	=> 0
+			)
+		);
+		$string1 = json_encode($array1);
 
 		// Test merge by JAccessRules.
 		$rules1 = new JAccessRules($array1);
@@ -183,14 +234,50 @@ class JAccessRulesTest extends PHPUnit_Framework_TestCase
 		$rules2->merge($rules1);
 		$this->assertThat(
 			(string) $rules2,
-			$this->equalTo($string1)
+			$this->equalTo($string1),
+			'Merge by JRules where second rules are empty'
+		);
+	}
+	public function testMergeRules()
+	{
+		$array1 = array(
+			'edit' => array(
+				-42	=> 1
+			),
+			'delete' => array(
+				-42	=> 0
+			)
+		);
+		$string1 = json_encode($array1);
+
+		$array2 = array(
+			'create' => array(
+				2	=> 1
+			),
+			'delete' => array(
+				2	=> 0
+			)
+		);
+
+		$result2 = array(
+			'edit' => array(
+				-42	=> 1
+			),
+			'delete' => array(
+				-42	=> 0,
+				2	=> 0
+			),
+			'create' => array(
+				2	=> 1
+			),
 		);
 
 		$rules1 = new JAccessRules($array1);
 		$rules1->merge($array2);
 		$this->assertThat(
 			(string) $rules1,
-			$this->equalTo(json_encode($result2))
+			$this->equalTo(json_encode($result2)),
+			'Input as a JRules'
 		);
 
 	}

--- a/tests/suites/unit/joomla/access/stubs/S01.xml
+++ b/tests/suites/unit/joomla/access/stubs/S01.xml
@@ -3419,6 +3419,23 @@ separator=
 			<value>44</value>
 			<value>6</value>
 		</row>
+		<row>
+			<value>45</value>
+			<value>7</value>
+		</row>
+		<row>
+			<value>46</value>
+			<value>4</value>
+		</row>
+		<row>
+			<value>47</value>
+			<value>7</value>
+		</row>
+		<row>
+			<value>47</value>
+			<value>4</value>
+		</row>
+
 	</table>
 	<table name="jos_usergroups">
 		<column>id</column>
@@ -3499,8 +3516,8 @@ separator=
 		<row>
 			<value>42</value>
 			<value>Super User</value>
-			<value>admin</value>
-			<value>admin@example.com</value>
+			<value>superadmin</value>
+			<value>superadmin@example.com</value>
 			<value>7017fe127670faddb25f3a893a36229c:eCU2KtKahxQIMH5i3nwc05zVTBtZXbVV</value>
 			<value>deprecated</value>
 			<value>0</value>
@@ -3551,6 +3568,48 @@ separator=
 			<value>0000-00-00 00:00:00</value>
 			<value></value>
 			<value>{&quot;admin_language&quot;:&quot;&quot;,&quot;language&quot;:&quot;&quot;,&quot;editor&quot;:&quot;&quot;,&quot;helpsite&quot;:&quot;&quot;,&quot;timezone&quot;:&quot;&quot;}</value>
+		</row>
+		<row>
+			<value>45</value>
+			<value>Admin</value>
+			<value>admin</value>
+			<value>admin@example.com</value>
+			<value>7017fe127670faddb25f3a893a36229c:eCU2KtKahxQIMH5i3nwc05zVTBtZXbVV</value>
+			<value>deprecated</value>
+			<value>0</value>
+			<value>1</value>
+			<value>2010-02-13 00:34:42</value>
+			<value>0000-00-00 00:00:00</value>
+			<value></value>
+			<value></value>
+		</row>
+		<row>
+			<value>46</value>
+			<value>Editor</value>
+			<value>editor</value>
+			<value>editor@example.com</value>
+			<value>7017fe127670faddb25f3a893a36229c:eCU2KtKahxQIMH5i3nwc05zVTBtZXbVV</value>
+			<value>deprecated</value>
+			<value>0</value>
+			<value>1</value>
+			<value>2010-02-13 00:34:42</value>
+			<value>0000-00-00 00:00:00</value>
+			<value></value>
+			<value></value>
+		</row>
+		<row>
+			<value>47</value>
+			<value>EditorandAdmin</value>
+			<value>editorandadmin</value>
+			<value>editorandadmin@example.com</value>
+			<value>7017fe127670faddb25f3a893a36229c:eCU2KtKahxQIMH5i3nwc05zVTBtZXbVV</value>
+			<value>deprecated</value>
+			<value>0</value>
+			<value>1</value>
+			<value>2010-02-13 00:34:42</value>
+			<value>0000-00-00 00:00:00</value>
+			<value></value>
+			<value></value>
 		</row>
 	</table>
 	<table name="jos_viewlevels">


### PR DESCRIPTION
Although there is some confusion in the wording examination of the comments and docblocks of JAccess indicates that if there is parenting to the root asset or there is an invalid asset that the rules from the root asset should be used. For various reasons this was not actually working in the current class. This has been causing problems for developers who wish to parent assets from the root asset. In addition this corrects a situation where as a result of the asset_id being privately manage a corrupted asset_id could never be corrected using the class. 

The approach to solving this involved several steps.
First, change the code so that the id of the root asset is always obtained using the API rather than assuming either that the parent_id is 0 or that the id is 1. This solves problems when the asset table data has been created outside of Joomla and imported, possibly with the root not as the first record.

Second, when there are no rules available, for example when the asset is not found, the root asset rules are used regardless of whether the rules are being treated as recursive or not.  This is important for a number of reasons not least of which is it provides super user permissions if available. Previously in this situation the super user did not have special super user permissions.

Third, there are some complications when getActions/getActionsFromFile/getActionsFromData do not include a section that matches an asset (that is that final assets are parented to the root asset with nothing akin to a component in between). In this case, such assets will now fall back to the root asset for their rules unless something else is provided. 

Fourth, a number of the tests for JRules and JAccess had incorrect expected results. These have been corrected.
