### PR TITLE
Fix improper detection of UTF-8 encoding in strcasecmp and strcmp.

### DIFF
--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -349,7 +349,7 @@ abstract class JString
 			{
 				$encoding = 'CP' . $m[1];
 			}
-			elseif (stristr($locale, 'UTF-8'))
+			elseif (stristr($locale, 'UTF-8') || stristr($locale, 'utf8'))
 			{
 				$encoding = 'UTF-8';
 			}
@@ -408,7 +408,7 @@ abstract class JString
 			{
 				$encoding = 'CP' . $m[1];
 			}
-			elseif (stristr($locale, 'UTF-8'))
+			elseif (stristr($locale, 'UTF-8') || stristr($locale, 'utf8'))
 			{
 				$encoding = 'UTF-8';
 			}


### PR DESCRIPTION
The test of whether locale is UTF-8 is incorrect because it is missing the 'utf8' string which is commonly what is in the string returned when locale0 is obtained.  
