### PR TITLE
fix bug on stream transport http layer CMS#29565

### DIFF
--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -155,9 +155,9 @@ class JHttpTransportStream implements JHttpTransport
 		{
 			$headers = array();
 		}
-		
+
 		return $this->getResponse($headers, $content);
-		
+
 	}
 
 	/**

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -146,16 +146,18 @@ class JHttpTransportStream implements JHttpTransport
 		if (isset($metadata['wrapper_data']['headers']))
 		{
 			$headers = $metadata['wrapper_data']['headers'];
-		} 
-		else if (isset($metadata['wrapper_data']))
+		}
+		elseif (isset($metadata['wrapper_data']))
 		{
-			$headers = $metadata['wrapper_data'];			
+			$headers = $metadata['wrapper_data'];
 		}
 		else
 		{
 			$headers = array();
 		}
+		
 		return $this->getResponse($headers, $content);
+		
 	}
 
 	/**

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -143,7 +143,19 @@ class JHttpTransportStream implements JHttpTransport
 		// Close the stream.
 		fclose($stream);
 
-		return $this->getResponse($metadata['wrapper_data'], $content);
+		if (isset($metadata['wrapper_data']['headers']))
+		{
+			$headers = $metadata['wrapper_data']['headers'];
+		} 
+		else if (isset($metadata['wrapper_data']))
+		{
+			$headers = $metadata['wrapper_data'];			
+		}
+		else
+		{
+			$headers = array();
+		}
+		return $this->getResponse($headers, $content);
 	}
 
 	/**


### PR DESCRIPTION
some servers put the headers inside wrapper data of the meta data instead in the wrapper data itself.
thanks to Daniel K. from SiteGround for reporting this issue.
