### PR TITLE
Bring some sanity to JComponentHelper::isEnabled

### DIFF
--- a/libraries/legacy/component/helper.php
+++ b/libraries/legacy/component/helper.php
@@ -62,18 +62,17 @@ class JComponentHelper
 	/**
 	 * Checks if the component is enabled
 	 *
-	 * @param   string   $option  The component option.
-	 * @param   boolean  $strict  If set and the component does not exist, false will be returned.
+	 * @param   string  $option  The component option.
 	 *
 	 * @return  boolean
 	 *
 	 * @since   11.1
 	 */
-	public static function isEnabled($option, $strict = false)
+	public static function isEnabled($option)
 	{
-		$result = self::getComponent($option, $strict);
+		$result = self::getComponent($option, true);
 
-		return ($result->enabled | JFactory::getApplication()->isAdmin());
+		return $result->enabled;
 	}
 
 	/**


### PR DESCRIPTION
JComponentHelper::isEnabled is a rather confusing piece of API, this should let it behave as expected.

Please don't pull this until we have buy-in from the CMS since this a B/C break and a CMS specific piece of API!
