### PR TITLE
Set param for file to load with render method

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -307,7 +307,7 @@ class JApplicationWeb extends JApplicationBase
 		// Setup the document options.
 		$options = array(
 			'template' => $this->get('theme'),
-			'file' => 'index.php',
+			'file' => $this->get('themeFile', 'index.php'),
 			'params' => $this->get('themeParams')
 		);
 


### PR DESCRIPTION
This change to JApplicationWeb::render() allows downstream users to set a file to load using the same methods as the template and params values are set with.  For example, in the CMS, we would have to override this method to use the tmpl=component URL param.  Now, it's just another param to set.
