### PR TITLE
Validate that the key parameter is a string

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -851,7 +851,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 
 		// Update the primary key if it exists.
 		$id = $this->insertid();
-		if ($key && $id)
+		if ($key && $id && is_string($key))
 		{
 			$object->$key = $id;
 		}


### PR DESCRIPTION
This pull request validates that the `$key` parameter provided to the function is actually a string before trying to use this. I came across this as I was working to modify JTable to be able to support multiple primary keys in a somewhat transparent way. By default JTable passes through it's keys onto the database `insertObject` and `updateObject` function which works well for single keys but not properly for `insertObject` when the `$key` is an array.
