### PR TITLE
Fix installer/updater in platform for Joomla 3. Thanks Rouven

### DIFF
--- a/libraries/joomla/installer/helper.php
+++ b/libraries/joomla/installer/helper.php
@@ -52,9 +52,9 @@ abstract class JInstallerHelper
 			return false;
 		}
 
-		if ($response->headers['wrapper_data']['Content-Disposition'])
+		if (isset($response->headers['Content-Disposition']))
 		{
-			$contentfilename = explode("\"", $response->headers['wrapper_data']['Content-Disposition']);
+			$contentfilename = explode("\"", $response->headers['Content-Disposition']);
 			$target = $contentfilename[1];
 		}
 


### PR DESCRIPTION
When using the Updater in Joomla 3 right now you get a:
- Notice: Undefined index: wrapper_data in /Users/rouven/Sites/joomla-cms/libraries/joomla/installer/helper.php on line 55

Checking with Rouven he suggested that change attached in the pull request. I have tested with the 3 transports like that:

// using STREAM
$http = new JHttp(null, new JHttpTransportStream(null));

// using sockets
$http = new JHttp(null, new JHttpTransportSocket(null));

// using CURL
$http = JHttpFactory::getHttp();

All they worked for me. 

Please review it. 
Thanks ^_^
