### PR TITLE
Removing doc references to JController in JViewBase and JViewHtml

### DIFF
--- a/docs/manual/en-US/chapters/classes/jviewbase.xml
+++ b/docs/manual/en-US/chapters/classes/jviewbase.xml
@@ -10,11 +10,9 @@
   <section>
     <title>Construction</title>
 
-    <para>The contructor for <classname>JViewBase</classname> takes a <classname>JModel</classname> object and a
-    <classname>JController</classname> object. Both are mandatory.</para>
+    <para>The contructor for <classname>JViewBase</classname> takes a mandatory <classname>JModel</classname> parameter.</para>
 
-    <para>Note that these are interfaces so the objects do no necessarily have to extend from <classname>JModelBase</classname> or
-    <classname>JControllerBase</classname> classes. Given that, the view should only rely on the API that is exposed by the
+    <para>Note that JModel is an interface so the actual object passed does necessarily have to extend from <classname>JModelBase</classname> class. Given that, the view should only rely on the API that is exposed by the
     interface and not concrete classes unless the contructor is changed in a derived class to take more explicit classes or
     interaces as required by the developer.</para>
   </section>
@@ -62,7 +60,7 @@ class MyView extends JViewBase
 
 try
 {
-	$view = new MyView(new MyDatabaseModel, new MyController);
+	$view = new MyView(new MyDatabaseModel);
 	echo $view-&gt;render();
 }
 catch (RuntimeException $e)

--- a/docs/manual/en-US/chapters/classes/jviewhtml.xml
+++ b/docs/manual/en-US/chapters/classes/jviewhtml.xml
@@ -11,7 +11,7 @@
     <title>Construction</title>
 
     <para><classname>JViewHtml</classname> is extended from <classname>JViewBase</classname>. The constructor, in addition to the
-    model and controller arguments, take an optional <classname>SplPriorityQueue</classname> object that serves as a lookup for
+    required model argument, take an optional <classname>SplPriorityQueue</classname> object that serves as a lookup for
     layouts. If omitted, the view defers to the protected <methodname>loadPaths</methodname> method.</para>
   </section>
 
@@ -69,7 +69,7 @@ try
 	$paths = new SplPriorityQueue;
 	$paths-&gt;insert(__DIR__ . '/layouts');
 
-	$view = new MyView(new MyDatabaseModel, new MyController, $paths);
+	$view = new MyView(new MyDatabaseModel, $paths);
 	$view-&gt;setLayout('count');
 	echo $view-&gt;render();
 


### PR DESCRIPTION
When the new MVC was proposed, the original JViewBase and JViewHtml classes took a required second parameter of a JController object. This is not the case now. This pull request updates the docs to reflect the code.
