### PR TITLE
Prevent unit tests from fatally failing if database is not available.

### DIFF
--- a/tests/core/case/database.php
+++ b/tests/core/case/database.php
@@ -313,7 +313,14 @@ abstract class TestCaseDatabase extends PHPUnit_Extensions_Database_TestCase
 	 */
 	protected function getConnection()
 	{
-		return $this->createDefaultDBConnection(self::$driver->getConnection(), ':memory:');
+		if (self::$driver)
+		{
+			return $this->createDefaultDBConnection(self::$driver->getConnection(), ':memory:');
+		}
+		else
+		{
+			return null;
+		}
 	}
 
 	/**

--- a/tests/core/case/database.php
+++ b/tests/core/case/database.php
@@ -313,7 +313,7 @@ abstract class TestCaseDatabase extends PHPUnit_Extensions_Database_TestCase
 	 */
 	protected function getConnection()
 	{
-		if (self::$driver)
+		if (!is_null(self::$driver))
 		{
 			return $this->createDefaultDBConnection(self::$driver->getConnection(), ':memory:');
 		}

--- a/tests/suites/unit/joomla/form/fields/JFormFieldAccessLevelTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldAccessLevelTest.php
@@ -66,10 +66,17 @@ class JFormFieldAccessLevelTest extends TestCaseDatabase
 			'Line:'.__LINE__.' The setup method should return true.'
 		);
 
-		$this->assertThat(
-			strlen($field->input),
-			$this->greaterThan(0),
-			'Line:'.__LINE__.' The getInput method should return something without error.'
-		);
+		if (self::$driver)
+		{
+			$this->assertThat(
+				strlen($field->input),
+				$this->greaterThan(0),
+				'Line:'.__LINE__.' The getInput method should return something without error.'
+			);
+		}
+		else
+		{
+			$this->markTestSkipped();
+		}
 	}
 }

--- a/tests/suites/unit/joomla/form/fields/JFormFieldAccessLevelTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldAccessLevelTest.php
@@ -66,7 +66,7 @@ class JFormFieldAccessLevelTest extends TestCaseDatabase
 			'Line:'.__LINE__.' The setup method should return true.'
 		);
 
-		if (self::$driver)
+		if (!is_null(self::$driver))
 		{
 			$this->assertThat(
 				strlen($field->input),

--- a/tests/suites/unit/joomla/form/fields/JFormFieldPluginsTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldPluginsTest.php
@@ -66,7 +66,7 @@ class JFormFieldPluginsTest extends TestCaseDatabase
 			'Line:'.__LINE__.' The setup method should return true.'
 		);
 
-		if (self::$driver)
+		if (!is_null(self::$driver))
 		{
 			$this->assertThat(
 				strlen($field->input),

--- a/tests/suites/unit/joomla/form/fields/JFormFieldPluginsTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldPluginsTest.php
@@ -66,11 +66,18 @@ class JFormFieldPluginsTest extends TestCaseDatabase
 			'Line:'.__LINE__.' The setup method should return true.'
 		);
 
-		$this->assertThat(
-			strlen($field->input),
-			$this->greaterThan(0),
-			'Line:'.__LINE__.' The getInput method should return something without error.'
-		);
+		if (self::$driver)
+		{
+			$this->assertThat(
+				strlen($field->input),
+				$this->greaterThan(0),
+				'Line:'.__LINE__.' The getInput method should return something without error.'
+			);
+		}
+		else
+		{
+			$this->markTestSkipped();
+		}
 
 		// TODO: Should check all the attributes have come in properly.
 	}

--- a/tests/suites/unit/joomla/form/fields/JFormFieldSQLTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldSQLTest.php
@@ -66,10 +66,17 @@ class JFormFieldSQLTest extends TestCaseDatabase
 		'Line:'.__LINE__.' The setup method should return true.'
 		);
 
-		$this->assertThat(
-			strlen($field->input),
-			$this->greaterThan(0),
-		'Line:'.__LINE__.' The getInput method should return something without error.'
-		);
+		if (self::$driver)
+		{
+			$this->assertThat(
+				strlen($field->input),
+				$this->greaterThan(0),
+				'Line:'.__LINE__.' The getInput method should return something without error.'
+			);
+		}
+		else
+		{
+			$this->markTestSkipped();
+		}
 	}
 }

--- a/tests/suites/unit/joomla/form/fields/JFormFieldSQLTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldSQLTest.php
@@ -66,7 +66,7 @@ class JFormFieldSQLTest extends TestCaseDatabase
 		'Line:'.__LINE__.' The setup method should return true.'
 		);
 
-		if (self::$driver)
+		if (!is_null(self::$driver))
 		{
 			$this->assertThat(
 				strlen($field->input),

--- a/tests/suites/unit/joomla/form/fields/JFormFieldUsergroupTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldUsergroupTest.php
@@ -66,11 +66,18 @@ class JFormFieldUsergroupTest extends TestCaseDatabase
 			'Line:'.__LINE__.' The setup method should return true.'
 		);
 
-		$this->assertThat(
-			strlen($field->input),
-			$this->greaterThan(0),
-			'Line:'.__LINE__.' The getInput method should return something without error.'
-		);
+		if (self::$driver)
+		{
+			$this->assertThat(
+				strlen($field->input),
+				$this->greaterThan(0),
+				'Line:'.__LINE__.' The getInput method should return something without error.'
+			);
+		}
+		else
+		{
+			$this->markTestSkipped();
+		}
 
 		// TODO: Should check all the attributes have come in properly.
 	}

--- a/tests/suites/unit/joomla/form/fields/JFormFieldUsergroupTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldUsergroupTest.php
@@ -66,7 +66,7 @@ class JFormFieldUsergroupTest extends TestCaseDatabase
 			'Line:'.__LINE__.' The setup method should return true.'
 		);
 
-		if (self::$driver)
+		if (!is_null(self::$driver))
 		{
 			$this->assertThat(
 				strlen($field->input),


### PR DESCRIPTION
Without these changes, all unit test crash when phpunit attempts to call a method on a null object.
