### PR TITLE
Add JArrayHelper::invert

### DIFF
--- a/libraries/joomla/utilities/arrayhelper.php
+++ b/libraries/joomla/utilities/arrayhelper.php
@@ -331,6 +331,55 @@ abstract class JArrayHelper
 	}
 
 	/**
+	 * Takes an associative array of arrays and inverts the array keys to values using the array values as keys.
+	 *
+	 * Example:
+	 * $input = array(
+	 *     'New' => array('1000', '1500', '1750'),
+	 *     'Used' => array('3000', '4000', '5000', '6000')
+	 * );
+	 * $output = JArrayHelper::invert($input);
+	 *
+	 * Output would be equal to:
+	 * $output = array(
+	 *     '1000' => 'New',
+	 *     '1500' => 'New',
+	 *     '1750' => 'New',
+	 *     '3000' => 'Used',
+	 *     '4000' => 'Used',
+	 *     '5000' => 'Used',
+	 *     '6000' => 'Used'
+	 * );
+	 *
+	 * @param   array  $array  The source array.
+	 *
+	 * @return  array  The inverted array.
+	 *
+	 * @since   12.3
+	 */
+	public static function invert($array)
+	{
+		$return = array();
+		foreach ($array as $base => $values)
+		{
+			if (!is_array($values))
+			{
+				continue;
+			}
+
+			foreach ($values as $key)
+			{
+				// If the key isn't scalar then ignore it.
+				if (is_scalar($key))
+				{
+					$return[$key] = $base;
+				}
+			}
+		}
+		return $return;
+	}
+
+	/**
 	 * Method to determine if an array is an associative array.
 	 *
 	 * @param   array  $array  An array to test.

--- a/tests/suites/unit/joomla/utilities/JArrayHelperTest.php
+++ b/tests/suites/unit/joomla/utilities/JArrayHelperTest.php
@@ -373,6 +373,59 @@ class JArrayHelperTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Data provider for invert
+	 *
+	 * @return  array
+	 *
+	 * @since   12.3
+	 */
+	function getTestInvertData()
+	{
+
+		return array(
+			'Case 1' => array(
+				// Input
+				array(
+					'New' => array('1000', '1500', '1750'),
+		 			'Used' => array('3000', '4000', '5000', '6000')
+				),
+				// Expected
+				array(
+					'1000' => 'New',
+					'1500' => 'New',
+					'1750' => 'New',
+					'3000' => 'Used',
+					'4000' => 'Used',
+					'5000' => 'Used',
+					'6000' => 'Used'
+				)
+			),
+			'Case 2' => array(
+				// Input
+				array(
+					'New' => array(1000, 1500, 1750),
+					'Used' => array(2750, 3000, 4000, 5000, 6000),
+					'Refurbished' => array(2000, 2500),
+					'Unspecified' => array()
+				),
+				// Expected
+				array(
+					'1000' => 'New',
+					'1500' => 'New',
+					'1750' => 'New',
+					'2750' => 'Used',
+					'3000' => 'Used',
+					'4000' => 'Used',
+					'5000' => 'Used',
+					'6000' => 'Used',
+					'2000' => 'Refurbished',
+					'2500' => 'Refurbished'
+				)
+			)
+		);
+	}
+
+	/**
 	 * Data provider for testPivot
 	 *
 	 * @return  array
@@ -1329,6 +1382,7 @@ class JArrayHelperTest extends PHPUnit_Framework_TestCase
 			$this->equalTo($expected)
 		);
 	}
+
 	/**
 	 * Tests conversion of object to string.
 	 *
@@ -1407,6 +1461,25 @@ class JArrayHelperTest extends PHPUnit_Framework_TestCase
 		}
 
 		$this->assertEquals($expect, $output, $message);
+	}
+
+	/**
+	 * Tests the JArrayHelper::invert method.
+	 *
+	 * @param   array   $input     The array being input.
+	 * @param   string  $expected  The expected return value.
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider  getTestInvertData
+	 * @since   12.3
+	 */
+	public function testInvert($input, $expected)
+	{
+		$this->assertThat(
+			JArrayHelper::invert($input),
+			$this->equalTo($expected)
+		);
 	}
 
 	/**


### PR DESCRIPTION
This adds a new method to JArrayHelper called 'invert'. The 'invert' method provides the ability to provide an associative array of arrays and then make the values in those arrays the keys with the key from the input associative array as the value for those entries.

So if we use the following code:

``` php
$input = array(
    'New' => array('1000', '1500', '1750'),
    'Used' => array('3000', '4000', '5000', '6000')
);
$output = JArrayHelper::invert($input);
```

The result for output would be equal to:

``` php
$output = array(
    '1000' => 'New',
    '1500' => 'New',
    '1750' => 'New',
    '3000' => 'Used',
    '4000' => 'Used',
    '5000' => 'Used',
    '6000' => 'Used'
);
```

This provides a quick means of a slightly more powerful 'array_flip' method where multiple values are concerned.
