### PR TITLE
New function: JDatabaseQuery:format() 

### DIFF
--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -1565,4 +1565,191 @@ abstract class JDatabaseQuery
 		// Apply the distinct flag to the union.
 		return $this->union($query, $distinct, $glue);
 	}
+
+	/**
+	 * Find and replace sprintf-like tokens in a format string.
+	 * Each token takes one of the following forms:
+	 *     %%       - A literal percent character.
+	 *     %[t]     - Where [t] is a type specifier.
+	 *     %[n]$[x] - Where [n] is an argument specifier and [t] is a type specifier.
+	 *
+	 * Types:
+	 * a - Numeric: Replacement text is coerced to a numeric type but not quoted or escaped.
+	 * e - Escape: Replacement text is passed to $this->escape().
+	 * E - Escape (extra): Replacement text is passed to $this->escape() with true as the second argument.
+	 * n - Name Quote: Replacement text is passed to $this->quoteName().
+	 * q - Quote: Replacement text is passed to $this->quote().
+	 * Q - Quote (no escape): Replacement text is passed to $this->quote() with false as the second argument.
+	 * r - Raw: Replacement text is used as-is. (Be careful)
+	 *
+	 * Date Types:
+	 * - Replacement text automatically quoted (use uppercase for Name Quote).
+	 * - Replacement text should be a string in date format or name of a date column.
+	 * y/Y - Year
+	 * m/M - Month
+	 * d/D - Day
+	 * h/H - Hour
+	 * i/I - Minute
+	 * s/S - Second
+	 *
+	 * Invariable Types:
+	 * - Takes no argument.
+	 * - Argument index not incremented.
+	 * t - Replacement text is the result of $this->currentTimestamp().
+	 * z - Replacement text is the result of $this->nullDate(false).
+	 * Z - Replacement text is the result of $this->nullDate(true).
+	 *
+	 * Usage:
+	 * $query->format('SELECT %1$n FROM %2$n WHERE %3$n = %4$a', 'foo', '#__foo', 'bar', 1);
+	 * Returns: SELECT `foo` FROM `#__foo` WHERE `bar` = 1
+	 *
+	 * Notes:
+	 * The argument specifier is optional but recommended for clarity.
+	 * The argument index used for unspecified tokens is incremented only when used.
+	 *
+	 * @param   string  $format  The formatting string.
+	 *
+	 * @return  string  Returns a string produced according to the formatting string.
+	 *
+	 * @since   12.3
+	 */
+	public function format($format)
+	{
+		$query = $this;
+		$args = array_slice(func_get_args(), 1);
+		array_unshift($args, null);
+
+		$i = 1;
+		$func = function ($match) use ($query, $args, &$i)
+		{
+			if (isset($match[6]) && $match[6] == '%')
+			{
+				return '%';
+			}
+
+			// No argument required, do not increment the argument index.
+			switch ($match[5])
+			{
+				case 't':
+					return $query->currentTimestamp();
+					break;
+
+				case 'z':
+					return $query->nullDate(false);
+					break;
+
+				case 'Z':
+					return $query->nullDate(true);
+					break;
+			}
+
+			// Increment the argument index only if argument specifier not provided.
+			$index = is_numeric($match[4]) ? (int) $match[4] : $i++;
+			if (!$index || !isset($args[$index]))
+			{
+				// TODO - What to do? sprintf() throws a Warning in these cases.
+				$replacement = '';
+			}
+			else
+			{
+				$replacement = $args[$index];
+			}
+
+			switch ($match[5])
+			{
+				case 'a':
+					return 0 + $replacement;
+					break;
+
+				case 'e':
+					return $query->escape($replacement);
+					break;
+
+				case 'E':
+					return $query->escape($replacement, true);
+					break;
+
+				case 'n':
+					return $query->quoteName($replacement);
+					break;
+
+				case 'q':
+					return $query->quote($replacement);
+					break;
+
+				case 'Q':
+					return $query->quote($replacement, false);
+					break;
+
+				case 'r':
+					return $replacement;
+					break;
+
+				// Dates
+
+				case 'y':
+					return $query->year($query->quote($replacement));
+					break;
+
+				case 'Y':
+					return $query->year($query->quoteName($replacement));
+					break;
+
+				case 'm':
+					return $query->month($query->quote($replacement));
+					break;
+
+				case 'M':
+					return $query->month($query->quoteName($replacement));
+					break;
+
+				case 'd':
+					return $query->day($query->quote($replacement));
+					break;
+
+				case 'D':
+					return $query->day($query->quoteName($replacement));
+					break;
+
+				case 'h':
+					return $query->hour($query->quote($replacement));
+					break;
+
+				case 'H':
+					return $query->hour($query->quoteName($replacement));
+					break;
+
+				case 'i':
+					return $query->minute($query->quote($replacement));
+					break;
+
+				case 'I':
+					return $query->minute($query->quoteName($replacement));
+					break;
+
+				case 's':
+					return $query->second($query->quote($replacement));
+					break;
+
+				case 'S':
+					return $query->second($query->quoteName($replacement));
+					break;
+			}
+
+			return '';
+		};
+
+		/**
+		 * Regexp to find an replace all tokens.
+		 * Matched fields:
+		 * 0: Full token
+		 * 1: Everything following '%'
+		 * 2: Everything following '%' unless '%'
+		 * 3: Argument specifier and '$'
+		 * 4: Argument specifier
+		 * 5: Type specifier
+		 * 6: '%' if full token is '%%'
+		 */
+		return preg_replace_callback('#%(((([\d]+)\$)?([aeEnqQryYmMdDhHiIsStzZ]))|(%))#', $func, $format);
+	}
 }

--- a/tests/suites/unit/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suites/unit/joomla/database/JDatabaseQueryTest.php
@@ -1763,4 +1763,32 @@ class JDatabaseQueryTest extends TestCase
 		);
 	}
 
+	/**
+	 * Tests the JDatabaseQuery::format method.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.3
+	 */
+	public function testFormat()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
+
+		$result = $q->format('SELECT %n FROM %n WHERE %n = %a', 'foo', '#__bar', 'id', 10);
+		$expected = 'SELECT ' . $q->qn('foo') . ' FROM ' . $q->qn('#__bar') . ' WHERE ' . $q->qn('id') . ' = 10';
+		$this->assertThat(
+			$result,
+			$this->equalTo($expected),
+			'Line: ' . __LINE__ . '.'
+		);
+
+		$result = $q->format('SELECT %n FROM %n WHERE %n = %t OR %3$n = %Z', 'id', '#__foo', 'date');
+		$expected = 'SELECT ' . $q->qn('id') . ' FROM ' . $q->qn('#__foo') . ' WHERE ' . $q->qn('date') . ' = ' . $q->currentTimestamp() . ' OR ' . $q->qn('date') . ' = ' . $q->nullDate(true);
+		$this->assertThat(
+			$result,
+			$this->equalTo($expected),
+			'Line: ' . __LINE__ . '.'
+		);
+
+	}
 }


### PR DESCRIPTION
A sprintf-like function for building queries or query fragments.

Usage:

``` php
$query->format('SELECT %1$n FROM %2$n WHERE %3$n = %4$a', 'foo', '#__foo', 'bar', 1);
```

Returns: 

``` php
'SELECT `foo` FROM `#__foo` WHERE `bar` = 1'
```

Maybe a more common use would be to make something like this:

``` php
$query = $db->getQuery(true);
$query->select($query->qn('extension_id'))
    ->from($query->qn('#__extensions'))
    ->where($query->qn('type') . ' = ' . $query->q('file'))
    ->where($query->qn('element') . ' = ' . $query->q($element));
```

Into something like this:

``` php
$query = $db->getQuery(true);
$query->select($query->qn('extension_id'))
    ->from($query->qn('#__extensions'))
    ->where($query->format('%1$n = %2$q', 'type', 'file'))
    ->where($query->format('%1$n = %2$q', 'element', $element));
```
