### PR TITLE
Add name.min.ext file format to debug check

### DIFF
--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -334,7 +334,20 @@ abstract class JHtml
 					// Detect debug mode
 					if ($detect_debug && JFactory::getConfig()->get('debug'))
 					{
-						$files[] = $strip . '-uncompressed.' . $ext;
+						/*
+						 * Detect if we received a file in the format name.min.ext
+						 * If so, strip the .min part out, otherwise append -uncompressed
+						 */
+						if (strrpos($strip, '.min', '-4'))
+						{
+							$position = strrpos($strip, '.min', '-4');
+							$filename = str_replace('.min', '.', $strip, $position);
+							$files[]  = $filename . $ext;
+						}
+						else
+						{
+							$files[] = $strip . '-uncompressed.' . $ext;
+						}
 					}
 					$files[] = $strip . '.' . $ext;
 


### PR DESCRIPTION
Improving on JHtml::includeRelativeFiles() debug mode checks, I've added the possibility for files supplied in the format name.min.ext (jQuery files use this format for example) to be loaded in an uncompressed format in debug mode by stripping the .min portion of the filename out instead of appending -uncompressed.

Sample use case: In some code (https://github.com/mbabker/Podcast-Manager/blob/master/plg_content_podcastmanager/player.php#L283), I currently manually check for JDEBUG and change the filename as appropriate.  With this patch, the conditional around JDEBUG is no longer necessary in my code.
