### PR TITLE
Fix potentially broken code in JPagination

### DIFF
--- a/libraries/joomla/pagination/pagination.php
+++ b/libraries/joomla/pagination/pagination.php
@@ -707,9 +707,6 @@ class JPagination
 		{
 			$offset = ($i - 1) * $this->limit;
 
-			// Set the empty for removal from route
-			// @todo remove code: $offset = $offset == 0 ? '' : $offset;
-
 			$data->pages[$i] = new JPaginationObject($i, $this->prefix);
 			if ($i != $this->pagesCurrent || $this->viewall)
 			{

--- a/libraries/joomla/pagination/pagination.php
+++ b/libraries/joomla/pagination/pagination.php
@@ -716,7 +716,7 @@ class JPagination
 				$data->pages[$i]->base = $offset;
 				$data->pages[$i]->link = JRoute::_($params . '&' . $this->prefix . 'limitstart=' . $offset);
 			}
-			elseif ($i = $this->pagesCurrent)
+			else
 			{
 				$data->pages[$i]->active = true;
 			}


### PR DESCRIPTION
Potential endless loop by setting $i=0 inside for statement. It's though much more likely that the code has no effect at all (I think it's always setting $i = $i), but even then it's probably a typo and will cause issues if the if statement gets changed at some point.

See also:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29197
