### PR TITLE
Fix issues with Oracle DB Unit

### DIFF
--- a/tests/core/case/database/oracle.php
+++ b/tests/core/case/database/oracle.php
@@ -76,13 +76,19 @@ abstract class TestCaseDatabaseOracle extends TestCaseDatabase
 					$components = parse_url($v);
 					self::$_options['host'] = $components['host'];
 					self::$_options['port'] = $components['port'];
-					self::$_options['database'] = $components['path'];
+					self::$_options['database'] = ltrim($components['path'], '/');
 					break;
 				case 'user':
 					self::$_options['user'] = $v;
 					break;
 				case 'pass':
 					self::$_options['password'] = $v;
+					break;
+				case 'dbschema':
+					self::$_options['schema'] = $v;
+					break;
+				case 'prefix':
+					self::$_options['prefix'] = $v;
 					break;
 			}
 		}
@@ -136,7 +142,7 @@ abstract class TestCaseDatabaseOracle extends TestCaseDatabase
 	{
 		// Compile the connection DSN.
 		$dsn = 'oci:dbname=//' . self::$_options['host'] . ':' . self::$_options['port'] . '/' . self::$_options['database'];
-		$dsn .= ';charset=' . self::$_options['host'];
+		$dsn .= ';charset=' . self::$_options['charset'];
 
 		// Create the PDO object from the DSN and options.
 		$pdo = new PDO($dsn, self::$_options['user'], self::$_options['password']);


### PR DESCRIPTION
This commit provides some extra functionality and fixes to the Oracle DB Unit base case. It fixes an issue with the URI parsing where the preceding slash was included with the database name which triggered errors and it also supports passing in a custom Oracle database schema and table prefix as well. A bug with the charset is also fixes to use the right field instead of the host field it was previously using.
