### PR TITLE
Replace use of removed getActions method

### DIFF
--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -48,7 +48,10 @@ class JFormFieldRules extends JFormField
 		$assetField = $this->element['asset_field'] ? (string) $this->element['asset_field'] : 'asset_id';
 
 		// Get the actions for the asset.
-		$actions = JAccess::getActions($component, $section);
+		$actions = JAccess::getActionsFromFile(
+			JPATH_ADMINISTRATOR . '/components/' . $component . '/access.xml',
+			"/access/section[@name='" . $section . "']/"
+		);
 
 		// Iterate over the children and add to the actions.
 		foreach ($this->element->children() as $el)

--- a/libraries/joomla/form/rule/rules.php
+++ b/libraries/joomla/form/rule/rules.php
@@ -92,7 +92,10 @@ class JFormRuleRules extends JFormRule
 		$component = $element['component'] ? (string) $element['component'] : '';
 
 		// Get the asset actions for the element.
-		$elActions = JAccess::getActions($component, $section);
+		$elActions = JAccess::getActionsFromFile(
+			JPATH_ADMINISTRATOR . '/components/' . $component . '/access.xml',
+			"/access/section[@name='" . $section . "']/"
+		);
 
 		// Iterate over the asset actions and add to the actions.
 		foreach ($elActions as $item)

--- a/libraries/joomla/html/access.php
+++ b/libraries/joomla/html/access.php
@@ -204,7 +204,10 @@ abstract class JHtmlAccess
 
 		$count++;
 
-		$actions = JAccess::getActions($component, $section);
+		$actions = JAccess::getActionsFromFile(
+			JPATH_ADMINISTRATOR . '/components/' . $component . '/access.xml',
+			"/access/section[@name='" . $section . "']/"
+		);
 
 		$html = array();
 		$html[] = '<ul class="checklist access-actions">';


### PR DESCRIPTION
JAccess::getActions() was removed as part of the 12.3 cleanup, but it was still in use in a few places.  This corrects that use.
