### PR TITLE
JHTML Tabs and JHTML getJSObject fixes

### DIFF
--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -503,6 +503,9 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		// If an error occurred handle it.
 		if (!$this->cursor)
 		{
+			$this->errorNum = (int) mysqli_errno($this->connection);
+			$this->errorMsg = (string) mysqli_error($this->connection) . ' SQL=' . $sql;
+
 			// Check if the server was disconnected.
 			if (!$this->connected())
 			{
@@ -515,9 +518,6 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 				// If connect fails, ignore that exception and throw the normal exception.
 				catch (RuntimeException $e)
 				{
-					$this->errorNum = (int) mysqli_errno($this->connection);
-					$this->errorMsg = (string) mysqli_error($this->connection) . ' SQL=' . $sql;
-
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
 					throw new RuntimeException($this->errorMsg, $this->errorNum);
 				}
@@ -528,9 +528,6 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 			// The server was not disconnected.
 			else
 			{
-				$this->errorNum = (int) mysqli_errno($this->connection);
-				$this->errorMsg = (string) mysqli_error($this->connection) . ' SQL=' . $sql;
-
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
 				throw new RuntimeException($this->errorMsg, $this->errorNum);
 			}

--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -949,7 +949,7 @@ abstract class JHtml
 			elseif (!is_array($v) && !is_object($v))
 			{
 				$object .= ' ' . $k . ': ';
-				$object .= (is_numeric($v) || strpos($v, '\\') === 0) ? (is_numeric($v)) ? $v : substr($v, 1) : "'" . $v . "'";
+				$object .= (is_numeric($v) || strpos($v, '\\') === 0) ? (is_numeric($v)) ? $v : substr($v, 1) : "'" . str_replace("'", "\\'", trim($v, "'")) . "'";
 				$object .= ',';
 			}
 			else

--- a/libraries/joomla/html/tabs.php
+++ b/libraries/joomla/html/tabs.php
@@ -85,8 +85,8 @@ abstract class JHtmlTabs
 			$opt['onBackground']        = (isset($params['onBackground'])) ? '\\' . $params['onBackground'] : null;
 			$opt['display']             = (isset($params['startOffset'])) ? (int) $params['startOffset'] : null;
 			$opt['useStorage']          = (isset($params['useCookie']) && $params['useCookie']) ? 'true' : 'false';
-			$opt['titleSelector']       = "'dt.tabs'";
-			$opt['descriptionSelector'] = "'dd.tabs'";
+			$opt['titleSelector']       = "dt.tabs";
+			$opt['descriptionSelector'] = "dd.tabs";
 
 			$options = JHtml::getJSObject($opt);
 


### PR DESCRIPTION
With JHTML Tabs, the function getJSObject does not trim quote properly.
This fix would remove and strip single quotes.

Original issue :
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=29344

First pull request (with other different issues)
https://github.com/joomla/joomla-platform/pull/1549

(sorry, there is the other patch for mysql, but I don't find where exclude this file from my pull request in GitHub)
