### PR TITLE
Division by 0 in JCrypt

### DIFF
--- a/libraries/joomla/crypt/crypt.php
+++ b/libraries/joomla/crypt/crypt.php
@@ -194,7 +194,7 @@ class JCrypt
 					}
 					$microEnd = microtime(true) * 1000000;
 					$entropy .= $microStart . $microEnd;
-					if ($microStart > $microEnd)
+					if ($microStart >= $microEnd)
 					{
 						$microEnd += 1000000;
 					}


### PR DESCRIPTION
We have a report of division by 0 error  [#29372]  at line 210 (https://github.com/joomla/joomla-platform/blob/staging/libraries/joomla/crypt/crypt.php#L210) .  A look at the code indicates that you would get $duration == 0 where $microStart and $microEnd are the same (and all the conditions for getting to that point are met, which would not be typical).
