### PR TITLE
Add stripIframe method

### DIFF
--- a/libraries/joomla/filter/output.php
+++ b/libraries/joomla/filter/output.php
@@ -223,7 +223,7 @@ class JFilterOutput
 	 *
 	 * @since   11.1
 	 */
-	public static function stripIframe($string)
+	public static function stripIframes($string)
 	{
 		return preg_replace('#(<[/]?iframe.*>)#U', '', $string);
 	}

--- a/libraries/joomla/filter/output.php
+++ b/libraries/joomla/filter/output.php
@@ -213,4 +213,18 @@ class JFilterOutput
 	{
 		return preg_replace('#(<[/]?img.*>)#U', '', $string);
 	}
+
+	/**
+	 * Strip iframe-tags from string
+	 *
+	 * @param   string  $string  Sting to be cleaned.
+	 *
+	 * @return  string  Cleaned string
+	 *
+	 * @since   11.1
+	 */
+	public static function stripIframe($string)
+	{
+		return preg_replace('#(<[/]?iframe.*>)#U', '', $string);
+	}
 }

--- a/libraries/joomla/filter/output.php
+++ b/libraries/joomla/filter/output.php
@@ -221,7 +221,7 @@ class JFilterOutput
 	 *
 	 * @return  string  Cleaned string
 	 *
-	 * @since   11.1
+	 * @since   12.2
 	 */
 	public static function stripIframes($string)
 	{

--- a/tests/suites/unit/joomla/filter/JFilterOutputTest.php
+++ b/tests/suites/unit/joomla/filter/JFilterOutputTest.php
@@ -222,7 +222,7 @@ class JFilterOutputTest extends PHPUnit_Framework_TestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   11.3
+	 * @since   12.2
 	 */
 	public function testStripIframes()
 	{

--- a/tests/suites/unit/joomla/filter/JFilterOutputTest.php
+++ b/tests/suites/unit/joomla/filter/JFilterOutputTest.php
@@ -216,5 +216,21 @@ class JFilterOutputTest extends PHPUnit_Framework_TestCase
 			'Should remove img tags'
 		);
 	}
+
+	/**
+	 * Tests stripping iFrames.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testStripIframes()
+	{
+		$this->assertEquals(
+			'Hello  I am waving at you.',
+			$this->object->stripIframes('Hello <iframe src="http://player.vimeo.com/video/37576499" width="500" height="281" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe> I am waving at you.'),
+			'Should remove iFrame tags'
+		);
+	}
 }
 ?>


### PR DESCRIPTION
In doing some work with feeds I noticed that we have stripImage available, but we don't have a way to strip iFrames which pose similar or more serious issues than images. A separate method makes sense because sometimes it is very reasonable to take the images from a feed but not to want the risks associated with iFrames.
