### PR TITLE
Joomla CMS #27397 

### DIFF
--- a/libraries/joomla/installer/adapters/template.php
+++ b/libraries/joomla/installer/adapters/template.php
@@ -488,6 +488,15 @@ class JInstallerTemplate extends JAdapterInstance
 				continue;
 			}
 			$manifest_details = JInstaller::parseXMLInstallFile(JPATH_SITE . "/templates/$template/templateDetails.xml");
+    	
+			if ($template != $manifest_details['name']) 
+			{
+				JError::raiseWarning(100, JText::_('JLIB_INSTALLER_ERROR_TPL_DISCOVER_NAMES_DIFFERENT'));
+			
+				continue;
+				// Ignore if directory name is different than the templateDetails.xml <name> tag
+			}
+			
 			$extension = JTable::getInstance('extension');
 			$extension->set('type', 'template');
 			$extension->set('client_id', $site_info->id);


### PR DESCRIPTION
This is for CMS tracker id # 27397.

Link to tracker item:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=27397

The bug:
Template style doesn't show up if there's a space in the name tag of templateDetails.xml and the template is installed via the Discover feature

The pull request for the language strings is at:
https://github.com/joomla/joomla-cms/pull/346
