### PR TITLE
Fix issue with Oracle timestamp

### DIFF
--- a/libraries/joomla/database/driver/oracle.php
+++ b/libraries/joomla/database/driver/oracle.php
@@ -422,6 +422,11 @@ class JDatabaseDriverOracle extends JDatabaseDriverPdo
 		$this->connect();
 
 		$this->setQuery("ALTER SESSION SET NLS_DATE_FORMAT = '$dateFormat'");
+		if (!$this->execute())
+		{
+			return false;
+		}
+
 		$this->setQuery("ALTER SESSION SET NLS_TIMESTAMP_FORMAT = '$dateFormat'");
 
 		if (!$this->execute())


### PR DESCRIPTION
This pull request fixes up an issue with the Oracle NLS_DATE_FORMAT not being set properly after the change to add the NLS_TIMESTAMP_FORMAT to the set. The code should have duplicated the `execute()` clause however this was not done so this meant that the NLS_TIMESTAMP_FORMAT was updated triggering timestamp fields to follow with the right format however the NLS_DATE_FORMAT wasn't set properly triggering the existing date fields to utilise the wrong format.
