### PR TITLE
JFormFieldCombo::getInput()

### DIFF
--- a/libraries/joomla/form/fields/combo.php
+++ b/libraries/joomla/form/fields/combo.php
@@ -44,20 +44,11 @@ class JFormFieldCombo extends JFormFieldList
 
 		// Initialize some field attributes.
 		$attr['class'] = $this->element['class'] ? 'combobox ' . $this->element['class'] : 'combobox';
-		if ((string) $this->element['readonly'] == 'true')
-		{
-			$attr['readonly'] = 'readonly';
-		}
-		if ((string) $this->element['disabled'] == 'true')
-		{
-			$attr['disabled'] = 'disabled';
-		}
+		((string) $this->element['readonly'] == 'true') ? $attr['readonly'] = 'readonly' : null;
+		((string) $this->element['disabled'] == 'true') ? $attr['disabled'] = 'disabled' : null;
 
 		// Initialize JavaScript field attributes.
-		if ($this->element['onchange'])
-		{
-			$attr['onchange'] = (string) $this->element['onchange'];
-		}
+		($this->element['onchange']) ? $attr['onchange'] = (string) $this->element['onchange'] : null;
 
 		// Get the field options.
 		$options = $this->getOptions();

--- a/libraries/joomla/form/fields/combo.php
+++ b/libraries/joomla/form/fields/combo.php
@@ -40,16 +40,24 @@ class JFormFieldCombo extends JFormFieldList
 	{
 		// Initialize variables.
 		$html = array();
-		$attr = '';
+		$attr = array();
 
 		// Initialize some field attributes.
-		$attr .= $this->element['class'] ? ' class="combobox ' . (string) $this->element['class'] . '"' : ' class="combobox"';
-		$attr .= ((string) $this->element['readonly'] == 'true') ? ' readonly="readonly"' : '';
-		$attr .= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
-		$attr .= $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
+		$attr['class'] = $this->element['class'] ? 'combobox ' . $this->element['class'] : 'combobox';
+		if ((string) $this->element['readonly'] == 'true')
+		{
+			$attr['readonly'] = 'readonly';
+		}
+		if ((string) $this->element['disabled'] == 'true')
+		{
+			$attr['disabled'] = 'disabled';
+		}
 
 		// Initialize JavaScript field attributes.
-		$attr .= $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
+		if ($this->element['onchange'])
+		{
+			$attr['onchange'] = (string) $this->element['onchange'];
+		}
 
 		// Get the field options.
 		$options = $this->getOptions();
@@ -57,17 +65,8 @@ class JFormFieldCombo extends JFormFieldList
 		// Load the combobox behavior.
 		JHtml::_('behavior.combobox');
 
-		// Build the input for the combo box.
-		$html[] = '<input type="text" name="' . $this->name . '" id="' . $this->id . '"' . ' value="'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $attr . '/>';
-
-		// Build the list for the combo box.
-		$html[] = '<ul id="combobox-' . $this->id . '" style="display:none;">';
-		foreach ($options as $option)
-		{
-			$html[] = '<li>' . $option->text . '</li>';
-		}
-		$html[] = '</ul>';
+		// Generate the list
+		$html[] = JHTML::_('select.genericlist', $options, $this->name, $attr, 'value', 'text', $this->value, $this->id);
 
 		return implode($html);
 	}


### PR DESCRIPTION
JFormFieldCombo::getInput() should return a fully formed 'select' element with a class of 'combobox' as that is what is expected by the combobox javascript functions.

Isn't it a bit odd that this is part of 'platform' but the required javascript is part of 'cms'? 
