### PR TITLE
fix JViewLegacy::getName model name discovery

### DIFF
--- a/libraries/legacy/view/legacy.php
+++ b/libraries/legacy/view/legacy.php
@@ -456,16 +456,15 @@ class JViewLegacy extends JObject
 	{
 		if (empty($this->_name))
 		{
-			$r = null;
-			if (!preg_match('/View((view)*(.*(view)?.*))$/i', get_class($this), $r))
+			$classname = get_class($this);
+			$viewpos = strpos($classname, 'View');
+			
+			if ($viewpos === false)
 			{
 				throw new Exception(JText::_('JLIB_APPLICATION_ERROR_VIEW_GET_NAME'), 500);
 			}
-			if (strpos($r[3], "view"))
-			{
-				JLog::add(JText::_('JLIB_APPLICATION_ERROR_VIEW_GET_NAME_SUBSTRING'), JLog::WARNING, 'jerror');
-			}
-			$this->_name = strtolower($r[3]);
+			
+			$this->_name = strtolower(substr($classname, $viewpos+4));
 		}
 
 		return $this->_name;

--- a/libraries/legacy/view/legacy.php
+++ b/libraries/legacy/view/legacy.php
@@ -456,16 +456,15 @@ class JViewLegacy extends JObject
 	{
 		if (empty($this->_name))
 		{
-			$r = null;
-			if (!preg_match('/View((view)*(.*(view)?.*))$/i', get_class($this), $r))
+			$classname = get_class($this);
+			$viewpos = strpos($classname, 'View');
+
+			if ($viewpos === false)
 			{
 				throw new Exception(JText::_('JLIB_APPLICATION_ERROR_VIEW_GET_NAME'), 500);
 			}
-			if (strpos($r[3], "view"))
-			{
-				JLog::add(JText::_('JLIB_APPLICATION_ERROR_VIEW_GET_NAME_SUBSTRING'), JLog::WARNING, 'jerror');
-			}
-			$this->_name = strtolower($r[3]);
+
+			$this->_name = strtolower(substr($classname, $viewpos + 4));
 		}
 
 		return $this->_name;


### PR DESCRIPTION
The current regex implementation for model name auto-discovery in the JViewLegacy prevents a developer from the use of the substr of "view" in the classname without consequences. Hence the reason for the custom error created just for that case. (see line 466 of the diff: https://github.com/joomla/joomla-platform/pull/1509/files#L0L466). This pull request fixes that.

Note: This fix breaks Backwards Compatibility (potentially) as the previous regex implementation used the /i modifier and searched for case insensitive strings. Here we use strpos (case-sensitive). Be sure your classnames are properly CamelCased (http://docs.joomla.org/Coding_style_and_standards#Classes)

This is how I tested - https://gist.github.com/3563618
