### PR TITLE
Fix bug in JString::parse_url that causes urlencoded strings to be decoded

### DIFF
--- a/libraries/joomla/form/rules/url.php
+++ b/libraries/joomla/form/rules/url.php
@@ -62,7 +62,7 @@ class JFormRuleUrl extends JFormRule
 		 * accurately without a scheme.
 		 * @see http://php.net/manual/en/function.parse-url.php
 		 */
-		if (!array_key_exists('scheme', $urlParts))
+		if ($urlParts && !array_key_exists('scheme', $urlParts))
 		{
 			return false;
 		}

--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -961,12 +961,11 @@ abstract class JString
 	 */
 	public static function parse_url($url)
 	{
-		$result = array();
+		$result = false;
 
 		// Build arrays of values we need to decode before parsing
-		$entities = array('%21', '%2A', '%27', '%28', '%29', '%3B', '%3A', '%40', '%26', '%3D', '%24', '%2C', '%2F', '%3F', '%25', '%23', '%5B',
-			'%5D');
-		$replacements = array('!', '*', "'", "(", ")", ";", ":", "@", "&", "=", "$", ",", "/", "?", "%", "#", "[", "]");
+		$entities = array('%21', '%2A', '%27', '%28', '%29', '%3B', '%3A', '%40', '%26', '%3D', '%24', '%2C', '%2F', '%3F', '%23', '%5B', '%5D');
+		$replacements = array('!', '*', "'", "(", ")", ";", ":", "@", "&", "=", "$", ",", "/", "?", "#", "[", "]");
 
 		// Create encoded URL with special URL characters decoded so it can be parsed
 		// All other characters will be encoded
@@ -980,7 +979,7 @@ abstract class JString
 		{
 			foreach ($encodedParts as $key => $value)
 			{
-				$result[$key] = urldecode($value);
+				$result[$key] = urldecode(str_replace($replacements, $entities, $value));
 			}
 		}
 		return $result;

--- a/tests/suites/unit/joomla/string/JStringTest.php
+++ b/tests/suites/unit/joomla/string/JStringTest.php
@@ -597,6 +597,13 @@ class JStringTest extends PHPUnit_Framework_TestCase
 		$actual = JString::parse_url($url);
 		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
 
+		// Test all parts of query
+		$url = 'https://john:doe@www.google.com:80/folder/page.html#id?var=kay&var2=key&true';
+		$expected = parse_url($url);
+		$actual = JString::parse_url($url);
+		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
+
+		// Test special characters in URL
 		$url = 'http://joomla.org/mytestpath/È';
 		$expected = parse_url($url);
 		// Fix up path for UTF-8 characters
@@ -605,14 +612,28 @@ class JStringTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
 
 		// Test special characters in URL
-		$url = 'http://mydomain.com/!*\'();:@&=+$,/?%#[]';
+		$url = 'http://mydomain.com/!*\'();:@&=+$,/?%#[]" \\';
 		$expected = parse_url($url);
+		$actual = JString::parse_url($url);
+		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
+
+		// Test url encoding in URL
+		$url = 'http://mydomain.com/%21%2A%27%28%29%3B%3A%40%26%3D%24%2C%2F%3F%25%23%5B%22%20%5C';
+		$expected = parse_url($url);
+		$actual = JString::parse_url($url);
+		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
+
+		// Test a mix of the above
+		$url = 'http://john:doe@mydomain.com:80/%È21%25È3*%(';
+		$expected = parse_url($url);
+		// Fix up path for UTF-8 characters
+		$expected['path'] = '/%È21%25È3*%(';
 		$actual = JString::parse_url($url);
 		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
 
 		// Test invalild URL
 		$url = 'http:///mydomain.com';
-		$expected = array ();
+		$expected = parse_url($url);
 		$actual = JString::parse_url($url);
 		$this->assertEquals($expected, $actual, 'Line: ' . __LINE__ . ' Results should be equal');
 	}


### PR DESCRIPTION
Switch JString::parse_url to return false on failure as specified in it's doc block.
JString::parse_url is now identical to parse_url for ascii strings.
