### PR TITLE
Update JRegistry::def to support not string defaults.

### DIFF
--- a/libraries/joomla/registry/registry.php
+++ b/libraries/joomla/registry/registry.php
@@ -99,15 +99,15 @@ class JRegistry implements JsonSerializable
 	 * Sets a default value if not already assigned.
 	 *
 	 * @param   string  $key      The name of the parameter.
-	 * @param   string  $default  An optional value for the parameter.
+	 * @param   mixed   $default  An optional value for the parameter.
 	 *
-	 * @return  string  The value set, or the default if the value was not previously set (or null).
+	 * @return  mixed  The value set, or the default if the value was not previously set (or null).
 	 *
 	 * @since   11.1
 	 */
 	public function def($key, $default = '')
 	{
-		$value = $this->get($key, (string) $default);
+		$value = $this->get($key, $default);
 		$this->set($key, $value);
 		return $value;
 	}


### PR DESCRIPTION
This updates the behaviour of JRegistry::def so that it doesn't type cast the default value to a string but leaves it alone consistent with JRegistry::set's behaviour. This allows you to specify a default value that utilises an array of an object.
