### PR TITLE
Bootstrap/Import file fixes and disable GC during test runs.

### DIFF
--- a/build/bootstrap.stub.php
+++ b/build/bootstrap.stub.php
@@ -1,22 +1,18 @@
 <?php
 /**
- * Prepares a minimalist framework for unit testing.
+ * Unit test runner bootstrap file for the Joomla Platform.  This file becomes the PHAR stub
+ * when the platform and unit test classes are built into a single deployable archive to be
+ * used in testing Joomla applications.
  *
- * Joomla is assumed to include the /unittest/ directory.
- * eg, /path/to/joomla/unittest/
+ * @package    Joomla.UnitTest
  *
- * @package     Joomla.UnitTest
- *
- * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE
- * @link        http://www.phpunit.de/manual/current/en/installation.html
+ * @copyright  Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ * @link       http://www.phpunit.de/manual/current/en/installation.html
  */
 
 // Setup the Pharsanity!
 Phar::interceptFileFuncs();
-
-// Set the Joomla execution flag.
-define('_JEXEC', 1);
 
 // Fix magic quotes.
 @ini_set('magic_quotes_runtime', 0);
@@ -71,6 +67,25 @@ require_once JPATH_PLATFORM . '/import.php';
 
 // Register the core Joomla test classes.
 JLoader::registerPrefix('Test', 'phar://' . __FILE__ . '/core');
+
+/*
+ * The following classes still depend on `JVersion` so we must load it until they are dealt with.
+ *
+ * JInstallerHelper
+ * JUpdaterCollection
+ * JUpdaterExtension
+ * JUpdate
+ * JFactory
+ */
+require_once 'phar://' . __FILE__ . '/version.php';
+
+/*
+ * The PHP garbage collector can be too aggressive in closing circular references before they are no longer needed.  This can cause
+ * segfaults during long, memory-intensive processes such as testing large test suites and collecting coverage data.  We explicitly
+ * disable garbage collection during the execution of PHPUnit processes so that we (hopefully) don't run into these issues going
+ * forwards.  This is only a problem PHP 5.3+.
+ */
+gc_disable();
 
 // End of the Phar Stub.
 __HALT_COMPILER();?>

--- a/build/changelog.php
+++ b/build/changelog.php
@@ -10,13 +10,10 @@
  *
  * php -f run.php
  *
- * @package     Joomla.Examples
- * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE
+ * @package    Joomla.Examples
+ * @copyright  Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
  */
-
-// We are a valid Joomla entry point.
-define('_JEXEC', 1);
 
 // Setup the path related constants.
 define('JPATH_BASE', dirname(__FILE__));
@@ -310,6 +307,8 @@ class Changelog extends JApplicationCli
 
 	/**
 	 * Get information about a specific pull request.
+	 *
+	 * @param   integer  $id  The GitHub pull request number.
 	 *
 	 * @return  object
 	 *

--- a/build/import.stub.php
+++ b/build/import.stub.php
@@ -1,5 +1,8 @@
 <?php
 /**
+ * Bootstrap file for the Joomla Platform.  This file becomes the PHAR stub when the platform is built
+ * into a single deployable archive to be used in Joomla applications.
+ *
  * @package    Joomla.Platform
  *
  * @copyright  Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
@@ -21,13 +24,9 @@ if (!defined('IS_WIN'))
 {
 	define('IS_WIN', ($os === 'WIN') ? true : false);
 }
-if (!defined('IS_MAC'))
-{
-	define('IS_MAC', ($os === 'MAC') ? true : false);
-}
 if (!defined('IS_UNIX'))
 {
-	define('IS_UNIX', (($os !== 'MAC') && ($os !== 'WIN')) ? true : false);
+	define('IS_UNIX', (IS_WIN === false) ? true : false);
 }
 
 // Import the platform version library if necessary.

--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -1,5 +1,8 @@
 <?php
 /**
+ * Bootstrap file for the Joomla Platform [with legacy libraries].  Including this file into your application
+ * will make Joomla Platform libraries [including legacy libraries] available for use.
+ *
  * @package    Joomla.Platform
  *
  * @copyright  Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
@@ -43,7 +46,11 @@ if (!class_exists('JLoader'))
 	require_once JPATH_PLATFORM . '/loader.php';
 }
 
-class_exists('JLoader') or die;
+// Make sure that the Joomla Platform has been successfully loaded.
+if (!class_exists('JLoader'))
+{
+	throw new RuntimeException('Joomla Platform not loaded.');
+}
 
 // Setup the autoloaders.
 JLoader::setup();
@@ -54,15 +61,15 @@ JLoader::registerPrefix('J', JPATH_PLATFORM . '/legacy');
 // Import the Joomla Factory.
 JLoader::import('joomla.factory');
 
+// Register classes for compatability with PHP 5.3
+if (version_compare(PHP_VERSION, '5.4.0', '<'))
+{
+	JLoader::register('JsonSerializable', __DIR__ . '/compat/jsonserializable.php');
+}
+
 // Register classes that don't follow one file per class naming conventions.
 JLoader::register('JText', JPATH_PLATFORM . '/joomla/language/text.php');
 JLoader::register('JRoute', JPATH_PLATFORM . '/joomla/application/route.php');
 
 // Register the folder for the moved JHtml classes
 JHtml::addIncludePath(JPATH_PLATFORM . '/legacy/html');
-
-// Register classes for compatability with PHP 5.3
-if (version_compare(PHP_VERSION, '5.4.0', '<'))
-{
-	JLoader::register('JsonSerializable', __DIR__ . '/compat/jsonserializable.php');
-}

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -1,5 +1,8 @@
 <?php
 /**
+ * Bootstrap file for the Joomla Platform.  Including this file into your application will make Joomla
+ * Platform libraries available for use.
+ *
  * @package    Joomla.Platform
  *
  * @copyright  Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
@@ -35,7 +38,11 @@ if (!class_exists('JLoader'))
 	require_once JPATH_PLATFORM . '/loader.php';
 }
 
-class_exists('JLoader') or die;
+// Make sure that the Joomla Platform has been successfully loaded.
+if (!class_exists('JLoader'))
+{
+	throw new RuntimeException('Joomla Platform not loaded.');
+}
 
 // Setup the autoloaders.
 JLoader::setup();

--- a/packager.test.xml
+++ b/packager.test.xml
@@ -4,6 +4,7 @@
 		<file localPath="lib">libraries/import.php</file>
 		<file localPath="lib">libraries/loader.php</file>
 		<file localPath="lib">libraries/platform.php</file>
+		<file localPath="">tests/version.php</file>
 		<folder recursive="true" localPath="lib/compat">libraries/compat</folder>
 		<folder recursive="true" localPath="lib/joomla">libraries/joomla</folder>
 		<folder recursive="true" localPath="lib/phpmailer">libraries/phpmailer</folder>

--- a/tests/bootstrap.legacy.php
+++ b/tests/bootstrap.legacy.php
@@ -1,9 +1,6 @@
 <?php
 /**
- * Prepares a minimalist framework for unit testing.
- *
- * Joomla is assumed to include the /unittest/ directory.
- * eg, /path/to/joomla/unittest/
+ * Unit test runner bootstrap file for the Joomla Platform [with legacy libraries].
  *
  * @package    Joomla.UnitTest
  *
@@ -11,8 +8,6 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  * @link       http://www.phpunit.de/manual/current/en/installation.html
  */
-
-define('_JEXEC', 1);
 
 // Fix magic quotes.
 @ini_set('magic_quotes_runtime', 0);
@@ -65,5 +60,25 @@ if (!defined('JPATH_THEMES'))
 // Import the platform.
 require_once JPATH_PLATFORM . '/import.legacy.php';
 
+
 // Register the core Joomla test classes.
 JLoader::registerPrefix('Test', __DIR__ . '/core');
+
+/*
+ * The following classes still depend on `JVersion` so we must load it until they are dealt with.
+ *
+ * JInstallerHelper
+ * JUpdaterCollection
+ * JUpdaterExtension
+ * JUpdate
+ * JFactory
+ */
+require_once __DIR__ . '/version.php';
+
+/*
+ * The PHP garbage collector can be too aggressive in closing circular references before they are no longer needed.  This can cause
+ * segfaults during long, memory-intensive processes such as testing large test suites and collecting coverage data.  We explicitly
+ * disable garbage collection during the execution of PHPUnit processes so that we (hopefully) don't run into these issues going
+ * forwards.  This is only a problem PHP 5.3+.
+ */
+gc_disable();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,9 +1,6 @@
 <?php
 /**
- * Prepares a minimalist framework for unit testing.
- *
- * Joomla is assumed to include the /unittest/ directory.
- * eg, /path/to/joomla/unittest/
+ * Unit test runner bootstrap file for the Joomla Platform.
  *
  * @package    Joomla.UnitTest
  *
@@ -11,8 +8,6 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  * @link       http://www.phpunit.de/manual/current/en/installation.html
  */
-
-define('_JEXEC', 1);
 
 // Fix magic quotes.
 @ini_set('magic_quotes_runtime', 0);
@@ -68,9 +63,24 @@ require_once JPATH_PLATFORM . '/import.php';
 // Register the core Joomla test classes.
 JLoader::registerPrefix('Test', __DIR__ . '/core');
 
-// Some classes still dependen on JVersion
-// until that's fixed we need to load it
+/*
+ * The following classes still depend on `JVersion` so we must load it until they are dealt with.
+ *
+ * JInstallerHelper
+ * JUpdaterCollection
+ * JUpdaterExtension
+ * JUpdate
+ * JFactory
+ */
 require_once __DIR__ . '/version.php';
 
-// We need this to test JSession
+/*
+ * The PHP garbage collector can be too aggressive in closing circular references before they are no longer needed.  This can cause
+ * segfaults during long, memory-intensive processes such as testing large test suites and collecting coverage data.  We explicitly
+ * disable garbage collection during the execution of PHPUnit processes so that we (hopefully) don't run into these issues going
+ * forwards.  This is only a problem PHP 5.3+.
+ */
+gc_disable();
+
+// We need this to test JSession for now.  We should really fix this.
 ob_start();

--- a/tests/suites/unit/joomla/language/data/language/en-GB/en-GB.localise.php
+++ b/tests/suites/unit/joomla/language/data/language/en-GB/en-GB.localise.php
@@ -6,8 +6,6 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
-
 /**
  * en-GB localise class
  *

--- a/tests/version.php
+++ b/tests/version.php
@@ -6,8 +6,6 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
-defined('_JEXEC') or die;
-
 /**
  * Version information class for the Joomla CMS.
  *


### PR DESCRIPTION
Cleaning up bootstrap/import files and adding gc_disable() to PHPUnit boostrap files to reduce the likelyhood of a PHP induced segfault during long running test suites.
