### PR TITLE
fixing JTable::addIncludePaths and updating unit tests

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -228,7 +228,7 @@ abstract class JTable extends JObject
 		settype($path, 'array');
 
 		// If we have new paths to add, do so.
-		if (!empty($path) && !in_array($path, self::$_includePaths))
+		if (!empty($path))
 		{
 			// Check and add each individual new path.
 			foreach ($path as $dir)
@@ -237,7 +237,10 @@ abstract class JTable extends JObject
 				$dir = trim($dir);
 
 				// Add to the front of the list so that custom paths are searched first.
-				array_unshift(self::$_includePaths, $dir);
+				if (!in_array($dir, self::$_includePaths))
+				{
+					array_unshift(self::$_includePaths, $dir);
+				}
 			}
 		}
 

--- a/tests/suites/unit/joomla/table/JTableTest.php
+++ b/tests/suites/unit/joomla/table/JTableTest.php
@@ -92,6 +92,20 @@ class JTableTest extends TestCaseDatabase
 			$this->equalTo(realpath(JPATH_PLATFORM . '/joomla/table')),
 			'The default return from addIncludePath without additional parameters should be to "JPATH_PLATFORM . /joomla/table"'
 		);
+
+		// Test that adding paths that already exist don't get re-added
+		$expected = array(
+			'/dummy/',
+			'dir/not/exist',
+			JPATH_PLATFORM . '/joomla/table'
+		);
+
+		// Add dummy paths
+		$paths = JTable::addIncludePath(array('dir/not/exist', '/dummy/'));
+		// Re-add the returned paths - these shouldn't get added again.
+		$paths = JTable::addIncludePath($paths);
+
+		$this->assertEquals($expected, $paths);
 	}
 
 	/**


### PR DESCRIPTION
When passed paths that already exist in the `$_includePaths` array, `JTable::addIncludePath` mistakenly re-adds them. This is due to the fact that before `!in_array($path, self::$_includePaths)` runs, `$path` is converted to an array. This was to facilitate the ability to pass either an array of paths or a path string to the method. However, it also caused the `in_array` function to check `$_includePaths` as a multi-dimensional array, when it is only ever a single-dimensional array. This code fixes that behavior. I've included tests as well.
