### PR TITLE
Adding JMail::IsHTML and have it return $this for chaining. Includes tests.

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -359,7 +359,7 @@ class JMail extends PHPMailer
 	 *
 	 * @since   12.3
 	 */
-	public function IsHTML($ishtml = true)
+	public function isHtml($ishtml = true)
 	{
 		parent::IsHTML($ishtml);
 		return $this;

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -351,6 +351,21 @@ class JMail extends PHPMailer
 	}
 
 	/**
+	 * Sets message type to HTML
+	 *
+	 * @param   bool  $ishtml  Boolean true or false. 
+	 *
+	 * @return  JMail  Returns this object for chaining.
+	 *
+	 * @since   12.3
+	 */
+	public function IsHTML($ishtml = true)
+	{
+		parent::IsHTML($ishtml);
+		return $this;
+	}
+
+	/**
 	 * Use sendmail for sending the email
 	 *
 	 * @param   string  $sendmail  Path to sendmail [optional]

--- a/tests/suites/unit/joomla/mail/JMailTest.php
+++ b/tests/suites/unit/joomla/mail/JMailTest.php
@@ -304,7 +304,7 @@ class JMailTest extends TestCase
 	 */
 	public function testIsHTML()
 	{
-		$returnedObject = $this->object->IsHTML(false);
+		$returnedObject = $this->object->isHtml(false);
 
 		$this->assertThat('text/plain', $this->equalTo($this->object->ContentType));
 

--- a/tests/suites/unit/joomla/mail/JMailTest.php
+++ b/tests/suites/unit/joomla/mail/JMailTest.php
@@ -296,6 +296,23 @@ class JMailTest extends TestCase
 	}
 
 	/**
+	 * Tests the IsHTML method.
+	 *
+	 * @covers  JMail::IsHTML
+	 *
+	 * @return void
+	 */
+	public function testIsHTML()
+	{
+		$returnedObject = $this->object->IsHTML(false);
+
+		$this->assertThat('text/plain', $this->equalTo($this->object->ContentType));
+
+		// Test to ensure that a JMail object is being returned for chaining
+		$this->assertInstanceOf('JMail', $returnedObject);
+	}
+
+	/**
 	 * Test...
 	 *
 	 * @todo Implement testUseSendmail().


### PR DESCRIPTION
With the current implementation of JMail, you can't do something like this:

```
JFactory::getMailer()
    ->addRecipient($to)
    ->setSubject($subject)
    ->setBody($body)
    ->addAttachment($attachment)
    ->IsHTML(true)
    ->Send();
```

because `PHPMailer::IsHTML` doesn't support method chaining on the object. This PR fixes that.
