### PR TITLE
Fix IS_MAC operating system check

### DIFF
--- a/libraries/import.php
+++ b/libraries/import.php
@@ -20,11 +20,11 @@ if (!defined('IS_WIN'))
 }
 if (!defined('IS_MAC'))
 {
-	define('IS_MAC', ($os === 'MAC') ? true : false);
+	define('IS_MAC', ($os === 'MAC' || $os === 'DAR') ? true : false);
 }
 if (!defined('IS_UNIX'))
 {
-	define('IS_UNIX', (($os !== 'MAC') && ($os !== 'WIN')) ? true : false);
+	define('IS_UNIX', (($os !== 'MAC' || $os !== 'DAR') && ($os !== 'WIN')) ? true : false);
 }
 
 // Import the platform version library if necessary.


### PR DESCRIPTION
On my OS X 10.8 machine, when I run the code `strtoupper(substr(PHP_OS, 0, 3))`, I get the result of 'DAR', which is short for Darwin. Under the previous revision, the IS_UNIX would be defined as true, and IS_MAC is defined as false, even though I am running the check on a Mac. 

In the platform docs, it says IS_UNIX is only set to true if it is a flavor of UNIX or Linux, but not Mac. This is not true, as Darwin IS Mac, but is labeled as IS_UNIX using the existing code. This fixes that.
