### PR TITLE
JHTML Tabs javascript fix

### DIFF
--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -949,7 +949,7 @@ abstract class JHtml
 			elseif (!is_array($v) && !is_object($v))
 			{
 				$object .= ' ' . $k . ': ';
-				$object .= (is_numeric($v) || strpos($v, '\\') === 0) ? (is_numeric($v)) ? $v : substr($v, 1) : "'" . $v . "'";
+				$object .= (is_numeric($v) || strpos($v, '\\') === 0) ? (is_numeric($v)) ? $v : substr($v, 1) : "'" . str_replace("'", "\\'", trim($v, "'")) . "'";
 				$object .= ',';
 			}
 			else

--- a/libraries/joomla/html/tabs.php
+++ b/libraries/joomla/html/tabs.php
@@ -85,8 +85,8 @@ abstract class JHtmlTabs
 			$opt['onBackground']        = (isset($params['onBackground'])) ? '\\' . $params['onBackground'] : null;
 			$opt['display']             = (isset($params['startOffset'])) ? (int) $params['startOffset'] : null;
 			$opt['useStorage']          = (isset($params['useCookie']) && $params['useCookie']) ? 'true' : 'false';
-			$opt['titleSelector']       = "'dt.tabs'";
-			$opt['descriptionSelector'] = "'dd.tabs'";
+			$opt['titleSelector']       = "dt.tabs";
+			$opt['descriptionSelector'] = "dd.tabs";
 
 			$options = JHtml::getJSObject($opt);
 


### PR DESCRIPTION
With JHTML Tabs, the function getJSObject does not trim quote properly.
This fix would remove and strip single quotes.

Original issue :
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=29344
