### PR TITLE
Deal with the PDO class not being available.

### DIFF
--- a/libraries/joomla/database/driver/oracle.php
+++ b/libraries/joomla/database/driver/oracle.php
@@ -515,7 +515,7 @@ class JDatabaseDriverOracle extends JDatabaseDriverPdo
 	 */
 	public static function isSupported()
 	{
-		return in_array('oci', PDO::getAvailableDrivers());
+		return class_exists('PDO') && in_array('oci', PDO::getAvailableDrivers());
 	}
 
 	/**

--- a/libraries/joomla/database/driver/sqlite.php
+++ b/libraries/joomla/database/driver/sqlite.php
@@ -39,19 +39,6 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 	protected $nameQuote = '`';
 
 	/**
-	 * Constructor.
-	 *
-	 * @param   array  $options  List of options used to configure the connection
-	 *
-	 * @since   12.1
-	 */
-	public function __construct($options)
-	{
-		// Finalize initialisation
-		parent::__construct($options);
-	}
-
-	/**
 	 * Destructor.
 	 *
 	 * @since   12.1
@@ -391,6 +378,6 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 	 */
 	public static function isSupported()
 	{
-		return in_array('sqlite', PDO::getAvailableDrivers());
+		return class_exists('PDO') && in_array('sqlite', PDO::getAvailableDrivers());
 	}
 }


### PR DESCRIPTION
Database drivers that use PDO throw fatal erros when isSupported() is called and the PDO class doesn't exist.
