### PR TITLE
Update to libraries/html/grid.php. Fixes grid.sort for components that use query strings in their URIs.

### DIFF
--- a/libraries/joomla/html/grid.php
+++ b/libraries/joomla/html/grid.php
@@ -86,7 +86,7 @@ abstract class JHtmlGrid
 			$direction = ($direction == 'desc') ? 'asc' : 'desc';
 		}
 
-		$html = '<a href="#" onclick="Joomla.tableOrdering(\'' . $order . '\',\'' . $direction . '\',\'' . $task . '\');" title="'
+		$html = '<a href="#" onclick="Joomla.tableOrdering(\'' . $order . '\',\'' . $direction . '\',\'' . $task . '\'); return false;" title="'
 			. JText::_('JGLOBAL_CLICK_TO_SORT_THIS_COLUMN') . '">';
 		$html .= JText::_($title);
 


### PR DESCRIPTION
Some browsers will follow the "#" hyperlink generated by JHTML's
grid.sort command unless the javascript onclick returns false. This will
cause components with URLs that look like "index.php?option=com_example"
to redirect to "index.php#", effectively breaking sorting functions.
The commit adds "return false;" to the generated javascript in onclick.
This affects at least frontend functions that use this in Joomla! 2.5.x
