### PR TITLE
Use of undefined constant JPATH_SITE

### DIFF
--- a/libraries/joomla/filesystem/path.php
+++ b/libraries/joomla/filesystem/path.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 if (!defined('JPATH_ROOT'))
 {
 	// Define a string constant for the root directory of the file system in native format
-	define('JPATH_ROOT', JPath::clean(JPATH_SITE));
+	define('JPATH_ROOT', JPath::clean('JPATH_SITE'));
 }
 
 /**


### PR DESCRIPTION
Notice: Use of undefined constant JPATH_SITE - assumed 'JPATH_SITE' in .....\htdocs\jplateform\libraries\joomla\filesystem\path.php on line 15

emerges when testing for web application
