### PR TITLE
Add active flag to JPaginationObject, add coverage-legacy to build/.gitignore

### DIFF
--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,4 +1,5 @@
 /coverage
+/coverage-legacy
 /logs
 /pdepend
 /code-browser

--- a/libraries/joomla/pagination/object.php
+++ b/libraries/joomla/pagination/object.php
@@ -43,20 +43,28 @@ class JPaginationObject
 	public $prefix;
 
 	/**
+	 * @var    boolean  Flag whether the object is the 'active' page
+	 * @since  12.2
+	 */
+	public $active;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param   string   $text    The link text.
 	 * @param   integer  $prefix  The prefix used for request variables.
 	 * @param   integer  $base    The number of rows as a base offset.
 	 * @param   string   $link    The link URL.
+	 * @param   boolean  $active  Flag whether the object is the 'active' page
 	 *
 	 * @since   11.1
 	 */
-	public function __construct($text, $prefix = '', $base = null, $link = null)
+	public function __construct($text, $prefix = '', $base = null, $link = null, $active = false)
 	{
 		$this->text   = $text;
 		$this->prefix = $prefix;
 		$this->base   = $base;
 		$this->link   = $link;
+		$this->active = $active;
 	}
 }

--- a/libraries/joomla/pagination/pagination.php
+++ b/libraries/joomla/pagination/pagination.php
@@ -721,6 +721,10 @@ class JPagination
 				$data->pages[$i]->base = $offset;
 				$data->pages[$i]->link = JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $offset);
 			}
+			elseif ($i = $this->pagesCurrent)
+			{
+				$data->pages[$i]->active = true;
+			}
 		}
 		return $data;
 	}


### PR DESCRIPTION
This adds a flag to JPaginationObject so that items can be reported as the active page in the pagination.

Also, I added the legacy unit report coverage to the .gitignore since it wasn't there.
