### PR TITLE
Deprecating IS_MAC in favor if strictly IS_UNIX

### DIFF
--- a/docs/manual/en-US/chapters/classes/jviewhtml.xml
+++ b/docs/manual/en-US/chapters/classes/jviewhtml.xml
@@ -11,7 +11,7 @@
     <title>Construction</title>
 
     <para><classname>JViewHtml</classname> is extended from <classname>JViewBase</classname>. The constructor, in addition to the
-    model and controller arguments, take an optional <classname>SplPriorityQueue</classname> object that serves as a lookup for
+    required model argument, take an optional <classname>SplPriorityQueue</classname> object that serves as a lookup for
     layouts. If omitted, the view defers to the protected <methodname>loadPaths</methodname> method.</para>
   </section>
 
@@ -69,7 +69,7 @@ try
 	$paths = new SplPriorityQueue;
 	$paths-&gt;insert(__DIR__ . '/layouts');
 
-	$view = new MyView(new MyDatabaseModel, new MyController, $paths);
+	$view = new MyView(new MyDatabaseModel, $paths);
 	$view-&gt;setLayout('count');
 	echo $view-&gt;render();
 

--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -18,13 +18,17 @@ if (!defined('IS_WIN'))
 {
 	define('IS_WIN', ($os === 'WIN') ? true : false);
 }
-if (!defined('IS_MAC'))
-{
-	define('IS_MAC', ($os === 'MAC') ? true : false);
-}
 if (!defined('IS_UNIX'))
 {
 	define('IS_UNIX', (($os !== 'MAC') && ($os !== 'WIN')) ? true : false);
+}
+
+/**
+ * @deprecated 13.3	Use IS_UNIX instead
+ */
+if (!defined('IS_MAC'))
+{
+	define('IS_MAC', (IS_UNIX === true && ($os === 'DAR' || $os === 'MAC')) ? true : false);
 }
 
 // Import the platform version library if necessary.

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -18,13 +18,9 @@ if (!defined('IS_WIN'))
 {
 	define('IS_WIN', ($os === 'WIN') ? true : false);
 }
-if (!defined('IS_MAC'))
-{
-	define('IS_MAC', ($os === 'MAC') ? true : false);
-}
 if (!defined('IS_UNIX'))
 {
-	define('IS_UNIX', (($os !== 'MAC') && ($os !== 'WIN')) ? true : false);
+	define('IS_UNIX', (IS_WIN === false) ? true : false);
 }
 
 // Import the platform version library if necessary.

--- a/libraries/joomla/client/ftp.php
+++ b/libraries/joomla/client/ftp.php
@@ -121,7 +121,7 @@ class JClientFtp
 	 * @var    array
 	 * @since  12.1
 	 */
-	private $_lineEndings = array('UNIX' => "\n", 'MAC' => "\r", 'WIN' => "\r\n");
+	private $_lineEndings = array('UNIX' => "\n", 'WIN' => "\r\n");
 
 	/**
 	 * @var    array  JClientFtp instances container.
@@ -846,10 +846,6 @@ class JClientFtp
 			if (IS_WIN)
 			{
 				$os = 'WIN';
-			}
-			elseif (IS_MAC)
-			{
-				$os = 'MAC';
 			}
 
 			$buffer = preg_replace("/" . CRLF . "/", $this->_lineEndings[$os], $buffer);


### PR DESCRIPTION
This patch originally addressed an issue with the IS_MAC os check in import.php, but expanded into deprecating IS_MAC in favor of using strictly IS_UNIX since the only place IS_MAC was used was in the JClientFtp Library to check for line endings. Unix and Mac use the same LF line ending.
