### PR TITLE
JhtmlBehavior - improve  _getJSObject

### DIFF
--- a/libraries/joomla/html/html/behavior.php
+++ b/libraries/joomla/html/html/behavior.php
@@ -808,7 +808,7 @@ abstract class JHtmlBehavior
 
 	/**
 	 * Internal method to get a JavaScript object notation string from an array
-	 * 
+	 *
 	 * This function differs from json_encode() in two important ways:
 	 *	1) If the array contains a key 'fullScreen', the resulting object will have a property 'size' which will be an object with properties 'x' and 'y'
 	 *	2) Any elements in the array beginning with '\' will not be encoded, '\' will be stripped and they will be inserted as-is


### PR DESCRIPTION
This function has several flaws which I think I've solved. I think that with a little more work I can eliminate it entirely as json_encode() should be used whenever possible. 
