### PR TITLE
Add password hashing interface and basic implementation.

### DIFF
--- a/docs/manual/en-US/Developer_Manual.ent
+++ b/docs/manual/en-US/Developer_Manual.ent
@@ -1,4 +1,4 @@
 <!ENTITY PRODUCT "Joomla Platform">
 <!ENTITY BOOKID "Developer_Manual">
-<!ENTITY YEAR "2011">
+<!ENTITY YEAR "2012">
 <!ENTITY HOLDER "| Open Source Matters |">

--- a/docs/manual/en-US/chapters/classes/jcryptpasswordsimple.xml
+++ b/docs/manual/en-US/chapters/classes/jcryptpasswordsimple.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+<!ENTITY % BOOK_ENTITIES SYSTEM "../../Developer_Manual.ent">
+%BOOK_ENTITIES;
+]>
+<section id="chap-Joomla_Platform_Manual-JCryptPasswordSimple">
+  <title>JCryptPasswordSimple</title>
+
+  <section>
+	  <title>Usage</title>
+
+	  <para>In addition to the interface <interface>JCryptPassword</interface> there is also a basic implementation provided
+		  which provides for use with the most common password schemes. This if found in the <classname>JCryptPasswordSimple</classname>
+		  class.</para>
+
+	  <para>Aside from the two methods <methodname>create</methodname> and <methodname>verify</methodname> methods, this
+		  implementation also adds an additional method called <methodname>setCost</methodname>. This method is used to
+		  set a cost parameter for methods that support workload factors. It takes an integer cost factor as a parameter.</para>
+
+	  <para><classname>JCryptPasswordSimple</classname> provides support for bcrypt, MD5 and the traditional Joomla! CMS hashing
+		  scheme. The hash format can be specified during hash creation by using the constants <constant>JCryptPassword::BLOWFISH</constant>,
+		  <constant>JCryptPassword::MD5</constant> and <constant>JCryptPassword::JOOMLA</constant>. An appropriate salt will be
+		  automatically generated when required.
+	  </para>
+  </section>
+</section>

--- a/docs/manual/en-US/chapters/interfaces/jcryptpassword.xml
+++ b/docs/manual/en-US/chapters/interfaces/jcryptpassword.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+<!ENTITY % BOOK_ENTITIES SYSTEM "../../Developer_Manual.ent">
+%BOOK_ENTITIES;
+]>
+<section>
+  <title>JCryptPassword</title>
+
+  <para><interfacename>JCryptPassword</interfacename> is an interface that requires a class to be implemented with a
+	  <methodname>create</methodname> and a <methodname>verify</methodname> method.</para>
+
+  <para>The <methodname>create</methodname> method should take a plain text password and a type and return a hashed password.</para>
+
+  <para>The <methodname>verify</methodname> method should accept a plain text password and a hashed password and return a boolean
+	  indicating whether or not the password matched the password in the hash.</para>
+
+  <para>The <interfacename>JCryptPassword</interfacename> interface defines the following constants for use with implementations:
+	  <itemizedlist>
+		  <listitem><para><constant>JCryptPassword::BLOWFISH</constant></para></listitem>
+		  <listitem><para><constant>JCryptPassword::JOOMLA</constant></para></listitem>
+		  <listitem><para><constant>JCryptPassword::MD5</constant></para></listitem>
+	  </itemizedlist>
+  </para>
+</section>

--- a/docs/manual/en-US/chapters/packages.xml
+++ b/docs/manual/en-US/chapters/packages.xml
@@ -9,6 +9,8 @@
 
   <para>This is information about the core platform packages.</para>
 
+  <xi:include href="packages/crypt.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
+
   <xi:include href="packages/database.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
 
   <xi:include href="packages/github.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/manual/en-US/chapters/packages/crypt.xml
+++ b/docs/manual/en-US/chapters/packages/crypt.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+<!ENTITY % BOOK_ENTITIES SYSTEM "../../Developer_Manual.ent">
+%BOOK_ENTITIES;
+]>
+<section id="chap-Joomla_Platform_Manual-Crypt">
+  <title>The Crypt Package</title>
+
+  <para>The Crypt password provides a set of classes that can be used for encrypting and hashing data.</para>
+
+  <xi:include href="../interfaces/jcryptpassword.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
+
+  <xi:include href="../classes/jcryptpasswordsimple.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
+</section>

--- a/libraries/joomla/crypt/password.php
+++ b/libraries/joomla/crypt/password.php
@@ -41,8 +41,8 @@ interface JCryptPassword
 	/**
 	 * Verifies a password hash
 	 *
-	 * @param   string   $password  The password to verify.
-	 * @param   string   $hash      The password hash to check.
+	 * @param   string  $password  The password to verify.
+	 * @param   string  $hash      The password hash to check.
 	 *
 	 * @return  boolean  True if the password is valid, false otherwise.
 	 *

--- a/libraries/joomla/crypt/password.php
+++ b/libraries/joomla/crypt/password.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Crypt
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Joomla Platform Password Hashing Interface
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Crypt
+ * @since       12.2
+ */
+interface JCryptPassword
+{
+	const BLOWFISH = '$2y$';
+
+	const JOOMLA = 'Joomla';
+
+	const PBKDF = '$pbkdf$';
+
+	const MD5 = '$1$';
+
+	/**
+	 * Creates a password hash
+	 *
+	 * @param   string  $password  The password to hash.
+	 * @param   string  $prefix    The prefix of the hashing function.
+	 *
+	 * @return  string  The hashed password.
+	 *
+	 * @since   12.2
+	 */
+	public function create($password, $prefix = '$2a$');
+
+	/**
+	 * Verifies a password hash
+	 *
+	 * @param   string   $password  The password to verify.
+	 * @param   string   $hash      The password hash to check.
+	 *
+	 * @return  boolean  True if the password is valid, false otherwise.
+	 *
+	 * @since   12.2
+	 */
+	public function verify($password, $hash);
+}

--- a/libraries/joomla/crypt/password/simple.php
+++ b/libraries/joomla/crypt/password/simple.php
@@ -28,7 +28,7 @@ class JCryptPasswordSimple implements JCryptPassword
 	 * Creates a password hash
 	 *
 	 * @param   string  $password  The password to hash.
-	 * @param   string  $prefix    The prefix of the hashing function.
+	 * @param   string  $type      The hash type.
 	 *
 	 * @return  string  The hashed password.
 	 *
@@ -52,22 +52,19 @@ class JCryptPasswordSimple implements JCryptPassword
 
 				$salt = $prefix . str_pad($this->cost, 2, '0', STR_PAD_LEFT) . '$' . $this->getSalt(22);
 
-				return crypt($password, $salt);
-				break;
+			return crypt($password, $salt);
 
 			case JCryptPassword::MD5:
 				$salt = $this->getSalt(12);
 
 				$salt = '$1$' . $salt;
 
-				return crypt($password, $salt);
-				break;
-	
+			return crypt($password, $salt);
+
 			case JCryptPassword::JOOMLA:
 				$salt = $this->getSalt(32);
 
-				return md5($password . $salt) . ':' . $salt;
-				break;
+			return md5($password . $salt) . ':' . $salt;
 
 			default:
 				throw new InvalidArgumentException(sprintf('Hash type %s is not supported', $type));
@@ -94,7 +91,7 @@ class JCryptPasswordSimple implements JCryptPassword
 	 *
 	 * @param   integer  $length  The number of characters to return.
 	 *
-	 * @return  string   The string of random characters.
+	 * @return  string  The string of random characters.
 	 *
 	 * @since   12.2
 	 */
@@ -110,8 +107,8 @@ class JCryptPasswordSimple implements JCryptPassword
 	/**
 	 * Verifies a password hash
 	 *
-	 * @param   string   $password  The password to verify.
-	 * @param   string   $hash      The password hash to check.
+	 * @param   string  $password  The password to verify.
+	 * @param   string  $hash      The password hash to check.
 	 *
 	 * @return  boolean  True if the password is valid, false otherwise.
 	 *

--- a/libraries/joomla/crypt/password/simple.php
+++ b/libraries/joomla/crypt/password/simple.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Crypt
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Joomla Platform Password Crypter
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Crypt
+ * @since       12.2
+ */
+class JCryptPasswordSimple implements JCryptPassword
+{
+	/**
+	 * @var    integer  The cost parameter for hashing algorithms.
+	 * @since  12.2
+	 */
+	protected $cost = 10;
+
+	/**
+	 * Creates a password hash
+	 *
+	 * @param   string  $password  The password to hash.
+	 * @param   string  $prefix    The prefix of the hashing function.
+	 *
+	 * @return  string  The hashed password.
+	 *
+	 * @since   12.2
+	 */
+	public function create($password, $type = JCryptPassword::BLOWFISH)
+	{
+		switch ($type)
+		{
+			case JCryptPassword::BLOWFISH:
+				$salt = $this->getSalt(22);
+
+				if (version_compare(PHP_VERSION, '5.3.7') >= 0)
+				{
+					$prefix = '$2y$';
+				}
+				else
+				{
+					$prefix = '$2a$';
+				}
+
+				$salt = $prefix . str_pad($this->cost, 2, '0', STR_PAD_LEFT) . '$' . $this->getSalt(22);
+
+				return crypt($password, $salt);
+				break;
+
+			case JCryptPassword::MD5:
+				$salt = $this->getSalt(12);
+
+				$salt = '$1$' . $salt;
+
+				return crypt($password, $salt);
+				break;
+	
+			case JCryptPassword::JOOMLA:
+				$salt = $this->getSalt(32);
+
+				return md5($password . $salt) . ':' . $salt;
+				break;
+
+			default:
+				throw new InvalidArgumentException(sprintf('Hash type %s is not supported', $type));
+				break;
+		}
+	}
+
+	/**
+	 * Sets the cost parameter for the generated hash for algorithms that use a cost factor.
+	 *
+	 * @param   integer  $cost  The new cost value.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.2
+	 */
+	public function setCost($cost)
+	{
+		$this->cost = $cost;
+	}
+
+	/**
+	 * Generates a salt of specified length. The salt consists of characters in the set [./0-9A-Za-z].
+	 *
+	 * @param   integer  $length  The number of characters to return.
+	 *
+	 * @return  string   The string of random characters.
+	 *
+	 * @since   12.2
+	 */
+	protected function getSalt($length)
+	{
+		$bytes = ceil($length * 6 / 8);
+
+		$randomData = str_replace('+', '.', base64_encode(JCrypt::getRandomBytes($bytes)));
+
+		return substr($randomData, 0, $length);
+	}
+
+	/**
+	 * Verifies a password hash
+	 *
+	 * @param   string   $password  The password to verify.
+	 * @param   string   $hash      The password hash to check.
+	 *
+	 * @return  boolean  True if the password is valid, false otherwise.
+	 *
+	 * @since   12.2
+	 */
+	public function verify($password, $hash)
+	{
+		// Check if the hash is a blowfish hash.
+		if (substr($hash, 0, 4) == '$2a$' || substr($hash, 0, 4) == '$2y$')
+		{
+			if (version_compare(PHP_VERSION, '5.3.7') >= 0)
+			{
+				$prefix = '$2y$';
+			}
+			else
+			{
+				$prefix = '$2a$';
+			}
+			$hash = $prefix . substr($hash, 4);
+
+			return (crypt($password, $hash) === $hash);
+		}
+
+		// Check if the hash is an MD5 hash.
+		if (substr($hash, 0, 3) == '$1$')
+		{
+			return (crypt($password, $hash) === $hash);
+		}
+
+		// Check if the hash is a Joomla hash.
+		if (preg_match('#[a-z0-9]{32}:[A-Za-z0-9]{32}#', $hash) === 1)
+		{
+			return md5($password . substr($hash, 33)) == substr($hash, 0, 32);
+		}
+		return false;
+	}
+}

--- a/tests/suites/unit/joomla/crypt/password/JCryptPasswordSimpleTest.php
+++ b/tests/suites/unit/joomla/crypt/password/JCryptPasswordSimpleTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Hash
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+require_once JPATH_PLATFORM . '/joomla/crypt/password.php';
+require_once JPATH_PLATFORM . '/joomla/crypt/password/simple.php';
+
+/**
+ * Test class for JCryptPasswordSimple.
+ */
+class JCryptPasswordSimpleTest extends PHPUnit_Framework_TestCase
+{
+	/**
+	 * Data provider for testCreate method.
+	 */
+	public function createData()
+	{
+		return array(
+			'Blowfish'   => array('password', JCryptPassword::BLOWFISH, 'ABCDEFGHIJKLMNOPQRSTUV', '$2y$10$ABCDEFGHIJKLMNOPQRSTUOiAi7OcdE4zRCh6NcGWusEcNPtq6/w8.'),
+			'MD5'        => array('password', JCryptPassword::MD5, 'ABCDEFGHIJKL', '$1$ABCDEFGH$hGGndps75hhROKqu/zh9q1'),
+			'Joomla'     => array('password', JCryptPassword::JOOMLA, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ123456', '883a96d8da5440781fe7b60f1d4ae2b3:ABCDEFGHIJKLMNOPQRSTUVWXYZ123456'),
+			'Blowfish_5' => array('password', JCryptPassword::BLOWFISH, 'ABCDEFGHIJKLMNOPQRSTUV', '$2y$05$ABCDEFGHIJKLMNOPQRSTUOvv7EU5o68GAoLxyfugvULZR70IIMZqW', 5)
+		);
+	}
+
+	/**
+	 * Tests create method.
+	 *
+	 * @covers  JCryptPasswordSimple::create
+	 *
+	 * @dataProvider  createData
+	 */
+	public function testCreate($password, $type, $salt, $expected, $cost = 10)
+	{
+		$hasher = $this->getMock('JCryptPasswordSimple', array('getSalt'));
+
+		$hasher->setCost($cost);
+
+		$hasher->expects($this->any())
+			   ->method('getSalt')
+			   ->with(strlen($salt))
+			   ->will($this->returnValue($salt));
+
+		$this->assertEquals(
+			$expected,
+			$hasher->create($password, $type)
+		);
+	}
+
+	/**
+	 * Data Provider for testVerify.
+	 */
+	public function verifyData()
+	{
+		return array(
+			'Blowfish Valid:'   => array('password', '$2y$10$ABCDEFGHIJKLMNOPQRSTUOiAi7OcdE4zRCh6NcGWusEcNPtq6/w8.', true),
+			'Blowfish Invalid:' => array('wrong password', '$2y$10$ABCDEFGHIJKLMNOPQRSTUOiAi7OcdE4zRCh6NcGWusEcNPtq6/w8.', false),
+			'MD5 Valid'         => array('password', '$1$ABCDEFGH$hGGndps75hhROKqu/zh9q1', true),
+			'MD5 Invalid'       => array('passw0rd', '$1$ABCDEFGH$hGGndps75hhROKqu/zh9q1', false),
+			'Joomla Valid'      => array('password', '883a96d8da5440781fe7b60f1d4ae2b3:ABCDEFGHIJKLMNOPQRSTUVWXYZ123456', true),
+			'Joomla Invalid'    => array('passw0rd', '883a96d8da5440781fe7b60f1d4ae2b3:ABCDEFGHIJKLMNOPQRSTUVWXYZ123456', false)
+		);
+	}
+
+	/**
+	 * Tests the verify method.
+	 *
+	 * @covers        JCryptPasswordSimple::verify
+	 * @dataProvider  verifyData
+	 */
+	public function testVerify($password, $hash, $expectation)
+	{
+		$hasher = new JCryptPasswordSimple;
+
+		$this->assertEquals($hasher->verify($password, $hash), $expectation);
+	}
+}


### PR DESCRIPTION
This will provide basic password hashing capabilities using a straightforward and easy to use interface.

Use is easy:
$hasher = new JCryptPasswordSimple();

$hash = $hasher->create('MyPasswordHere', JCryptPassword::BLOWFISH);

---

$isPasswordCorrect = $hasher->verify('MyPasswordHere', $hash);

The basic implementation supports BLOWFISH, MD5 and the legacy Joomla password format.  For more complex requirements an alternative implementation of the interface can be supplied and used.
