### PR TITLE
Add missing return in the "extract()"

### DIFF
--- a/libraries/joomla/archive/zip.php
+++ b/libraries/joomla/archive/zip.php
@@ -139,11 +139,11 @@ class JArchiveZip implements JArchiveExtractable
 
 		if ($this->hasNativeSupport())
 		{
-			$this->_extractNative($archive, $destination, $options);
+			return $this->_extractNative($archive, $destination, $options);
 		}
 		else
 		{
-			$this->_extract($archive, $destination, $options);
+			return $this->_extract($archive, $destination, $options);
 		}
 	}
 


### PR DESCRIPTION
This apply the fix reported in the issue
https://github.com/joomla/joomla-platform/issues/1437#issuecomment-7539014
