### PR TITLE
[IMP] Ensure that publish doesnt receive empty ids array

### DIFF
--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -833,6 +833,12 @@ abstract class JModelAdmin extends JModelForm
 		$table = $this->getTable();
 		$pks = (array) $pks;
 
+		// Ensure that we do not receive an empty array
+		if (empty($pks))
+		{
+			return true;
+		}
+
 		// Include the content plugins for the change of state event.
 		JPluginHelper::importPlugin('content');
 


### PR DESCRIPTION
Trying to disable the default item in Joomla CMS finishes in a JModelAdmin::publish with an empty ids array.

http://awesomescreenshot.com/09ag6vbe3

I'm going also to fix CMS to ensure that we do not call this method with an empty array. 

Joomlacode tracker issue:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28990
