### PR TITLE
Loggers can be added which exclude specific categories

### DIFF
--- a/libraries/joomla/log/log.php
+++ b/libraries/joomla/log/log.php
@@ -159,12 +159,13 @@ class JLog
 	 * @param   array    $options     The object configuration array.
 	 * @param   integer  $priorities  Message priority
 	 * @param   array    $categories  Types of entry
+	 * @param   boolean  $exclude     If true, all categories will be logged except those in the $categories array
 	 *
 	 * @return  void
 	 *
 	 * @since   11.1
 	 */
-	public static function addLogger(array $options, $priorities = self::ALL, $categories = array())
+	public static function addLogger(array $options, $priorities = self::ALL, $categories = array(), $exclude = false)
 	{
 		// Automatically instantiate the singleton object if not already done.
 		if (empty(self::$instance))
@@ -204,7 +205,8 @@ class JLog
 
 		self::$instance->lookup[$signature] = (object) array(
 			'priorities' => $priorities,
-			'categories' => array_map('strtolower', (array) $categories));
+			'categories' => array_map('strtolower', (array) $categories),
+			'exclude' => (bool) $exclude);
 	}
 
 	/**
@@ -288,7 +290,8 @@ class JLog
 			{
 
 				// If either there are no set categories (meaning all) or the specific category is set, add this logger.
-				if (empty($category) || empty($rules->categories) || in_array($category, $rules->categories))
+				if (empty($category) || empty($rules->categories)
+					|| ($rules->exclude xor in_array($category, $rules->categories)))
 				{
 					$loggers[] = $signature;
 				}

--- a/tests/suites/unit/joomla/log/JLogTest.php
+++ b/tests/suites/unit/joomla/log/JLogTest.php
@@ -388,7 +388,7 @@ class JLogTest extends PHPUnit_Framework_TestCase
 
 		// Get the expected lookup array after adding the single logger.
 		$expectedLookup = array(
-			'55202c195e23298813df4292c827b241' => (object) array('priorities' => JLog::ALL, 'categories' => array())
+			'55202c195e23298813df4292c827b241' => (object) array('priorities' => JLog::ALL, 'categories' => array(), 'exclude' => false)
 		);
 
 		// Get the expected loggers array after adding the single logger (hasn't been instantiated yet so null).
@@ -426,7 +426,7 @@ class JLogTest extends PHPUnit_Framework_TestCase
 
 		// Get the expected lookup array after adding the single logger.
 		$expectedLookup = array(
-			'b67483f5ba61450d173aae527fa4163f' => (object) array('priorities' => JLog::ERROR, 'categories' => array())
+			'b67483f5ba61450d173aae527fa4163f' => (object) array('priorities' => JLog::ERROR, 'categories' => array(), 'exclude' => false)
 		);
 
 		// Get the expected loggers array after adding the single logger (hasn't been instantiated yet so null).


### PR DESCRIPTION
Suppose you want to separate your logs by category. Until now, it was only possible if you knew the names of all possible categories (which you don't). So now, let's say you want your deprecation logs in one place, your query logs in another, and all others someplace else. Then you just need to do this:

```
// Normal log files
JLog::addLogger(array('text_file' => 'deprecated'), JLog::ALL, 'deprecated');
JLog::addLogger(array('text_file' => 'databasequery'), JLog::ALL, 'databasequery');
// Excluding categories
JLog::addLogger(array('text_file' => 'others'), JLog::ALL, array('deprecated', 'databasequery'), true);
```
