### PR TITLE
Typo: self::getJSObject to JHtml::getJSObject

### DIFF
--- a/libraries/joomla/html/sliders.php
+++ b/libraries/joomla/html/sliders.php
@@ -107,7 +107,7 @@ abstract class JHtmlSliders
 			$opt['opacity'] = (isset($params['opacityTransition']) && ($params['opacityTransition'])) ? 'true' : 'false';
 			$opt['alwaysHide'] = (isset($params['allowAllClose']) && (!$params['allowAllClose'])) ? 'false' : 'true';
 
-			$options = self::getJSObject($opt);
+			$options = JHtml::getJSObject($opt);
 
 			$js = "window.addEvent('domready', function(){ new Fx.Accordion($$('div#" . $group
 				. ".pane-sliders > .panel > h3.pane-toggler'), $$('div#" . $group . ".pane-sliders > .panel > div.pane-slider'), " . $options

--- a/libraries/joomla/html/tabs.php
+++ b/libraries/joomla/html/tabs.php
@@ -88,7 +88,7 @@ abstract class JHtmlTabs
 			$opt['titleSelector']       = "'dt.tabs'";
 			$opt['descriptionSelector'] = "'dd.tabs'";
 
-			$options = self::getJSObject($opt);
+			$options = JHtml::getJSObject($opt);
 
 			$js = '	window.addEvent(\'domready\', function(){
 						$$(\'dl#' . $group . '.tabs\').each(function(tabs){


### PR DESCRIPTION
Fix for https://github.com/joomla/joomla-platform/pull/1475#discussion_r1555684 and https://github.com/joomla/joomla-platform/pull/1475#discussion_r1555688
