### PR TITLE
Improvments to getJSObject

### DIFF
--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -970,6 +970,6 @@ abstract class JHtml
 		}
 
 		return '{' . implode(',', $elements) . '}';
-		
+
 	}
 }


### PR DESCRIPTION
Resources are ignored
Object keys and strings are encoded with json_encode
If the input array contains (php) objects, their values are used for recursion rather than the objects themselves (the function takes an array, not an object)
Less string concatenation, more array implosion
