### PR TITLE
Support configurable facilities for JLogLoggerSyslog

### DIFF
--- a/libraries/joomla/log/logger/syslog.php
+++ b/libraries/joomla/log/logger/syslog.php
@@ -87,8 +87,17 @@ class JLogLoggerSyslog extends JLogLogger
 			$sysOptions = $sysOptions | LOG_PERROR;
 		}
 
+		// Default logging facility is LOG_USER for Windows compatibility.
+		$sysFacility = LOG_USER;
+
+		// If we have a facility passed in and we're not on Windows, reset it.
+		if (isset($this->options['sys_facility']) && !IS_WIN)
+		{
+			$sysFacility = $this->options['sys_facility'];
+		}
+
 		// Open the Syslog connection.
-		openlog((string) $this->options['sys_ident'], $sysOptions, LOG_USER);
+		openlog((string) $this->options['sys_ident'], $sysOptions, $sysFacility);
 	}
 
 	/**


### PR DESCRIPTION
At the moment JLogLoggerSyslog is hard coded to use the "user" log facility. For Windows this is the only log facility available to the PHP syslog command however for every other system with standard syslog support there are alternative options.

This change permits specifying other syslog facilities through a `sys_facility` option. The facilities supported are listed here:
http://us1.php.net/manual/en/function.openlog.php

An example of code which utilises this feature could look like this:

``` php
// Set up syslog
JLog::addLogger(
    array(
        'logger' => 'syslog',
        'sys_ident' => 'jplatform_app',
        'sys_facility' => LOG_LOCAL7
    ),
    JLog::ERROR,
    array('databasequery')
);
```

That example logs to `LOCAL7` any database query error with a custom identifier.
