### PR TITLE
Missing parentheses in grid sort

### DIFF
--- a/libraries/joomla/html/html/grid.php
+++ b/libraries/joomla/html/html/grid.php
@@ -75,7 +75,7 @@ abstract class JHtmlGrid
 	{
 		$direction = strtolower($direction);
 		$images = array('sort_asc.png', 'sort_desc.png');
-		$index = (int) $direction == 'desc';
+		$index = (int) ($direction == 'desc');
 
 		if ($order != $selected)
 		{


### PR DESCRIPTION
This causes sort columns to not work correctly in CMS manager screens. For example, the desc icon always shows.
