### PR TITLE
Fixing HTML Tabs

### DIFF
--- a/libraries/joomla/html/tabs.php
+++ b/libraries/joomla/html/tabs.php
@@ -85,8 +85,8 @@ abstract class JHtmlTabs
 			$opt['onBackground']        = (isset($params['onBackground'])) ? '\\' . $params['onBackground'] : null;
 			$opt['display']             = (isset($params['startOffset'])) ? (int) $params['startOffset'] : null;
 			$opt['useStorage']          = (isset($params['useCookie']) && $params['useCookie']) ? 'true' : 'false';
-			$opt['titleSelector']       = "'dt.tabs'";
-			$opt['descriptionSelector'] = "'dd.tabs'";
+			$opt['titleSelector']       = "dt.tabs";
+			$opt['descriptionSelector'] = "dd.tabs";
 
 			$options = JHtml::getJSObject($opt);
 


### PR DESCRIPTION
Removing quotes in HTML Tabs in order to remove a javascript error.
