### PR TITLE
Loggers can be added which exclude specific categories

### DIFF
--- a/libraries/joomla/log/log.php
+++ b/libraries/joomla/log/log.php
@@ -159,12 +159,13 @@ class JLog
 	 * @param   array    $options     The object configuration array.
 	 * @param   integer  $priorities  Message priority
 	 * @param   array    $categories  Types of entry
+	 * @param   boolean  $exclude     If true, all categories will be logged except those in the $categories array
 	 *
 	 * @return  void
 	 *
 	 * @since   11.1
 	 */
-	public static function addLogger(array $options, $priorities = self::ALL, $categories = array())
+	public static function addLogger(array $options, $priorities = self::ALL, $categories = array(), $exclude = false)
 	{
 		// Automatically instantiate the singleton object if not already done.
 		if (empty(self::$instance))
@@ -204,7 +205,8 @@ class JLog
 
 		self::$instance->lookup[$signature] = (object) array(
 			'priorities' => $priorities,
-			'categories' => array_map('strtolower', (array) $categories));
+			'categories' => array_map('strtolower', (array) $categories),
+			'exclude' => (bool) $exclude);
 	}
 
 	/**
@@ -286,11 +288,21 @@ class JLog
 			// Check to make sure the priority matches the logger.
 			if ($priority & $rules->priorities)
 			{
-
-				// If either there are no set categories (meaning all) or the specific category is set, add this logger.
-				if (empty($category) || empty($rules->categories) || in_array($category, $rules->categories))
+				if ($rules->exclude)
 				{
-					$loggers[] = $signature;
+					// If either there are no set categories or the category (including the empty case) is not in the list of excluded categories, add this logger.
+					if (empty($rules->categories) || !in_array($category, $rules->categories))
+					{
+						$loggers[] = $signature;
+					}
+				}
+				else
+				{
+					// If either there are no set categories (meaning all) or the specific category is set, add this logger.
+					if (empty($category) || empty($rules->categories) || in_array($category, $rules->categories))
+					{
+						$loggers[] = $signature;
+					}
 				}
 			}
 		}

--- a/tests/suites/unit/joomla/log/JLogTest.php
+++ b/tests/suites/unit/joomla/log/JLogTest.php
@@ -116,7 +116,7 @@ class JLogTest extends PHPUnit_Framework_TestCase
 
 		// Add a loggers to the JLog object.
 
-		// 7Note: 67d00c8f22f5859a1fd73835ee47e4d
+		// Note: 67d00c8f22f5859a1fd73835ee47e4d
 		JLog::addLogger(array('text_file' => 'deprecated.log'), JLog::ALL, 'deprecated');
 
 		// Note: 09826310049345665887853e4688d89e
@@ -182,6 +182,116 @@ class JLogTest extends PHPUnit_Framework_TestCase
 					'5099e81204381e68555c620cd8140421',
 					'b5550c1aa36c1eaf77206565ec5f9021',
 					'916ed48d2f635431a93aee60c56b0219',
+				)
+			),
+			'Line: ' . __LINE__ . '.'
+		);
+
+	}
+
+	/**
+	 * Test the JLog::findLoggers method to make sure given a category we are finding the correct loggers that
+	 * have been added to JLog (using exclusion).  It is important to note that empty category can also be excluded.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.3
+	 */
+	public function testFindLoggersByNotCategory()
+	{
+		// First let's test a set of priorities.
+		$log = new JLogInspector;
+		JLog::setInstance($log);
+
+		// Add a loggers to the JLog object.
+
+		// Note: 46c90979772c19bf707c0d8d6581cad5
+		JLog::addLogger(array('text_file' => 'not_deprecated.log'), JLog::ALL, 'deprecated', true);
+
+		// Note: 96ebc8ec99ccca7d8108232da1f35abe
+		JLog::addLogger(array('text_file' => 'not_com_foo.log'), JLog::ALL, 'com_foo', true);
+
+		// Note: 84c5af052b619356b9fdd2f5cefd90fd
+		JLog::addLogger(array('text_file' => 'not_none.log'), JLog::ALL, '', true);
+
+		// Note: 645f55d76f1d8bc00f79040d5bead8d6
+		JLog::addLogger(array('text_file' => 'not_deprecated-com_foo.log'), JLog::ALL, array('deprecated', 'com_foo'), true);
+
+		// Note: 07abacf4dc704fe78479149ad51bd044
+		JLog::addLogger(array('text_file' => 'not_foobar-deprecated.log'), JLog::ALL, array('foobar', 'deprecated'), true);
+
+		// Note: affc04af81476fbb5e19b2773a927ec6
+		JLog::addLogger(array('text_file' => 'not_transactions-paypal.log'), JLog::ALL, array('transactions', 'paypal'), true);
+
+		// Note: 1aa03749b113bc00fb030b6c5a67b6ec
+		JLog::addLogger(array('text_file' => 'not_transactions.log'), JLog::ALL, array('transactions'), true);
+
+		$this->assertThat(
+			$log->findLoggers(JLog::EMERGENCY, 'deprecated'),
+			$this->equalTo(
+				array(
+					'96ebc8ec99ccca7d8108232da1f35abe',
+					'84c5af052b619356b9fdd2f5cefd90fd',
+					'affc04af81476fbb5e19b2773a927ec6',
+					'1aa03749b113bc00fb030b6c5a67b6ec',
+				)
+			),
+			'Line: ' . __LINE__ . '.'
+		);
+
+		$this->assertThat(
+			$log->findLoggers(JLog::NOTICE, 'paypal'),
+			$this->equalTo(
+				array(
+					'46c90979772c19bf707c0d8d6581cad5',
+					'96ebc8ec99ccca7d8108232da1f35abe',
+					'84c5af052b619356b9fdd2f5cefd90fd',
+					'645f55d76f1d8bc00f79040d5bead8d6',
+					'07abacf4dc704fe78479149ad51bd044',
+					'1aa03749b113bc00fb030b6c5a67b6ec'
+				)
+			),
+			'Line: ' . __LINE__ . '.'
+		);
+
+		$this->assertThat(
+			$log->findLoggers(JLog::DEBUG, 'com_foo'),
+			$this->equalTo(
+				array(
+					'46c90979772c19bf707c0d8d6581cad5',
+					'84c5af052b619356b9fdd2f5cefd90fd',
+					'07abacf4dc704fe78479149ad51bd044',
+					'affc04af81476fbb5e19b2773a927ec6',
+					'1aa03749b113bc00fb030b6c5a67b6ec'
+				)
+			),
+			'Line: ' . __LINE__ . '.'
+		);
+
+		$this->assertThat(
+			$log->findLoggers(JLog::WARNING, 'transactions'),
+			$this->equalTo(
+				array(
+					'46c90979772c19bf707c0d8d6581cad5',
+					'96ebc8ec99ccca7d8108232da1f35abe',
+					'84c5af052b619356b9fdd2f5cefd90fd',
+					'645f55d76f1d8bc00f79040d5bead8d6',
+					'07abacf4dc704fe78479149ad51bd044'
+				)
+			),
+			'Line: ' . __LINE__ . '.'
+		);
+
+		$this->assertThat(
+			$log->findLoggers(JLog::INFO, ''),
+			$this->equalTo(
+				array(
+					'46c90979772c19bf707c0d8d6581cad5',
+					'96ebc8ec99ccca7d8108232da1f35abe',
+					'645f55d76f1d8bc00f79040d5bead8d6',
+					'07abacf4dc704fe78479149ad51bd044',
+					'affc04af81476fbb5e19b2773a927ec6',
+					'1aa03749b113bc00fb030b6c5a67b6ec'
 				)
 			),
 			'Line: ' . __LINE__ . '.'
@@ -388,7 +498,7 @@ class JLogTest extends PHPUnit_Framework_TestCase
 
 		// Get the expected lookup array after adding the single logger.
 		$expectedLookup = array(
-			'55202c195e23298813df4292c827b241' => (object) array('priorities' => JLog::ALL, 'categories' => array())
+			'55202c195e23298813df4292c827b241' => (object) array('priorities' => JLog::ALL, 'categories' => array(), 'exclude' => false)
 		);
 
 		// Get the expected loggers array after adding the single logger (hasn't been instantiated yet so null).
@@ -426,7 +536,7 @@ class JLogTest extends PHPUnit_Framework_TestCase
 
 		// Get the expected lookup array after adding the single logger.
 		$expectedLookup = array(
-			'b67483f5ba61450d173aae527fa4163f' => (object) array('priorities' => JLog::ERROR, 'categories' => array())
+			'b67483f5ba61450d173aae527fa4163f' => (object) array('priorities' => JLog::ERROR, 'categories' => array(), 'exclude' => false)
 		);
 
 		// Get the expected loggers array after adding the single logger (hasn't been instantiated yet so null).


### PR DESCRIPTION
Also, unit test for adding loggers to exclude specific categories

Suppose you want to separate your logs by category. Until now, it was only possible if you knew the names of all possible categories (which you don't). So now, let's say you want your deprecation logs in one place, your query logs in another, and all others someplace else. Then you just need to do this:

``` php
// Normal log files
JLog::addLogger(array('text_file' => 'deprecated'), JLog::ALL, 'deprecated');
JLog::addLogger(array('text_file' => 'databasequery'), JLog::ALL, 'databasequery');
// Excluding categories
JLog::addLogger(array('text_file' => 'others'), JLog::ALL, array('deprecated', 'databasequery'), true);
```
