### PR TITLE
Fix Inconsistent refreshManifestCache and missed manifest file for modules, component and plugins

### DIFF
--- a/libraries/joomla/installer/adapters/component.php
+++ b/libraries/joomla/installer/adapters/component.php
@@ -1789,9 +1789,9 @@ class JInstallerComponent extends JAdapterInstance
 		// Need to find to find where the XML file is since we don't store this normally
 		$client = JApplicationHelper::getClientInfo($this->parent->extension->client_id);
 		$short_element = str_replace('com_', '', $this->parent->extension->element);
-		$manifestPath = $client->path . '/components/' . $this->parent->extension->element . '/' . $short_element . '.xml';
-		$this->parent->manifest = $this->parent->isManifest($manifestPath);
-		$this->parent->setPath('manifest', $manifestPath);
+		$manifestPath = $client->path . '/components/' . $this->parent->extension->element;
+		$this->parent->setPath('source', $manifestPath);
+		$this->parent->manifest = $this->parent->getManifest();
 
 		$manifest_details = JInstaller::parseXMLInstallFile($this->parent->getPath('manifest'));
 		$this->parent->extension->manifest_cache = json_encode($manifest_details);

--- a/libraries/joomla/installer/adapters/module.php
+++ b/libraries/joomla/installer/adapters/module.php
@@ -687,9 +687,10 @@ class JInstallerModule extends JAdapterInstance
 	public function refreshManifestCache()
 	{
 		$client = JApplicationHelper::getClientInfo($this->parent->extension->client_id);
-		$manifestPath = $client->path . '/modules/' . $this->parent->extension->element . '/' . $this->parent->extension->element . '.xml';
-		$this->parent->manifest = $this->parent->isManifest($manifestPath);
-		$this->parent->setPath('manifest', $manifestPath);
+		$manifestPath = $client->path . '/modules/' . $this->parent->extension->element;
+		$this->parent->setPath('source', $manifestPath);
+		$this->parent->manifest = $this->parent->getManifest();
+
 		$manifest_details = JInstaller::parseXMLInstallFile($this->parent->getPath('manifest'));
 		$this->parent->extension->manifest_cache = json_encode($manifest_details);
 		$this->parent->extension->name = $manifest_details['name'];

--- a/libraries/joomla/installer/adapters/plugin.php
+++ b/libraries/joomla/installer/adapters/plugin.php
@@ -834,10 +834,10 @@ class JInstallerPlugin extends JAdapterInstance
 		 * If it's not in the extensions table we just add it
 		 */
 		$client = JApplicationHelper::getClientInfo($this->parent->extension->client_id);
-		$manifestPath = $client->path . '/plugins/' . $this->parent->extension->folder . '/' . $this->parent->extension->element . '/'
-			. $this->parent->extension->element . '.xml';
-		$this->parent->manifest = $this->parent->isManifest($manifestPath);
-		$this->parent->setPath('manifest', $manifestPath);
+		$manifestPath = $client->path . '/plugins/' . $this->parent->extension->folder . '/' . $this->parent->extension->element;
+		$this->parent->setPath('source', $manifestPath);
+		$this->parent->manifest = $this->parent->getManifest();
+
 		$manifest_details = JInstaller::parseXMLInstallFile($this->parent->getPath('manifest'));
 		$this->parent->extension->manifest_cache = json_encode($manifest_details);
 

--- a/libraries/joomla/installer/adapters/template.php
+++ b/libraries/joomla/installer/adapters/template.php
@@ -608,9 +608,9 @@ class JInstallerTemplate extends JAdapterInstance
 	{
 		// Need to find to find where the XML file is since we don't store this normally.
 		$client = JApplicationHelper::getClientInfo($this->parent->extension->client_id);
-		$manifestPath = $client->path . '/templates/' . $this->parent->extension->element . '/templateDetails.xml';
-		$this->parent->manifest = $this->parent->isManifest($manifestPath);
-		$this->parent->setPath('manifest', $manifestPath);
+		$manifestPath = $client->path . '/templates/' . $this->parent->extension->element;
+		$this->parent->setPath('source', $manifestPath);
+		$this->parent->manifest = $this->parent->getManifest();
 
 		$manifest_details = JInstaller::parseXMLInstallFile($this->parent->getPath('manifest'));
 		$this->parent->extension->manifest_cache = json_encode($manifest_details);


### PR DESCRIPTION
It was looking for a fixed file name for manifest, instead of use the installation behavior, to use the first valid manifest file found.

If someone install an extension with a manifest.xml instead of mod_myext.xml, it's ok, until the user refresh the manifest cache or try to add a module (joomla will not find the right manifest file).

For modules, components and plugins.
