### PR TITLE
Add deleted & required _unix2DOSTime method

### DIFF
--- a/libraries/joomla/archive/zip.php
+++ b/libraries/joomla/archive/zip.php
@@ -539,6 +539,33 @@ class JArchiveZip implements JArchiveExtractable
 	}
 
 	/**
+	 * Converts a UNIX timestamp to a 4-byte DOS date and time format
+	 * (date in high 2-bytes, time in low 2-bytes allowing magnitude
+	 * comparison).
+	 *
+	 * @param   int $unixtime   The current UNIX timestamp.
+	 *
+	 * @return  int The current date in a 4-byte DOS format.
+	 * @since   11.1
+	 */
+	protected function _unix2DOSTime($unixtime = null)
+	{
+		$timearray = (is_null($unixtime)) ? getdate() : getdate($unixtime);
+
+		if ($timearray['year'] < 1980)
+		{
+			$timearray['year'] = 1980;
+			$timearray['mon'] = 1;
+			$timearray['mday'] = 1;
+			$timearray['hours'] = 0;
+			$timearray['minutes'] = 0;
+			$timearray['seconds'] = 0;
+		}
+
+		return (($timearray['year'] - 1980) << 25) | ($timearray['mon'] << 21) | ($timearray['mday'] << 16) | ($timearray['hours'] << 11) | ($timearray['minutes'] << 5) | ($timearray['seconds'] >> 1);
+	}
+
+	/**
 	 * Adds a "file" to the ZIP archive.
 	 *
 	 * @param   array  &$file      File data array to add


### PR DESCRIPTION
Method _unix2DOSTime was in Platform 11.1 but does not exist actually. 

Is required by the method _addToZIPFile:

```
    // Get the hex time.
    $dtime = dechex($this->_unix2DosTime($ftime)); 
```

Was removed intentionally? If so what is the replacement? 

We have to re-add the method or replace its call.
