### PR TITLE
Allowing override of the xx-XX.localise.php 

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -199,9 +199,9 @@ class JLanguage
 			$paths[3] = JPATH_ADMINISTRATOR . "/language/$lang/$lang.localise.php";
 		}
 
-		ksort($paths); 
+		ksort($paths);
 		$path = reset($paths);
-		
+
 		while (!class_exists($class) && $path)
 		{
 			if (file_exists($path))

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -186,6 +186,26 @@ class JLanguage
 		$class = str_replace('-', '_', $lang . 'Localise');
 		if (!class_exists($class) && defined('JPATH_SITE'))
 		{
+			// Class does not exist. Try to find it in the Site Language Overrides Folder
+			$localise = JPATH_SITE . "/language/overrides/$lang.localise.php";
+			if (file_exists($localise))
+			{
+				require_once $localise;
+			}
+		}
+
+		if (!class_exists($class) && defined('JPATH_ADMINISTRATOR'))
+		{
+			// Class does not exist. Try to find it in the Administrator Language Overrides Folder
+			$localise = JPATH_ADMINISTRATOR . "/language/overrides/$lang.localise.php";
+			if (file_exists($localise))
+			{
+				require_once $localise;
+			}
+		}
+
+		if (!class_exists($class) && defined('JPATH_SITE'))
+		{
 			// Class does not exist. Try to find it in the Site Language Folder
 			$localise = JPATH_SITE . "/language/$lang/$lang.localise.php";
 			if (file_exists($localise))

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -184,44 +184,31 @@ class JLanguage
 
 		// Look for a language specific localise class
 		$class = str_replace('-', '_', $lang . 'Localise');
-		if (!class_exists($class) && defined('JPATH_SITE'))
+		$paths = array();
+		if (defined('JPATH_SITE'))
 		{
-			// Class does not exist. Try to find it in the Site Language Overrides Folder
-			$localise = JPATH_SITE . "/language/overrides/$lang.localise.php";
-			if (file_exists($localise))
-			{
-				require_once $localise;
-			}
+			// Note: Manual indexing to enforce load order.
+			$paths[0] = JPATH_SITE . "/language/overrides/$lang.localise.php";
+			$paths[2] = JPATH_SITE . "/language/$lang/$lang.localise.php";
 		}
 
-		if (!class_exists($class) && defined('JPATH_ADMINISTRATOR'))
+		if (defined('JPATH_ADMINISTRATOR'))
 		{
-			// Class does not exist. Try to find it in the Administrator Language Overrides Folder
-			$localise = JPATH_ADMINISTRATOR . "/language/overrides/$lang.localise.php";
-			if (file_exists($localise))
-			{
-				require_once $localise;
-			}
+			// Note: Manual indexing to enforce load order.
+			$paths[1] = JPATH_ADMINISTRATOR . "/language/overrides/$lang.localise.php";
+			$paths[3] = JPATH_ADMINISTRATOR . "/language/$lang/$lang.localise.php";
 		}
 
-		if (!class_exists($class) && defined('JPATH_SITE'))
+		ksort($paths); 
+		$path = reset($paths);
+		
+		while (!class_exists($class) && $path)
 		{
-			// Class does not exist. Try to find it in the Site Language Folder
-			$localise = JPATH_SITE . "/language/$lang/$lang.localise.php";
-			if (file_exists($localise))
+			if (file_exists($path))
 			{
-				require_once $localise;
+				require_once $path;
 			}
-		}
-
-		if (!class_exists($class) && defined('JPATH_ADMINISTRATOR'))
-		{
-			// Class does not exist. Try to find it in the Administrator Language Folder
-			$localise = JPATH_ADMINISTRATOR . "/language/$lang/$lang.localise.php";
-			if (file_exists($localise))
-			{
-				require_once $localise;
-			}
+			$path = next($paths);
 		}
 
 		if (class_exists($class))


### PR DESCRIPTION
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28877

This patch let's override the settings in the localise.php file without touching at the original file in the core language folders by letting add an xx-XX.localise.php file in the language/overrides/ folders.
For example the maximum number of characters allowed to search.
