### PR TITLE
More JModelLegacyTests

### DIFF
--- a/tests/suites/legacy/model/stubs/foobar.php
+++ b/tests/suites/legacy/model/stubs/foobar.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Model
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+
+/**
+ * Stub for the testing JModelLegacy class.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Model
+ * @since       12.3
+ */
+class StubModelFoobar extends JModelLegacy
+{
+}

--- a/tests/suites/legacy/model/stubs/lead.php
+++ b/tests/suites/legacy/model/stubs/lead.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Model
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+
+/**
+ * Stub for testing the JModelLegacy class.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Model
+ * @since       12.3
+ */
+class TestModelLead extends JModelLegacy
+{
+}

--- a/tests/suites/legacy/model/stubs/name.php
+++ b/tests/suites/legacy/model/stubs/name.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Model
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+
+/**
+ * Stub for testing the JModelLegacy class.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Model
+ * @since       12.3
+ */
+class NomodelInName extends JModelLegacy
+{
+	/**
+	 * Override parent __construct, so we bypass the Exception
+	 * thrown when 'Model' is not in the class name so we can
+	 * test the getName() function fully
+	 *
+	 * @since   12.3
+	 */
+	public function __construct()
+	{
+		return;
+	}
+}

--- a/tests/suites/legacy/model/stubs/room.php
+++ b/tests/suites/legacy/model/stubs/room.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Model
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+
+/**
+ * Stub for testing the JModelLegacy class.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Model
+ * @since       12.3
+ */
+class RemodelModelRoom extends JModelLegacy
+{
+}


### PR DESCRIPTION
I've added more tests for JModelLegacy. Specifically, I added and marked as incomplete all the methods that weren't tested yet and completed the __construct test as well as furthered the code coverage of the existing tests. There were some lines of some methods that were not being tested (according to http://developer.joomla.org/coverage-legacy/model_legacy.php.html) so I thought I'd start clearing that up.
