### PR TITLE
Fixing warnings triggered by cURL when no response is received.

### DIFF
--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -169,6 +169,12 @@ class JHttpTransportCurl implements JHttpTransport
 		// Create the response object.
 		$return = new JHttpResponse;
 
+		// Check if the content is actually a string.
+		if (!is_string($content))
+		{
+			throw new UnexpectedValueException('No HTTP response received.');
+		}
+
 		// Get the number of redirects that occurred.
 		$redirects = isset($info['redirect_count']) ? $info['redirect_count'] : 0;
 
@@ -187,7 +193,8 @@ class JHttpTransportCurl implements JHttpTransport
 
 		// Get the response code from the first offset of the response headers.
 		preg_match('/[0-9]{3}/', array_shift($headers), $matches);
-		$code = $matches[0];
+
+		$code = count($matches) ? $matches[0] : null;
 		if (is_numeric($code))
 		{
 			$return->code = (int) $code;


### PR DESCRIPTION
This pull request resolves a situation where when no response from a server is received a PHP warning is thrown by the cURL transport. Instead the code triggering the warning is mitigated and additionally a check to see if there was any response data is added to validate a response was actually received or throw an exception.
