### PR TITLE
Handling in HttpTransport when the requested uri does not exist

### DIFF
--- a/libraries/joomla/http/factory.php
+++ b/libraries/joomla/http/factory.php
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die;
 class JHttpFactory
 {
 	/**
-	 * method to recieve Http instance.
+	 * Method to recieve Http instance.
 	 *
 	 * @param   JRegistry  $options   Client options object.
 	 * @param   mixed      $adapters  Adapter (string) or queue of adapters (array) to use for communication.
@@ -58,7 +58,7 @@ class JHttpFactory
 			settype($default, 'array');
 			$availableAdapters = $default;
 		}
-		// Check if there is available http transport adapters
+		// Check if there is at least one available http transport adapter
 		if (!count($availableAdapters))
 		{
 			return false;

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -79,6 +79,7 @@ class JHttpTransportCurl implements JHttpTransport
 			{
 				$options[CURLOPT_POSTFIELDS] = $data;
 			}
+
 			// Otherwise we need to encode the value first.
 			else
 			{
@@ -150,6 +151,7 @@ class JHttpTransportCurl implements JHttpTransport
 		if (!is_string($content))
 		{
 			$message = curl_error($ch);
+
 			if (empty($message))
 			{
 				// Error but nothing from cURL? Create our own
@@ -210,6 +212,7 @@ class JHttpTransportCurl implements JHttpTransport
 		{
 			$return->code = (int) $code;
 		}
+
 		// No valid response code was detected.
 		else
 		{

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -146,6 +146,19 @@ class JHttpTransportCurl implements JHttpTransport
 		// Execute the request and close the connection.
 		$content = curl_exec($ch);
 
+		// Check if the content is a string. If it is not, it must be an error.
+		if (!is_string($content))
+		{
+			$message = curl_error($ch);
+			if (empty($message))
+			{
+				// Error but nothing from cURL? Create our own
+				$message = 'No HTTP response received';
+			}
+
+			throw new RuntimeException($message);
+		}
+
 		// Get the request information.
 		$info = curl_getinfo($ch);
 
@@ -158,7 +171,8 @@ class JHttpTransportCurl implements JHttpTransport
 	/**
 	 * Method to get a response object from a server response.
 	 *
-	 * @param   string  $content  The complete server response, including headers.
+	 * @param   string  $content  The complete server response, including headers
+	 *                            as a string if the response has no errors. 
 	 * @param   array   $info     The cURL request information.
 	 *
 	 * @return  JHttpResponse
@@ -170,12 +184,6 @@ class JHttpTransportCurl implements JHttpTransport
 	{
 		// Create the response object.
 		$return = new JHttpResponse;
-
-		// Check if the content is actually a string.
-		if (!is_string($content))
-		{
-			throw new UnexpectedValueException('No HTTP response received.');
-		}
 
 		// Get the number of redirects that occurred.
 		$redirects = isset($info['redirect_count']) ? $info['redirect_count'] : 0;

--- a/libraries/joomla/http/transport/socket.php
+++ b/libraries/joomla/http/transport/socket.php
@@ -159,6 +159,10 @@ class JHttpTransportSocket implements JHttpTransport
 	{
 		// Create the response object.
 		$return = new JHttpResponse;
+		if (empty($content))
+		{
+			throw new UnexpectedValueException('No content in response.');
+		}
 
 		// Split the response into headers and body.
 		$response = explode("\r\n\r\n", $content, 2);
@@ -167,7 +171,7 @@ class JHttpTransportSocket implements JHttpTransport
 		$headers = explode("\r\n", $response[0]);
 
 		// Set the body for the response.
-		$return->body = $response[1];
+		$return->body = empty($response[1]) ? '' : $response[1];
 
 		// Get the response code from the first offset of the response headers.
 		preg_match('/[0-9]{3}/', array_shift($headers), $matches);
@@ -177,6 +181,7 @@ class JHttpTransportSocket implements JHttpTransport
 		{
 			$return->code = (int) $code;
 		}
+
 		// No valid response code was detected.
 		else
 		{
@@ -217,6 +222,7 @@ class JHttpTransportSocket implements JHttpTransport
 		{
 			$port = ($uri->getScheme() == 'https') ? 443 : 80;
 		}
+
 		// Use the set port.
 		else
 		{
@@ -248,15 +254,32 @@ class JHttpTransportSocket implements JHttpTransport
 
 		if (!is_numeric($timeout))
 		{
-			$timeout = ini_get("default_socket_timeout");
+			$timeout = ini_get('default_socket_timeout');
 		}
-		// Attempt to connect to the server.
-		$connection = fsockopen($host, $port, $errno, $err, $timeout);
+
+		// Capture PHP errors
+		$php_errormsg = '';
+		$track_errors = ini_get('track_errors');
+		ini_set('track_errors', true);
+
+		// PHP sends a warning if the uri does not exists; we silence it and throw an exception instead.
+		// Attempt to connect to the server
+		$connection = @fsockopen($host, $port, $errno, $err, $timeout);
 
 		if (!$connection)
 		{
-			throw new RuntimeException($err, $errno);
+			if (!$php_errormsg)
+			{
+				// Error but nothing from php? Create our own
+				$php_errormsg = sprintf('Could not connect to resource: %s', $uri, $err, $errno);
+			}
+			// Restore error tracking to give control to the exception handler
+			ini_set('track_errors', $track_errors);
+
+			throw new RuntimeException($php_errormsg);
 		}
+		// Restore error tracking to what it was before.
+		ini_set('track_errors', $track_errors);
 
 		// Since the connection was successful let's store it in case we need to use it later.
 		$this->connections[$key] = $connection;
@@ -271,9 +294,9 @@ class JHttpTransportSocket implements JHttpTransport
 	}
 
 	/**
-	 * method to check if http transport socket available for using
+	 * Method to check if http transport socket available for use
 	 *
-	 * @return bool true if available else false
+	 * @return  boolean   True if available else false
 	 *
 	 * @since   12.1
 	 */

--- a/libraries/joomla/http/transport/socket.php
+++ b/libraries/joomla/http/transport/socket.php
@@ -159,6 +159,7 @@ class JHttpTransportSocket implements JHttpTransport
 	{
 		// Create the response object.
 		$return = new JHttpResponse;
+
 		if (empty($content))
 		{
 			throw new UnexpectedValueException('No content in response.');
@@ -245,6 +246,7 @@ class JHttpTransportSocket implements JHttpTransport
 					throw new RuntimeException('Cannot close connection');
 				}
 			}
+
 			// Make sure the connection has not timed out.
 			elseif (!$meta['timed_out'])
 			{
@@ -273,6 +275,7 @@ class JHttpTransportSocket implements JHttpTransport
 				// Error but nothing from php? Create our own
 				$php_errormsg = sprintf('Could not connect to resource: %s', $uri, $err, $errno);
 			}
+
 			// Restore error tracking to give control to the exception handler
 			ini_set('track_errors', $track_errors);
 

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -146,6 +146,7 @@ class JHttpTransportStream implements JHttpTransport
 
 			throw new RuntimeException($php_errormsg);
 		}
+
 		// Restore error tracking to what it was before.
 		ini_set('track_errors', $track_errors);
 
@@ -188,6 +189,7 @@ class JHttpTransportStream implements JHttpTransport
 		{
 			$return->code = (int) $code;
 		}
+
 		// No valid response code was detected.
 		else
 		{

--- a/tests/suites/unit/joomla/http/JHttpTransportTest.php
+++ b/tests/suites/unit/joomla/http/JHttpTransportTest.php
@@ -100,6 +100,29 @@ class JHttpTransportTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Tests the request method with a get request with a bad domain
+	 *
+	 * @dataProvider      transportProvider
+	 * @expectedException RuntimeException
+	 */
+	public function testBadDomainRequestGet($transportClass)
+	{
+		$transport = new $transportClass($this->options);
+		$response = $transport->request('get', new JUri('http://xommunity.joomla.org'));
+	}
+
+	/**
+	 * Tests the request method with a get request for non existant url
+	 *
+	 * @dataProvider  transportProvider
+	 */
+	public function testRequestGet404($transportClass)
+	{
+		$transport = new $transportClass($this->options);
+		$response = $transport->request('get', new JUri($this->stubUrl . ':80'));
+	}
+
+	/**
 	 * Tests the request method with a put request
 	 *
 	 * @param   string  $transportClass  @todo


### PR DESCRIPTION
The transports are currently not handling it well when the domain for a requested uri completely does not exist. At this point they are somewhat inconsistent in what they do (e.g. stream silences the message and then throws an exception similarly to what I propose here for socket). Rather than use a generic exception message this uses php and curl errors to give more detailed information about what went wrong. 
