### PR TITLE
Remove the weird exception handling from string.php.

### DIFF
--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -726,8 +726,14 @@ abstract class JString
 	{
 		if (is_string($source))
 		{
-			$iconv = @iconv($from_encoding, $to_encoding . '//TRANSLIT,IGNORE', $source);
-			return $iconv;
+			switch (ICONV_IMPL)
+			{
+				case 'glibc':
+				return @iconv($from_encoding, $to_encoding . '//TRANSLIT,IGNORE', $source);
+				case 'libiconv':
+				default:
+				return iconv($from_encoding, $to_encoding . '//IGNORE//TRANSLIT', $source);
+			}
 		}
 
 		return null;

--- a/libraries/joomla/string/string.php
+++ b/libraries/joomla/string/string.php
@@ -710,23 +710,6 @@ abstract class JString
 	}
 
 	/**
-	 * Catch an error and throw an exception.
-	 *
-	 * @param   integer  $number   Error level
-	 * @param   string   $message  Error message
-	 *
-	 * @return  void
-	 *
-	 * @link    https://bugs.php.net/bug.php?id=48147
-	 *
-	 * @throw   ErrorException
-	 */
-	private static function _iconvErrorHandler($number, $message)
-	{
-		throw new ErrorException($message, 0, $number);
-	}
-
-	/**
 	 * Transcode a string.
 	 *
 	 * @param   string  $source         The string to transcode.
@@ -743,25 +726,7 @@ abstract class JString
 	{
 		if (is_string($source))
 		{
-			set_error_handler(array(__CLASS__, '_iconvErrorHandler'), E_NOTICE);
-			try
-			{
-				/*
-				 * "//TRANSLIT//IGNORE" is appended to the $to_encoding to ensure that when iconv comes
-				 * across a character that cannot be represented in the target charset, it can
-				 * be approximated through one or several similarly looking characters or ignored.
-				 */
-				$iconv = iconv($from_encoding, $to_encoding . '//TRANSLIT//IGNORE', $source);
-			}
-			catch (ErrorException $e)
-			{
-				/*
-				 * "//IGNORE" is appended to the $to_encoding to ensure that when iconv comes
-				 * across a character that cannot be represented in the target charset, it is ignored.
-				 */
-				$iconv = iconv($from_encoding, $to_encoding . '//IGNORE', $source);
-			}
-			restore_error_handler();
+			$iconv = @iconv($from_encoding, $to_encoding . '//TRANSLIT,IGNORE', $source);
 			return $iconv;
 		}
 


### PR DESCRIPTION
This handling can cause problems in JArrayHelper::sortObjects due to https://bugs.php.net/bug.php?id=50688.

Iconv throws a notice if there is an illegal character regardless of whether ignore is set so this handling is pointless (and in fact broken since it will always fall back to IGNORE not TRANSLIT). Also, //TRANSLIT,IGNORE not //TRANSLIT//IGNORE will properly both transliterate and ignore.

See also: https://github.com/joomla/joomla-cms/issues/179#issuecomment-7835266
