### PR TITLE
Fix IS_MAC operating system check

### DIFF
--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -18,13 +18,17 @@ if (!defined('IS_WIN'))
 {
 	define('IS_WIN', ($os === 'WIN') ? true : false);
 }
-if (!defined('IS_MAC'))
-{
-	define('IS_MAC', ($os === 'MAC') ? true : false);
-}
 if (!defined('IS_UNIX'))
 {
-	define('IS_UNIX', (($os !== 'MAC') && ($os !== 'WIN')) ? true : false);
+	define('IS_UNIX', (IS_WIN === false) ? true : false);
+}
+
+/**
+ * @deprecated	13.3	Use IS_UNIX instead
+ */
+if (!defined('IS_MAC'))
+{
+	define('IS_MAC', (IS_UNIX === true && ($os === 'DAR' || $os === 'MAC')) ? true : false);
 }
 
 // Import the platform version library if necessary.

--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -20,11 +20,11 @@ if (!defined('IS_WIN'))
 }
 if (!defined('IS_MAC'))
 {
-	define('IS_MAC', ($os === 'MAC') ? true : false);
+	define('IS_MAC', ($os === 'MAC' || $os === 'DAR') ? true : false);
 }
 if (!defined('IS_UNIX'))
 {
-	define('IS_UNIX', (($os !== 'MAC') && ($os !== 'WIN')) ? true : false);
+	define('IS_UNIX', (IS_MAC === false && IS_WIN === false) ? true : false);
 }
 
 // Import the platform version library if necessary.

--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -18,13 +18,17 @@ if (!defined('IS_WIN'))
 {
 	define('IS_WIN', ($os === 'WIN') ? true : false);
 }
-if (!defined('IS_MAC'))
-{
-	define('IS_MAC', ($os === 'MAC' || $os === 'DAR') ? true : false);
-}
 if (!defined('IS_UNIX'))
 {
-	define('IS_UNIX', (IS_MAC === false && IS_WIN === false) ? true : false);
+	define('IS_UNIX', (IS_WIN === false) ? true : false);
+}
+
+/**
+ * @deprecated	12.1	Use IS_UNIX instead
+ */
+if (!defined('IS_MAC'))
+{
+	define('IS_MAC', IS_UNIX);
 }
 
 // Import the platform version library if necessary.

--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -28,7 +28,7 @@ if (!defined('IS_UNIX'))
  */
 if (!defined('IS_MAC'))
 {
-	define('IS_MAC', IS_UNIX);
+	define('IS_MAC', (IS_UNIX === true && ($os === 'DAR' || $os === 'MAC')) ? true : false);
 }
 
 // Import the platform version library if necessary.

--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -24,7 +24,7 @@ if (!defined('IS_UNIX'))
 }
 
 /**
- * @deprecated	12.1	Use IS_UNIX instead
+ * @deprecated	12.3	Use IS_UNIX instead
  */
 if (!defined('IS_MAC'))
 {

--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -24,7 +24,7 @@ if (!defined('IS_UNIX'))
 }
 
 /**
- * @deprecated	12.3	Use IS_UNIX instead
+ * @deprecated	13.3	Use IS_UNIX instead
  */
 if (!defined('IS_MAC'))
 {

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -18,13 +18,9 @@ if (!defined('IS_WIN'))
 {
 	define('IS_WIN', ($os === 'WIN') ? true : false);
 }
-if (!defined('IS_MAC'))
-{
-	define('IS_MAC', ($os === 'MAC') ? true : false);
-}
 if (!defined('IS_UNIX'))
 {
-	define('IS_UNIX', (($os !== 'MAC') && ($os !== 'WIN')) ? true : false);
+	define('IS_UNIX', (IS_WIN === false) ? true : false);
 }
 
 // Import the platform version library if necessary.

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -18,13 +18,9 @@ if (!defined('IS_WIN'))
 {
 	define('IS_WIN', ($os === 'WIN') ? true : false);
 }
-if (!defined('IS_MAC'))
-{
-	define('IS_MAC', ($os === 'MAC' || $os === 'DAR') ? true : false);
-}
 if (!defined('IS_UNIX'))
 {
-	define('IS_UNIX', (IS_MAC === false && IS_WIN === false) ? true : false);
+	define('IS_UNIX', (IS_WIN === false) ? true : false);
 }
 
 // Import the platform version library if necessary.

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -20,11 +20,11 @@ if (!defined('IS_WIN'))
 }
 if (!defined('IS_MAC'))
 {
-	define('IS_MAC', ($os === 'MAC') ? true : false);
+	define('IS_MAC', ($os === 'MAC' || $os === 'DAR') ? true : false);
 }
 if (!defined('IS_UNIX'))
 {
-	define('IS_UNIX', (($os !== 'MAC') && ($os !== 'WIN')) ? true : false);
+	define('IS_UNIX', (IS_MAC === false && IS_WIN === false) ? true : false);
 }
 
 // Import the platform version library if necessary.

--- a/libraries/joomla/client/ftp.php
+++ b/libraries/joomla/client/ftp.php
@@ -121,7 +121,7 @@ class JClientFtp
 	 * @var    array
 	 * @since  12.1
 	 */
-	private $_lineEndings = array('UNIX' => "\n", 'MAC' => "\r", 'WIN' => "\r\n");
+	private $_lineEndings = array('UNIX' => "\n", 'WIN' => "\r\n");
 
 	/**
 	 * @var    array  JClientFtp instances container.
@@ -846,10 +846,6 @@ class JClientFtp
 			if (IS_WIN)
 			{
 				$os = 'WIN';
-			}
-			elseif (IS_MAC)
-			{
-				$os = 'MAC';
 			}
 
 			$buffer = preg_replace("/" . CRLF . "/", $this->_lineEndings[$os], $buffer);


### PR DESCRIPTION
This patch fixes the IS_MAC os check in the import.php and the import.legacy.php file.

It also improves the IS_UNIX check. Instead of checking the $os variable again, we just compare the the IS_WIN and IS_MAC constants.
