### PR TITLE
Added some method inside JDatabaseDriver to create database and alter character set [v2]

### DIFF
--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -1117,7 +1117,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	 *
 	 * @return  string  The query that creates database, owned by $options['user']
 	 *
-	 * @since   12.2
+	 * @since   12.3
 	 */
 	protected function getCreateDatabaseQuery($options, $utf)
 	{

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -789,7 +789,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	/**
 	 * This function return a field value as a prepared string to be used in a SQL statement.
 	 *
-	 * @param   array   $columns      Array of table's column returned by ::getTableColumns.
+	 * @param   array   &$columns     Array of table's column returned by JDatabasePostgreSQL::getTableColumns.
 	 * @param   string  $field_name   The table field's name.
 	 * @param   string  $field_value  The variable value to quote and return.
 	 *
@@ -797,7 +797,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	 *
 	 * @since   11.3
 	 */
-	public function sqlValue($columns, $field_name, $field_value)
+	protected function sqlValue(&$columns, $field_name, $field_value)
 	{
 		switch ($columns[$field_name])
 		{
@@ -816,7 +816,6 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 			case 'bigserial':
 			case 'integer':
 			case 'money':
-			case 'numeric':
 			case 'real':
 			case 'smallint':
 			case 'serial':
@@ -1094,15 +1093,15 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	}
 
 	/**
-	 * Get the query string to alter the database character set.
+	 * Return the query string to alter the database character set.
 	 *
 	 * @param   string  $dbName  The database name
 	 *
 	 * @return  string  The query that alter the database query string
 	 *
-	 * @since   12.1
+	 * @since   12.2
 	 */
-	public function getAlterDbCharacterSet( $dbName )
+	protected function getAlterDbCharacterSet($dbName)
 	{
 		$query = 'ALTER DATABASE ' . $this->quoteName($dbName) . ' SET CLIENT_ENCODING TO ' . $this->quote('UTF8');
 
@@ -1110,18 +1109,17 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	}
 
 	/**
-	 * Get the query string to create new Database in correct PostgreSQL syntax.
+	 * Return the query string to create new Database using PostgreSQL's syntax
 	 *
-	 * @param   object   $options  object coming from "initialise" function to pass user
-	 * 									and database name to database driver.
-	 * @param   boolean  $utf      True if the database supports the UTF-8 character set,
-	 * 									not used in PostgreSQL "CREATE DATABASE" query.
+	 * @param   stdClass  $options  Object used to pass user and database name to database driver.
+	 * 									This object must have "db_name" and "db_user" set.
+	 * @param   boolean   $utf      True if the database supports the UTF-8 character set.
 	 *
-	 * @return  string	The query that creates database, owned by $options['user']
+	 * @return  string  The query that creates database, owned by $options['user']
 	 *
-	 * @since   12.1
+	 * @since   12.2
 	 */
-	public function getCreateDbQuery($options, $utf)
+	protected function getCreateDatabaseQuery($options, $utf)
 	{
 		$query = 'CREATE DATABASE ' . $this->quoteName($options->db_name) . ' OWNER ' . $this->quoteName($options->db_user);
 

--- a/tests/suites/database/driver/mysql/JDatabaseMySQLTest.php
+++ b/tests/suites/database/driver/mysql/JDatabaseMySQLTest.php
@@ -21,7 +21,7 @@ class JDatabaseMysqlTest extends TestCaseDatabaseMysql
 	 *
 	 * @return  array
 	 *
-	 * @since   11.3
+	 * @since   12.3
 	 */
 	public function dataGetCreateDbQuery()
 	{

--- a/tests/suites/database/driver/mysql/JDatabaseMySQLTest.php
+++ b/tests/suites/database/driver/mysql/JDatabaseMySQLTest.php
@@ -17,6 +17,22 @@
 class JDatabaseMysqlTest extends TestCaseDatabaseMysql
 {
 	/**
+	 * Data for the getCreateDbQuery test.
+	 *
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	public function dataGetCreateDbQuery()
+	{
+		$obj = new stdClass;
+		$obj->db_user = 'testName';
+		$obj->db_name = 'testDb';
+
+		return array(array($obj, false), array($obj, true));
+	}
+
+	/**
 	 * Data for the testEscape test.
 	 *
 	 * @return  array
@@ -44,6 +60,18 @@ class JDatabaseMysqlTest extends TestCaseDatabaseMysql
 	}
 
 	/**
+	 * Test alterDbCharacterSet with null param.
+	 *
+	 * @return   void
+	 *
+	 * @expectedException RuntimeException
+	 */
+	public function testAlterDbCharacterSet()
+	{
+		self::$driver->alterDbCharacterSet(null);
+	}
+
+	/**
 	 * Tests the connected method.
 	 *
 	 * @return  void
@@ -53,6 +81,18 @@ class JDatabaseMysqlTest extends TestCaseDatabaseMysql
 	public function testConnected()
 	{
 		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	/**
+	 * Test createDatabase with null param.
+	 *
+	 * @return   void
+	 *
+	 * @expectedException RuntimeException
+	 */
+	public function testCreateDatabase()
+	{
+		self::$driver->createDatabase(null);
 	}
 
 	/**
@@ -104,6 +144,20 @@ class JDatabaseMysqlTest extends TestCaseDatabaseMysql
 	}
 
 	/**
+	 * Tests the JDatabaseMysql getAlterDbCharacterSet method.
+	 *
+	 * @return  void
+	 */
+	public function testGetAlterDbCharacterSet()
+	{
+		$expected = 'ALTER DATABASE ' . self::$driver->quoteName('test') . ' CHARACTER SET ' . self::$driver->quote('utf8');
+
+		$result = TestReflection::invoke(self::$driver, 'getAlterDbCharacterSet', 'test');
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
 	 * Test getCollation method.
 	 *
 	 * @return  void
@@ -113,6 +167,31 @@ class JDatabaseMysqlTest extends TestCaseDatabaseMysql
 	public function testGetCollation()
 	{
 		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	/**
+	 * Tests the JDatabaseMysqli getCreateDbQuery method.
+	 *
+	 * @param   stdClass  $options  Object used to pass user and database name to database driver.
+	 * 									This object must have "db_name" and "db_user" set.
+	 * @param   boolean   $utf      True if the database supports the UTF-8 character set.
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider dataGetCreateDbQuery
+	 */
+	public function testGetCreateDatabaseQuery($options, $utf)
+	{
+		$expected = 'CREATE DATABASE ' . self::$driver->quoteName($options->db_name);
+
+		if ($utf)
+		{
+			$expected .= ' CHARACTER SET ' . self::$driver->quote('utf8');
+		}
+
+		$result = TestReflection::invoke(self::$driver, 'getCreateDatabaseQuery', $options, $utf);
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
 
 	/**

--- a/tests/suites/database/driver/mysqli/JDatabaseMySQLiTest.php
+++ b/tests/suites/database/driver/mysqli/JDatabaseMySQLiTest.php
@@ -17,6 +17,22 @@
 class JDatabaseMysqliTest extends TestCaseDatabaseMysqli
 {
 	/**
+	 * Data for the getCreateDbQuery test.
+	 *
+	 * @return  array
+	 *
+	 * @since   11.3
+	 */
+	public function dataGetCreateDbQuery()
+	{
+		$obj = new stdClass;
+		$obj->db_user = 'testName';
+		$obj->db_name = 'testDb';
+
+		return array(array($obj, false), array($obj, true));
+	}
+
+	/**
 	 * Data for the testEscape test.
 	 *
 	 * @return  array
@@ -44,6 +60,18 @@ class JDatabaseMysqliTest extends TestCaseDatabaseMysqli
 	}
 
 	/**
+	 * Test alterDbCharacterSet with null param.
+	 *
+	 * @return   void
+	 *
+	 * @expectedException RuntimeException
+	 */
+	public function testAlterDbCharacterSet()
+	{
+		self::$driver->alterDbCharacterSet(null);
+	}
+
+	/**
 	 * Test connected method.
 	 *
 	 * @return  void
@@ -53,6 +81,18 @@ class JDatabaseMysqliTest extends TestCaseDatabaseMysqli
 	public function testConnected()
 	{
 		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	/**
+	 * Test createDatabase with null param.
+	 *
+	 * @return   void
+	 *
+	 * @expectedException RuntimeException
+	 */
+	public function testCreateDatabase()
+	{
+		self::$driver->createDatabase(null);
 	}
 
 	/**
@@ -101,6 +141,45 @@ class JDatabaseMysqliTest extends TestCaseDatabaseMysqli
 		$result = self::$driver->execute();
 
 		$this->assertThat(self::$driver->getAffectedRows(), $this->equalTo(4), __LINE__);
+	}
+
+	/**
+	 * Tests the JDatabaseMysqli getAlterDbCharacterSet method.
+	 *
+	 * @return  void
+	 */
+	public function testGetAlterDbCharacterSet()
+	{
+		$expected = 'ALTER DATABASE ' . self::$driver->quoteName('test') . ' CHARACTER SET ' . self::$driver->quote('utf8');
+
+		$result = TestReflection::invoke(self::$driver, 'getAlterDbCharacterSet', 'test');
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
+	}
+
+	/**
+	 * Tests the JDatabaseMysqli getCreateDbQuery method.
+	 *
+	 * @param   stdClass  $options  Object used to pass user and database name to database driver.
+	 * 									This object must have "db_name" and "db_user" set.
+	 * @param   boolean   $utf      True if the database supports the UTF-8 character set.
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider dataGetCreateDbQuery
+	 */
+	public function testGetCreateDatabaseQuery($options, $utf)
+	{
+		$expected = 'CREATE DATABASE ' . self::$driver->quoteName($options->db_name);
+
+		if ($utf)
+		{
+			$expected .= ' CHARACTER SET ' . self::$driver->quote('utf8');
+		}
+
+		$result = TestReflection::invoke(self::$driver, 'getCreateDatabaseQuery', $options, $utf);
+
+		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
 
 	/**

--- a/tests/suites/database/driver/mysqli/JDatabaseMySQLiTest.php
+++ b/tests/suites/database/driver/mysqli/JDatabaseMySQLiTest.php
@@ -21,7 +21,7 @@ class JDatabaseMysqliTest extends TestCaseDatabaseMysqli
 	 *
 	 * @return  array
 	 *
-	 * @since   11.3
+	 * @since   12.3
 	 */
 	public function dataGetCreateDbQuery()
 	{


### PR DESCRIPTION
Added two public method inside JDatabaseDriver:
- alterDbCharacterSet to change database's character set
- createDatabase to create a new database

AlterDbCharacterSet needs database name as parameter, createDatabase needs a JObject, similar to that used inside CMS' "initialise" function, and a bool to set UTF8 database's support.

They use two protected method to obtain correct query in database's
supported syntax:
- getAlterDbCharacterSet
- getCreateDatabaseQuery

Protected method inside JDatabaseDriver return query for MySQL and MySQLi syntax, this commit contain also overridden version for PostgreSQL database.

There are tests only for protected methods inside MySQL, MySQLi and PostgreSQL test classes.

[Old Pull request](https://github.com/joomla/joomla-platform/pull/1261)
