### PR TITLE
JLoader : files located at the root path, where the prefix is registered...

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -321,7 +321,7 @@ abstract class JLoader
 		$fileName = false;
 
 		// If there is only one part.
-		if (count($parts == 1))
+		if (count($parts) == 1)
 		{
 			// Keep the possible file name.
 			$fileName = $parts[0];

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -318,8 +318,17 @@ abstract class JLoader
 		// Split the class name into parts separated by camelCase.
 		$parts = preg_split('/(?<=[a-z0-9])(?=[A-Z])/x', $class);
 
-		// If there is only one part we want to duplicate that part for generating the path.
-		$parts = (count($parts) === 1) ? array($parts[0], $parts[0]) : $parts;
+		$className = false;
+
+		// If there is only one part.
+		if (count($parts == 1))
+		{
+			// Keep the possible class name.
+			$className = $parts[0];
+
+			// Try to duplicate that part for generating the path.
+			$parts = array($parts[0], $parts[0]);
+		}
 
 		foreach ($lookup as $base)
 		{
@@ -330,6 +339,19 @@ abstract class JLoader
 			if (file_exists($path))
 			{
 				return include $path;
+			}
+
+			// If there is only one part.
+			if ($className)
+			{
+				// Try to include the class that might be located in the root folder.
+				$path = $base . '/' . strtolower($className) . '.php';
+
+				// Load the file if it exists.
+				if (file_exists($path))
+				{
+					return include $path;
+				}
 			}
 		}
 	}

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -318,15 +318,15 @@ abstract class JLoader
 		// Split the class name into parts separated by camelCase.
 		$parts = preg_split('/(?<=[a-z0-9])(?=[A-Z])/x', $class);
 
-		$className = false;
+		$fileName = false;
 
 		// If there is only one part.
 		if (count($parts == 1))
 		{
-			// Keep the possible class name.
-			$className = $parts[0];
+			// Keep the possible file name.
+			$fileName = $parts[0];
 
-			// Try to duplicate that part for generating the path.
+			// Duplicate that part for generating the path.
 			$parts = array($parts[0], $parts[0]);
 		}
 
@@ -342,10 +342,10 @@ abstract class JLoader
 			}
 
 			// If there is only one part.
-			if ($className)
+			if ($fileName)
 			{
 				// Try to include the class that might be located in the root folder.
-				$path = $base . '/' . strtolower($className) . '.php';
+				$path = $base . '/' . strtolower($fileName) . '.php';
 
 				// Load the file if it exists.
 				if (file_exists($path))


### PR DESCRIPTION
Files located at the root path, where the prefix is registered, cannot be autoloaded.

Ex : Prefix `PN` registered in `/path/to/pn`.
A class `PNVariable` located in `path/to/pn/variable.php` won't be autoloaded, because the auto loader try to find it in `path/to/pn/variable/variable.php`
