### PR TITLE
Add error handling for __get and __call methods.

### DIFF
--- a/libraries/joomla/application/web/client.php
+++ b/libraries/joomla/application/web/client.php
@@ -224,6 +224,15 @@ class JApplicationWebClient
 					$this->detectRobot($this->userAgent);
 				}
 				break;
+
+			default:
+				// In dynamic methods we have to do the error handling ourself.
+				$trace = debug_backtrace();
+				trigger_error(
+					'Undefined property via __get(): ' . $name . ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'],
+					E_USER_NOTICE
+				);
+				return null;
 		}
 
 		// Return the property if it exists.

--- a/libraries/joomla/crypt/key.php
+++ b/libraries/joomla/crypt/key.php
@@ -72,9 +72,13 @@ class JCryptKey
 		{
 			return $this->type;
 		}
-		else
-		{
-			trigger_error('Cannot access property ' . __CLASS__ . '::' . $name, E_USER_WARNING);
-		}
+
+		// In dynamic methods we have to do the error handling ourself.
+		$trace = debug_backtrace();
+		trigger_error(
+			'Undefined property via __get(): ' . $name . ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'],
+			E_USER_NOTICE
+		);
+		return null;
 	}
 }

--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -338,7 +338,12 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	{
 		if (empty($args))
 		{
-			return;
+			// In dynamic methods we have to do the error handling ourself.
+			$trace = debug_backtrace();
+			trigger_error(
+				'Call to undefined method via __call(): ' . $method . ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'],
+				E_USER_ERROR
+			);
 		}
 
 		switch ($method)
@@ -350,6 +355,13 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 				return $this->quoteName($args[0], isset($args[1]) ? $args[1] : null);
 				break;
 		}
+
+		// In dynamic methods we have to do the error handling ourself.
+		$trace = debug_backtrace();
+		trigger_error(
+			'Call to undefined method via __call(): ' . $method . ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'],
+			E_USER_ERROR
+		);
 	}
 
 	/**

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -283,7 +283,12 @@ abstract class JDatabaseQuery
 	{
 		if (empty($args))
 		{
-			return;
+			// In dynamic methods we have to do the error handling ourself.
+			$trace = debug_backtrace();
+			trigger_error(
+				'Call to undefined method via __call(): ' . $method . ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'],
+				E_USER_ERROR
+			);
 		}
 
 		switch ($method)
@@ -300,6 +305,13 @@ abstract class JDatabaseQuery
 				return $this->escape($args[0], isset($args[1]) ? $args[1] : false);
 				break;
 		}
+
+		// In dynamic methods we have to do the error handling ourself.
+		$trace = debug_backtrace();
+		trigger_error(
+			'Call to undefined method via __call(): ' . $method . ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'],
+			E_USER_ERROR
+		);
 	}
 
 	/**
@@ -470,7 +482,18 @@ abstract class JDatabaseQuery
 	 */
 	public function __get($name)
 	{
-		return isset($this->$name) ? $this->$name : null;
+		if (isset($this->$name) || property_exists($this, $name))
+		{
+			return $this->$name;
+		}
+
+		// In dynamic methods we have to do the error handling ourself.
+		$trace = debug_backtrace();
+		trigger_error(
+			'Undefined property via __get(): ' . $name . ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'],
+			E_USER_NOTICE
+		);
+		return null;
 	}
 
 	/**

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -270,6 +270,12 @@ abstract class JFormField
 				return $this->getTitle();
 		}
 
+		// In dynamic methods we have to do the error handling ourself.
+		$trace = debug_backtrace();
+		trigger_error(
+			'Undefined property via __get(): ' . $name . ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'],
+			E_USER_NOTICE
+		);
 		return null;
 	}
 

--- a/libraries/joomla/github/github.php
+++ b/libraries/joomla/github/github.php
@@ -154,6 +154,14 @@ class JGithub
 			}
 			return $this->commits;
 		}
+
+		// In dynamic methods we have to do the error handling ourself.
+		$trace = debug_backtrace();
+		trigger_error(
+			'Undefined property via __get(): ' . $name . ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'],
+			E_USER_NOTICE
+		);
+		return null;
 	}
 
 	/**

--- a/libraries/joomla/input/input.php
+++ b/libraries/joomla/input/input.php
@@ -127,7 +127,13 @@ class JInput implements Serializable, Countable
 			return $this->inputs[$name];
 		}
 
-		// TODO throw an exception
+		// In dynamic methods we have to do the error handling ourself.
+		$trace = debug_backtrace();
+		trigger_error(
+			'Undefined property via __get(): ' . $name . ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'],
+			E_USER_NOTICE
+		);
+		return null;
 	}
 
 	/**
@@ -260,7 +266,6 @@ class JInput implements Serializable, Countable
 	{
 		if (substr($name, 0, 3) == 'get')
 		{
-
 			$filter = substr($name, 3);
 
 			$default = null;
@@ -271,6 +276,13 @@ class JInput implements Serializable, Countable
 
 			return $this->get($arguments[0], $default, $filter);
 		}
+
+		// In dynamic methods we have to do the error handling ourself.
+		$trace = debug_backtrace();
+		trigger_error(
+			'Call to undefined method via __call(): ' . $name . ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'],
+			E_USER_ERROR
+		);
 	}
 
 	/**

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -156,6 +156,14 @@ class JSession implements IteratorAggregate
 			$property = '_' . $name;
 			return $this->$property;
 		}
+
+		// In dynamic methods we have to do the error handling ourself.
+		$trace = debug_backtrace();
+		trigger_error(
+			'Undefined property via __get(): ' . $name . ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'],
+			E_USER_NOTICE
+		);
+		return null;
 	}
 
 	/**

--- a/tests/suites/unit/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suites/unit/joomla/database/JDatabaseQueryTest.php
@@ -93,6 +93,7 @@ class JDatabaseQueryTest extends TestCase
 	 * @return  void
 	 *
 	 * @since   11.1
+	 * @covers  JDatabaseQuery::__call
 	 */
 	public function test__call()
 	{
@@ -115,12 +116,22 @@ class JDatabaseQueryTest extends TestCase
 			$this->equalTo($q->quoteName('foo')),
 			'Tests the qn alias of quoteName.'
 		);
+	}
 
-		$this->assertThat(
-			$q->foo(),
-			$this->isNull(),
-			'Tests for an unknown method.'
-		);
+	/**
+	 * Test for the JDatabaseQuery::__call method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.2
+	 * @covers  JDatabaseQuery::__call
+	 * @expectedException  PHPUnit_Framework_Error
+	 */
+	public function test__callError()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
+
+		$q->foo();
 	}
 
 	/**

--- a/tests/suites/unit/joomla/database/JDatabaseTest.php
+++ b/tests/suites/unit/joomla/database/JDatabaseTest.php
@@ -5,7 +5,6 @@
  * @license		GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-require_once JPATH_PLATFORM . '/joomla/database/database.php';
 require_once __DIR__ . '/stubs/nosqldriver.php';
 
 /**
@@ -44,11 +43,30 @@ class JDatabaseTest extends TestCaseDatabase
 	}
 
 	/**
-	 * Test for the JDatabase::__call method.
+	 * Test for the JDatabaseDriver::__call method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.2
+	 * @covers  JDatabaseDriver::__call
+	 * @expectedException  PHPUnit_Framework_Error
+	 */
+	public function test__callError()
+	{
+		$this->assertThat(
+			$this->db->foo(),
+			$this->isNull(),
+			'Tests for an unknown method.'
+		);
+	}
+
+	/**
+	 * Test for the JDatabaseDriver::__call method.
 	 *
 	 * @return  void
 	 *
 	 * @since   12.1
+	 * @covers  JDatabaseDriver::__call
 	 */
 	public function test__call()
 	{
@@ -62,12 +80,6 @@ class JDatabaseTest extends TestCaseDatabase
 			$this->db->qn('foo'),
 			$this->equalTo($this->db->quoteName('foo')),
 			'Tests the qn alias of quoteName.'
-		);
-
-		$this->assertThat(
-			$this->db->foo(),
-			$this->isNull(),
-			'Tests for an unknown method.'
 		);
 	}
 

--- a/tests/suites/unit/joomla/form/JFormFieldTest.php
+++ b/tests/suites/unit/joomla/form/JFormFieldTest.php
@@ -307,6 +307,25 @@ class JFormFieldTest extends TestCase
 	}
 
 	/**
+	 * Tests the JFormField::__get method
+	 *
+	 * @covers  JFormField::__get
+	 * @expectedException  PHPUnit_Framework_Error_Notice
+	 */
+	public function test__getUnexisting()
+	{
+		$form = new JFormInspector('form1');
+		$form->load(JFormDataHelper::$loadFieldDocument);
+		$field = new JFormFieldInspector($form);
+
+		$this->assertThat(
+			$field->unexisting,
+			$this->equalTo(null),
+			'Line:'.__LINE__.' The property should be computed from the XML.'
+		);
+	}
+
+	/**
 	 * Tests the JFormField::setup method
 	 *
 	 * @covers JFormField::setup
@@ -315,13 +334,7 @@ class JFormFieldTest extends TestCase
 	public function testSetup()
 	{
 		$form = new JFormInspector('form1');
-
-		$this->assertThat(
-			$form->load(JFormDataHelper::$loadFieldDocument),
-			$this->isTrue(),
-			'Line:'.__LINE__.' XML string should load successfully.'
-		);
-
+		$form->load(JFormDataHelper::$loadFieldDocument);
 		$field = new JFormFieldInspector($form);
 
 		// Standard usage.
@@ -392,12 +405,6 @@ class JFormFieldTest extends TestCase
 		$this->assertThat(
 			$field->title,
 			$this->equalTo('Title'),
-			'Line:'.__LINE__.' The property should be computed from the XML.'
-		);
-
-		$this->assertThat(
-			$field->unexisting,
-			$this->equalTo(null),
 			'Line:'.__LINE__.' The property should be computed from the XML.'
 		);
 

--- a/tests/suites/unit/joomla/github/JGithubTest.php
+++ b/tests/suites/unit/joomla/github/JGithubTest.php
@@ -131,6 +131,7 @@ class JGithubTest extends PHPUnit_Framework_TestCase
 	/**
 	 * Tests the magic __get method - refs
 	 * @since  11.3
+	 * @expectedException  PHPUnit_Framework_Error_Notice
 	 */
 	public function test__GetOther()
 	{


### PR DESCRIPTION
Adding a __get or __call method may mask errors about unexisting method or properties if we don't do our own error handling. This pull should provide appropriate errors for all of these.

Note: The test results will show one error in JTableNested that I suspect is an actual bug but I'm not sure how to fix.
