### PR TITLE
J form field combo wrong element type

### DIFF
--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,4 +1,5 @@
 /coverage
+/coverage-legacy
 /logs
 /pdepend
 /code-browser

--- a/libraries/joomla/form/fields/combo.php
+++ b/libraries/joomla/form/fields/combo.php
@@ -40,16 +40,24 @@ class JFormFieldCombo extends JFormFieldList
 	{
 		// Initialize variables.
 		$html = array();
-		$attr = '';
+		$attr = array();
 
 		// Initialize some field attributes.
-		$attr .= $this->element['class'] ? ' class="combobox ' . (string) $this->element['class'] . '"' : ' class="combobox"';
-		$attr .= ((string) $this->element['readonly'] == 'true') ? ' readonly="readonly"' : '';
-		$attr .= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
-		$attr .= $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
+		$attr['class'] = $this->element['class'] ? 'combobox ' . $this->element['class'] : 'combobox';
+		if ((string) $this->element['readonly'] == 'true')
+		{
+			$attr['readonly'] = 'readonly';
+		}
+		if ((string) $this->element['disabled'] == 'true')
+		{
+			$attr['disabled'] = 'disabled';
+		}
 
 		// Initialize JavaScript field attributes.
-		$attr .= $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
+		if ($this->element['onchange'])
+		{
+			$attr['onchange'] = (string) $this->element['onchange'];
+		}
 
 		// Get the field options.
 		$options = $this->getOptions();
@@ -57,17 +65,8 @@ class JFormFieldCombo extends JFormFieldList
 		// Load the combobox behavior.
 		JHtml::_('behavior.combobox');
 
-		// Build the input for the combo box.
-		$html[] = '<input type="text" name="' . $this->name . '" id="' . $this->id . '"' . ' value="'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $attr . '/>';
-
-		// Build the list for the combo box.
-		$html[] = '<ul id="combobox-' . $this->id . '" style="display:none;">';
-		foreach ($options as $option)
-		{
-			$html[] = '<li>' . $option->text . '</li>';
-		}
-		$html[] = '</ul>';
+		// Generate the list
+		$html[] = JHTML::_('select.genericlist', $options, $this->name, $attr, 'value', 'text', $this->value, $this->id);
 
 		return implode($html);
 	}

--- a/libraries/joomla/pagination/object.php
+++ b/libraries/joomla/pagination/object.php
@@ -43,20 +43,28 @@ class JPaginationObject
 	public $prefix;
 
 	/**
+	 * @var    boolean  Flag whether the object is the 'active' page
+	 * @since  12.2
+	 */
+	public $active;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param   string   $text    The link text.
 	 * @param   integer  $prefix  The prefix used for request variables.
 	 * @param   integer  $base    The number of rows as a base offset.
 	 * @param   string   $link    The link URL.
+	 * @param   boolean  $active  Flag whether the object is the 'active' page
 	 *
 	 * @since   11.1
 	 */
-	public function __construct($text, $prefix = '', $base = null, $link = null)
+	public function __construct($text, $prefix = '', $base = null, $link = null, $active = false)
 	{
 		$this->text   = $text;
 		$this->prefix = $prefix;
 		$this->base   = $base;
 		$this->link   = $link;
+		$this->active = $active;
 	}
 }

--- a/libraries/joomla/pagination/pagination.php
+++ b/libraries/joomla/pagination/pagination.php
@@ -721,6 +721,10 @@ class JPagination
 				$data->pages[$i]->base = $offset;
 				$data->pages[$i]->link = JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $offset);
 			}
+			elseif ($i = $this->pagesCurrent)
+			{
+				$data->pages[$i]->active = true;
+			}
 		}
 		return $data;
 	}


### PR DESCRIPTION
JFormFieldCombo::getInput() is generating a text input and a hidden list. The combobox javascript actually expects a select. So, combo field actually just shows up as a text field with none of the features of a combobox. 

Anyway, isn't it weird that this is part of the platform while the javascript that it requires is part of the cms? 
