### PR TITLE
Simple fix on JCryptPasswordSimple class

### DIFF
--- a/libraries/joomla/crypt/password/simple.php
+++ b/libraries/joomla/crypt/password/simple.php
@@ -99,7 +99,7 @@ class JCryptPasswordSimple implements JCryptPassword
 	{
 		$bytes = ceil($length * 6 / 8);
 
-		$randomData = str_replace('+', '.', base64_encode(JCrypt::getRandomBytes($bytes)));
+		$randomData = str_replace('+', '.', base64_encode(JCrypt::genRandomBytes($bytes)));
 
 		return substr($randomData, 0, $length);
 	}


### PR DESCRIPTION
Fix error:
Fatal error: Call to undefined method JCrypt::getRandomBytes() in /var/www/jplatform/libraries/joomla/crypt/password/simple.php on line 102
