### PR TITLE
Union - updated functionality and unit test

### DIFF
--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -372,7 +372,22 @@ abstract class JDatabaseQuery
 				break;
 
 			case 'union':
+				$order = $this->order;
+
+				if($this->select)
+				{
+					$this->type = 'select';
+					$this->clear('order');
+					$query .= '(' . self::__toString($this->select) . ')';
+					$this->type = 'union';
+				}
 				$query .= (string) $this->union;
+				if ($order)
+				{
+					$this->order = $order;
+					$query .= (string) $order;
+				}
+
 				break;
 
 			case 'delete':
@@ -1513,12 +1528,7 @@ abstract class JDatabaseQuery
 	 */
 	public function union($query, $distinct = false, $glue = '')
 	{
-		// Clear any ORDER BY clause in UNION query
-		// See http://dev.mysql.com/doc/refman/5.0/en/union.html
-		if (!is_null($this->order))
-		{
-			$this->clear('order');
-		}
+		$this->type = 'union';
 
 		// Set up the DISTINCT flag, the name with parentheses, and the glue.
 		if ($distinct)

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -374,7 +374,7 @@ abstract class JDatabaseQuery
 			case 'union':
 				$order = $this->order;
 
-				if($this->select)
+				if ($this->select)
 				{
 					$this->type = 'select';
 					$this->clear('order');
@@ -382,6 +382,7 @@ abstract class JDatabaseQuery
 					$this->type = 'union';
 				}
 				$query .= (string) $this->union;
+
 				if ($order)
 				{
 					$this->order = $order;

--- a/tests/suites/unit/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suites/unit/joomla/database/JDatabaseQueryTest.php
@@ -374,6 +374,24 @@ class JDatabaseQueryTest extends TestCase
 	}
 
 	/**
+	 * Test use of union clause produces a full select
+	 *
+	 * @return void
+	 */
+	public function test__toStringFullUnion()
+	{
+		$q = new JDatabaseQueryInspector($this->dbo);
+
+		$q->select('id FROM a')->union('SELECT id FROM b');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo("(\nSELECT id FROM a)\nUNION (SELECT id FROM b)"),
+			'Tests union for correct rendering.'
+		);
+	}
+
+	/**
 	 * Test for the castAsChar method.
 	 *
 	 * @return  void
@@ -1606,13 +1624,14 @@ class JDatabaseQueryTest extends TestCase
 
 	/**
 	 * Tests the JDatabaseQuery::union method.
+	 * does not clear the order clause
 	 *
 	 * @return  void
 	 *
 	 * @covers  JDatabaseQuery::union
 	 * @since   12.1
 	 */
-	public function testUnionClear()
+	public function testUnionNotClear()
 	{
 		$this->_instance->union = null;
 		$this->_instance->order = null;
@@ -1620,8 +1639,9 @@ class JDatabaseQueryTest extends TestCase
 		$this->_instance->union('SELECT name FROM foo');
 		$this->assertThat(
 			$this->_instance->order,
-			$this->equalTo(null),
-			'Tests that ORDER BY is cleared with union.'
+			$this->logicalNot(
+				$this->equalTo(null)),
+				'Tests that ORDER BY is cleared with union.'
 		);
 	}
 

--- a/tests/suites/unit/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suites/unit/joomla/database/JDatabaseQueryTest.php
@@ -381,12 +381,18 @@ class JDatabaseQueryTest extends TestCase
 	public function test__toStringFullUnion()
 	{
 		$q = new JDatabaseQueryInspector($this->dbo);
+		$q1= new JDatabaseQueryInspector($this->dbo);
 
-		$q->select('id FROM a')->union('SELECT id FROM b');
+		$q->select($this->dbo->qn('id'));
+		$q->from($this->dbo->qn('a'));
+		$q1->select($this->dbo->qn('id'));
+		$q1->from($this->dbo->qn('b'));
+		$q->union($q1);
 
 		$this->assertThat(
 			(string) $q,
-			$this->equalTo("(\nSELECT id FROM a)\nUNION (SELECT id FROM b)"),
+			$this->equalTo('(' . PHP_EOL . 'SELECT `id`' . PHP_EOL . 'FROM `a`)' . PHP_EOL .
+						'UNION (' . PHP_EOL . 'SELECT `id`' . PHP_EOL . 'FROM `b`)'),
 			'Tests union for correct rendering.'
 		);
 	}
@@ -1624,7 +1630,7 @@ class JDatabaseQueryTest extends TestCase
 
 	/**
 	 * Tests the JDatabaseQuery::union method.
-	 * does not clear the order clause
+	 * Does not clear the order clause.
 	 *
 	 * @return  void
 	 *
@@ -1641,7 +1647,7 @@ class JDatabaseQueryTest extends TestCase
 			$this->_instance->order,
 			$this->logicalNot(
 				$this->equalTo(null)),
-				'Tests that ORDER BY is cleared with union.'
+				'Tests that ORDER BY is not cleared with union.'
 		);
 	}
 


### PR DESCRIPTION
This is an update to pull request joomla/joomla-platform#1539 and implements the changes required to make the general syntax

$q->select(a query)->union(another query)

generate correct SQL for a union query, which is not currently the case.

I've added a unit test for correct SQL in this instance, and modified the "testUnionClear" test to "testUnionNotClear", since "ORDER" can be used in this version of an SQL query.
