### PR TITLE
Specify additional options for cURL transfers.

### DIFF
--- a/libraries/joomla/http/http.php
+++ b/libraries/joomla/http/http.php
@@ -111,15 +111,16 @@ class JHttp
 	/**
 	 * Method to send the HEAD command to the server.
 	 *
-	 * @param   string   $url      Path to the resource.
-	 * @param   array    $headers  An array of name-value pairs to include in the header of the request.
-	 * @param   integer  $timeout  Read timeout in seconds.
+	 * @param   string   $url          Path to the resource.
+	 * @param   array    $headers      An array of name-value pairs to include in the header of the request.
+	 * @param   integer  $timeout      Read timeout in seconds.
+	 * @param   array    $curlOptions  An array used to specify additional options for a cURL transfer.
 	 *
 	 * @return  JHttpResponse
 	 *
 	 * @since   11.3
 	 */
-	public function head($url, array $headers = null, $timeout = null)
+	public function head($url, array $headers = null, $timeout = null, $curlOptions = array())
 	{
 		// Look for headers set in the options.
 		$temp = (array) $this->options->get('headers');
@@ -137,21 +138,22 @@ class JHttp
 			$timeout = $this->options->get('timeout');
 		}
 
-		return $this->transport->request('HEAD', new JUri($url), null, $headers, $timeout, $this->options->get('userAgent', null));
+		return $this->transport->request('HEAD', new JUri($url), null, $headers, $timeout, $this->options->get('userAgent', null), $curlOptions);
 	}
 
 	/**
 	 * Method to send the GET command to the server.
 	 *
-	 * @param   string   $url      Path to the resource.
-	 * @param   array    $headers  An array of name-value pairs to include in the header of the request.
-	 * @param   integer  $timeout  Read timeout in seconds.
+	 * @param   string   $url          Path to the resource.
+	 * @param   array    $headers      An array of name-value pairs to include in the header of the request.
+	 * @param   integer  $timeout      Read timeout in seconds.
+	 * @param   array    $curlOptions  An array used to specify additional options for a cURL transfer.
 	 *
 	 * @return  JHttpResponse
 	 *
 	 * @since   11.3
 	 */
-	public function get($url, array $headers = null, $timeout = null)
+	public function get($url, array $headers = null, $timeout = null, $curlOptions = array())
 	{
 		// Look for headers set in the options.
 		$temp = (array) $this->options->get('headers');
@@ -169,22 +171,23 @@ class JHttp
 			$timeout = $this->options->get('timeout');
 		}
 
-		return $this->transport->request('GET', new JUri($url), null, $headers, $timeout, $this->options->get('userAgent', null));
+		return $this->transport->request('GET', new JUri($url), null, $headers, $timeout, $this->options->get('userAgent', null), $curlOptions);
 	}
 
 	/**
 	 * Method to send the POST command to the server.
 	 *
-	 * @param   string   $url      Path to the resource.
-	 * @param   mixed    $data     Either an associative array or a string to be sent with the request.
-	 * @param   array    $headers  An array of name-value pairs to include in the header of the request
-	 * @param   integer  $timeout  Read timeout in seconds.
+	 * @param   string   $url          Path to the resource.
+	 * @param   mixed    $data         Either an associative array or a string to be sent with the request.
+	 * @param   array    $headers      An array of name-value pairs to include in the header of the request
+	 * @param   integer  $timeout      Read timeout in seconds.
+	 * @param   array    $curlOptions  An array used to specify additional options for a cURL transfer.
 	 *
 	 * @return  JHttpResponse
 	 *
 	 * @since   11.3
 	 */
-	public function post($url, $data, array $headers = null, $timeout = null)
+	public function post($url, $data, array $headers = null, $timeout = null, $curlOptions = array())
 	{
 		// Look for headers set in the options.
 		$temp = (array) $this->options->get('headers');
@@ -202,22 +205,23 @@ class JHttp
 			$timeout = $this->options->get('timeout');
 		}
 
-		return $this->transport->request('POST', new JUri($url), $data, $headers, $timeout, $this->options->get('userAgent', null));
+		return $this->transport->request('POST', new JUri($url), $data, $headers, $timeout, $this->options->get('userAgent', null), $curlOptions);
 	}
 
 	/**
 	 * Method to send the PUT command to the server.
 	 *
-	 * @param   string   $url      Path to the resource.
-	 * @param   mixed    $data     Either an associative array or a string to be sent with the request.
-	 * @param   array    $headers  An array of name-value pairs to include in the header of the request.
-	 * @param   integer  $timeout  Read timeout in seconds.
+	 * @param   string   $url          Path to the resource.
+	 * @param   mixed    $data         Either an associative array or a string to be sent with the request.
+	 * @param   array    $headers      An array of name-value pairs to include in the header of the request.
+	 * @param   integer  $timeout      Read timeout in seconds.
+	 * @param   array    $curlOptions  An array used to specify additional options for a cURL transfer.
 	 *
 	 * @return  JHttpResponse
 	 *
 	 * @since   11.3
 	 */
-	public function put($url, $data, array $headers = null, $timeout = null)
+	public function put($url, $data, array $headers = null, $timeout = null, $curlOptions = array())
 	{
 		// Look for headers set in the options.
 		$temp = (array) $this->options->get('headers');
@@ -235,21 +239,22 @@ class JHttp
 			$timeout = $this->options->get('timeout');
 		}
 
-		return $this->transport->request('PUT', new JUri($url), $data, $headers, $timeout, $this->options->get('userAgent', null));
+		return $this->transport->request('PUT', new JUri($url), $data, $headers, $timeout, $this->options->get('userAgent', null), $curlOptions);
 	}
 
 	/**
 	 * Method to send the DELETE command to the server.
 	 *
-	 * @param   string   $url      Path to the resource.
-	 * @param   array    $headers  An array of name-value pairs to include in the header of the request.
-	 * @param   integer  $timeout  Read timeout in seconds.
+	 * @param   string   $url          Path to the resource.
+	 * @param   array    $headers      An array of name-value pairs to include in the header of the request.
+	 * @param   integer  $timeout      Read timeout in seconds.
+	 * @param   array    $curlOptions  An array used to specify additional options for a cURL transfer.
 	 *
 	 * @return  JHttpResponse
 	 *
 	 * @since   11.3
 	 */
-	public function delete($url, array $headers = null, $timeout = null)
+	public function delete($url, array $headers = null, $timeout = null, $curlOptions = array())
 	{
 		// Look for headers set in the options.
 		$temp = (array) $this->options->get('headers');
@@ -267,21 +272,22 @@ class JHttp
 			$timeout = $this->options->get('timeout');
 		}
 
-		return $this->transport->request('DELETE', new JUri($url), null, $headers, $timeout, $this->options->get('userAgent', null));
+		return $this->transport->request('DELETE', new JUri($url), null, $headers, $timeout, $this->options->get('userAgent', null), $curlOptions);
 	}
 
 	/**
 	 * Method to send the TRACE command to the server.
 	 *
-	 * @param   string   $url      Path to the resource.
-	 * @param   array    $headers  An array of name-value pairs to include in the header of the request.
-	 * @param   integer  $timeout  Read timeout in seconds.
+	 * @param   string   $url          Path to the resource.
+	 * @param   array    $headers      An array of name-value pairs to include in the header of the request.
+	 * @param   integer  $timeout      Read timeout in seconds.
+	 * @param   array    $curlOptions  An array used to specify additional options for a cURL transfer.
 	 *
 	 * @return  JHttpResponse
 	 *
 	 * @since   11.3
 	 */
-	public function trace($url, array $headers = null, $timeout = null)
+	public function trace($url, array $headers = null, $timeout = null, $curlOptions = array())
 	{
 		// Look for headers set in the options.
 		$temp = (array) $this->options->get('headers');
@@ -299,7 +305,7 @@ class JHttp
 			$timeout = $this->options->get('timeout');
 		}
 
-		return $this->transport->request('TRACE', new JUri($url), null, $headers, $timeout, $this->options->get('userAgent', null));
+		return $this->transport->request('TRACE', new JUri($url), null, $headers, $timeout, $this->options->get('userAgent', null), $curlOptions);
 	}
 
 }

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -45,18 +45,19 @@ class JHttpTransportCurl implements JHttpTransport
 	/**
 	 * Send a request to the server and return a JHttpResponse object with the response.
 	 *
-	 * @param   string   $method     The HTTP method for sending the request.
-	 * @param   JUri     $uri        The URI to the resource to request.
-	 * @param   mixed    $data       Either an associative array or a string to be sent with the request.
-	 * @param   array    $headers    An array of request headers to send with the request.
-	 * @param   integer  $timeout    Read timeout in seconds.
-	 * @param   string   $userAgent  The optional user agent string to send with the request.
+	 * @param   string   $method       The HTTP method for sending the request.
+	 * @param   JUri     $uri          The URI to the resource to request.
+	 * @param   mixed    $data         Either an associative array or a string to be sent with the request.
+	 * @param   array    $headers      An array of request headers to send with the request.
+	 * @param   integer  $timeout      Read timeout in seconds.
+	 * @param   string   $userAgent    The optional user agent string to send with the request.
+	 * @param   array    $curlOptions  An array used to specify additional options for a cURL transfer.
 	 *
 	 * @return  JHttpResponse
 	 *
 	 * @since   11.3
 	 */
-	public function request($method, JUri $uri, $data = null, array $headers = null, $timeout = null, $userAgent = null)
+	public function request($method, JUri $uri, $data = null, array $headers = null, $timeout = null, $userAgent = null, $curlOptions = array())
 	{
 		// Setup the cURL handle.
 		$ch = curl_init();
@@ -135,8 +136,11 @@ class JHttpTransportCurl implements JHttpTransport
 		// Link: http://the-stickman.com/web-development/php-and-curl-disabling-100-continue-header/
 		$options[CURLOPT_HTTPHEADER][] = 'Expect:';
 
-		// Follow redirects.
-		$options[CURLOPT_FOLLOWLOCATION] = true;
+		// Add additional options to the curl transfer.
+		foreach ($curlOptions as $key => $value)
+		{
+			$options[$key] = $value;
+		}
 
 		// Set the cURL options.
 		curl_setopt_array($ch, $options);


### PR DESCRIPTION
I have added a new parameter to the request method through which to specify additional options for the cURL transfer.

Currently the HTTP client will automatically follow redirects. I have removed this because (see RFC [0]):
- it is not always necessary to follow redirects
- following redirects automatically may lead to an infinite loop
- HTTP redirection codes may need to be handled differently

[0] http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html - 10.3 Redirection 3xx
