### PR TITLE
Add a defaultType property to JCryptPassword

### DIFF
--- a/libraries/joomla/crypt/password.php
+++ b/libraries/joomla/crypt/password.php
@@ -30,13 +30,13 @@ interface JCryptPassword
 	 * Creates a password hash
 	 *
 	 * @param   string  $password  The password to hash.
-	 * @param   string  $prefix    The prefix of the hashing function.
+	 * @param   string  $type      The type of hash. This determines the prefix of the hashing function.
 	 *
 	 * @return  string  The hashed password.
 	 *
 	 * @since   12.2
 	 */
-	public function create($password, $prefix = '$2a$');
+	public function create($password, $type = null);
 
 	/**
 	 * Verifies a password hash
@@ -49,4 +49,24 @@ interface JCryptPassword
 	 * @since   12.2
 	 */
 	public function verify($password, $hash);
+
+	/**
+	 * Sets a default prefix
+	 *
+	 * @param   string  $prefix  The prefix to set as default
+	 *
+	 * @return  void
+	 *
+	 * @since   12.3
+	 */
+	public function setDefaultType($type);
+
+	/**
+	 * Gets the default type
+	 *
+	 * @return  void
+	 *
+	 * @since   12.3
+	 */
+	public function getDefaultType();
 }

--- a/libraries/joomla/crypt/password/simple.php
+++ b/libraries/joomla/crypt/password/simple.php
@@ -25,6 +25,12 @@ class JCryptPasswordSimple implements JCryptPassword
 	protected $cost = 10;
 
 	/**
+	 * @var    string   The default hash type
+	 * @since  12.3
+	 */
+	 protected $defaultType = '$2y$';
+
+	/**
 	 * Creates a password hash
 	 *
 	 * @param   string  $password  The password to hash.
@@ -34,23 +40,28 @@ class JCryptPasswordSimple implements JCryptPassword
 	 *
 	 * @since   12.2
 	 */
-	public function create($password, $type = JCryptPassword::BLOWFISH)
+	public function create($password, $type = null)
 	{
+		if (empty($type))
+		{
+			$type = $this->defaultType;
+		}
 		switch ($type)
 		{
+			case '$2a$':
 			case JCryptPassword::BLOWFISH:
 				$salt = $this->getSalt(22);
 
 				if (version_compare(PHP_VERSION, '5.3.7') >= 0)
 				{
-					$prefix = '$2y$';
+					$type = '$2y$';
 				}
 				else
 				{
-					$prefix = '$2a$';
+					$type = '$2a$';
 				}
 
-				$salt = $prefix . str_pad($this->cost, 2, '0', STR_PAD_LEFT) . '$' . $this->getSalt(22);
+				$salt = $type . str_pad($this->cost, 2, '0', STR_PAD_LEFT) . '$' . $this->getSalt(22);
 
 			return crypt($password, $salt);
 
@@ -121,13 +132,13 @@ class JCryptPasswordSimple implements JCryptPassword
 		{
 			if (version_compare(PHP_VERSION, '5.3.7') >= 0)
 			{
-				$prefix = '$2y$';
+				$type = '$2y$';
 			}
 			else
 			{
-				$prefix = '$2a$';
+				$type = '$2a$';
 			}
-			$hash = $prefix . substr($hash, 4);
+			$hash = $type . substr($hash, 4);
 
 			return (crypt($password, $hash) === $hash);
 		}
@@ -144,5 +155,31 @@ class JCryptPasswordSimple implements JCryptPassword
 			return md5($password . substr($hash, 33)) == substr($hash, 0, 32);
 		}
 		return false;
+	}
+
+	/**
+	 * Sets a default type
+	 *
+	 * @param   string  $type  The value to set as default.
+	 *
+	 * @since   12.3
+	 */
+	public function setDefaultType($type)
+	{
+		if (!empty($type))
+		{
+			$this->defaultType = $type;
+		}
+	}
+	/**
+	 * Gets the default type
+	 *
+	 * @return   string  $type  The default type
+	 *
+	 * @since   12.3
+	 */
+	public function getDefaultType()
+	{
+		return $this->defaultType;
 	}
 }

--- a/tests/suites/unit/joomla/crypt/JCryptTest.php
+++ b/tests/suites/unit/joomla/crypt/JCryptTest.php
@@ -119,8 +119,8 @@ class JCryptTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testGenRandomBytes()
 	{
-		// We're just testing wether the value has the expected length,
-		// we obviously can't test the result since it's random.
+		// We're just testing wether the value has the expected length.
+		// We obviously can't test the result since it's random.
 
 		$randomBytes16 = JCrypt::genRandomBytes();
 		$this->assertEquals(strlen($randomBytes16), 16);

--- a/tests/suites/unit/joomla/crypt/password/JCryptPasswordSimpleTest.php
+++ b/tests/suites/unit/joomla/crypt/password/JCryptPasswordSimpleTest.php
@@ -19,6 +19,7 @@ class JCryptPasswordSimpleTest extends PHPUnit_Framework_TestCase
 {
 	/**
 	 * Data provider for testCreate method.
+	 *
 	 * @param   string   $password  The password to create
 	 * @param   string   $type      The type of hash
 	 * @param   string   $salt      The salt to be used
@@ -34,7 +35,7 @@ class JCryptPasswordSimpleTest extends PHPUnit_Framework_TestCase
 			'Blowfish2' => array('password', '$2a$', 'ABCDEFGHIJKLMNOPQRSTUV', '$2y$10$ABCDEFGHIJKLMNOPQRSTUOiAi7OcdE4zRCh6NcGWusEcNPtq6/w8.'),
 			'MD5' => array('password', JCryptPassword::MD5, 'ABCDEFGHIJKL', '$1$ABCDEFGH$hGGndps75hhROKqu/zh9q1'),
 			'Joomla' => array('password', JCryptPassword::JOOMLA, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ123456', '883a96d8da5440781fe7b60f1d4ae2b3:ABCDEFGHIJKLMNOPQRSTUVWXYZ123456'),
-			'Blowfish_5' => array('password', JCryptPassword::BLOWFISH, 'ABCDEFGHIJKLMNOPQRSTUV', '$2y$05$ABCDEFGHIJKLMNOPQRSTUOvv7EU5o68GAoLxyfugvULZR70IIMZqW',5),
+			'Blowfish_5' => array('password', JCryptPassword::BLOWFISH, 'ABCDEFGHIJKLMNOPQRSTUV', '$2y$05$ABCDEFGHIJKLMNOPQRSTUOvv7EU5o68GAoLxyfugvULZR70IIMZqW', 5),
 			'default' => array('password', null, 'ABCDEFGHIJKLMNOPQRSTUV', '$2y$05$ABCDEFGHIJKLMNOPQRSTUOvv7EU5o68GAoLxyfugvULZR70IIMZqW', 5)
 		);
 	}
@@ -79,7 +80,8 @@ class JCryptPasswordSimpleTest extends PHPUnit_Framework_TestCase
 		$hasher->expects($this->any())
 			->method('getSalt')
 			->with(strlen($salt))
-			->will($this->returnValue($salt));
+			->will($this->returnValue($salt)
+		);
 
 		$this->assertEquals(
 			$expected,
@@ -105,7 +107,8 @@ class JCryptPasswordSimpleTest extends PHPUnit_Framework_TestCase
 		$hasher->expects($this->any())
 			->method('getSalt')
 			->with(strlen($salt))
-			->will($this->returnValue($salt));
+			->will($this->returnValue($salt)
+		);
 
 		$this->assertEquals(
 			$expected,
@@ -187,8 +190,9 @@ class JCryptPasswordSimpleTest extends PHPUnit_Framework_TestCase
 		$test = new JCryptPasswordSimple;
 		$test->setDefaultType($type);
 		$this->assertThat(
-		TestReflection::getValue($test, 'defaultType'),
-		$this->equalTo($expectation));
+			TestReflection::getValue($test, 'defaultType'),
+			$this->equalTo($expectation)
+		);
 	}
 
 	/**
@@ -209,7 +213,8 @@ class JCryptPasswordSimpleTest extends PHPUnit_Framework_TestCase
 		$test->setDefaultType($type);
 
 		$this->assertThat(
-		$test->getDefaultType(),
-		$this->equalTo($expectation));
+			$test->getDefaultType(),
+			$this->equalTo($expectation)
+		);
 	}
 }

--- a/tests/suites/unit/joomla/crypt/password/JCryptPasswordSimpleTest.php
+++ b/tests/suites/unit/joomla/crypt/password/JCryptPasswordSimpleTest.php
@@ -7,8 +7,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
-require_once JPATH_PLATFORM . '/joomla/crypt/password.php';
-require_once JPATH_PLATFORM . '/joomla/crypt/password/simple.php';
 
 /**
  * Test class for JCryptPasswordSimple.
@@ -21,6 +19,11 @@ class JCryptPasswordSimpleTest extends PHPUnit_Framework_TestCase
 {
 	/**
 	 * Data provider for testCreate method.
+	 * @param   string   $password  The password to create
+	 * @param   string   $type      The type of hash
+	 * @param   string   $salt      The salt to be used
+	 * @param   string   $expected  The expected result
+	 * @param   integer  $cost      The cost value
 	 *
 	 * @return array
 	 */
@@ -28,26 +31,70 @@ class JCryptPasswordSimpleTest extends PHPUnit_Framework_TestCase
 	{
 		return array(
 			'Blowfish' => array('password', JCryptPassword::BLOWFISH, 'ABCDEFGHIJKLMNOPQRSTUV', '$2y$10$ABCDEFGHIJKLMNOPQRSTUOiAi7OcdE4zRCh6NcGWusEcNPtq6/w8.'),
+			'Blowfish2' => array('password', '$2a$', 'ABCDEFGHIJKLMNOPQRSTUV', '$2y$10$ABCDEFGHIJKLMNOPQRSTUOiAi7OcdE4zRCh6NcGWusEcNPtq6/w8.'),
 			'MD5' => array('password', JCryptPassword::MD5, 'ABCDEFGHIJKL', '$1$ABCDEFGH$hGGndps75hhROKqu/zh9q1'),
 			'Joomla' => array('password', JCryptPassword::JOOMLA, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ123456', '883a96d8da5440781fe7b60f1d4ae2b3:ABCDEFGHIJKLMNOPQRSTUVWXYZ123456'),
-			'Blowfish_5' => array('password', JCryptPassword::BLOWFISH, 'ABCDEFGHIJKLMNOPQRSTUV', '$2y$05$ABCDEFGHIJKLMNOPQRSTUOvv7EU5o68GAoLxyfugvULZR70IIMZqW', 5)
+			'Blowfish_5' => array('password', JCryptPassword::BLOWFISH, 'ABCDEFGHIJKLMNOPQRSTUV', '$2y$05$ABCDEFGHIJKLMNOPQRSTUOvv7EU5o68GAoLxyfugvULZR70IIMZqW',5),
+			'default' => array('password', null, 'ABCDEFGHIJKLMNOPQRSTUV', '$2y$05$ABCDEFGHIJKLMNOPQRSTUOvv7EU5o68GAoLxyfugvULZR70IIMZqW', 5)
 		);
 	}
 
 	/**
-	 * Tests create method.
+	 * Data provider for testCreateException method.
 	 *
-	 * @param   string  $password  @todo
-	 * @param   string  $type      @todo
-	 * @param   string  $salt      @todo
-	 * @param   string  $expected  @todo
-	 * @param   int     $cost      @todo
+	 * @return  array
+	 *
+	 * @since   12.3
+	 */
+	public function createExceptionData()
+	{
+		return array(
+			'Bogus' => array('password', 'abc', 'ABCDEFGHIJKLMNOPQRSTUV', '$2y$10$ABCDEFGHIJKLMNOPQRSTUOiAi7OcdE4zRCh6NcGWusEcNPtq6/w8.', 10),
+		);
+	}
+
+	/**
+	 * Tests create method for expected exception
+	 *
+	 * @param   string   $password  The password to create
+	 * @param   string   $type      The type of hash
+	 * @param   string   $salt      The salt to be used
+	 * @param   string   $expected  The expected result
+	 * @param   integer  $cost      The cost value
 	 *
 	 * @covers  JCryptPasswordSimple::create
 	 *
-	 * @dataProvider  createData
+	 * @expectedException  InvalidArgumentException
 	 *
 	 * @return void
+	 * @dataProvider  createExceptionData
+	 *
+	 * @since    12.3
+	 */
+	public function testCreateException($password, $type, $salt, $expected, $cost)
+	{
+		$hasher = $this->getMock('JCryptPasswordSimple', array('getSalt'));
+		$hasher->setCost($cost);
+
+		$hasher->expects($this->any())
+			->method('getSalt')
+			->with(strlen($salt))
+			->will($this->returnValue($salt));
+
+		$this->assertEquals(
+			$expected,
+			$hasher->create($password, $type)
+		);
+
+	}
+
+	/**
+	 * Tests the JCryptPasswordSimple::Create method.
+	 *
+	 * @return        void
+	 * @dataProvider  createData
+	 *
+	 * @since   11.3
 	 */
 	public function testCreate($password, $type, $salt, $expected, $cost = 10)
 	{
@@ -69,6 +116,10 @@ class JCryptPasswordSimpleTest extends PHPUnit_Framework_TestCase
 	/**
 	 * Data Provider for testVerify.
 	 *
+	 * @param   string   $password  The password to create
+	 * @param   string   $hash      The hash to use
+	 * @param   string   $expected  The expected result
+	 *
 	 * @return array
 	 */
 	public function verifyData()
@@ -86,9 +137,9 @@ class JCryptPasswordSimpleTest extends PHPUnit_Framework_TestCase
 	/**
 	 * Tests the verify method.
 	 *
-	 * @param   string  $password     @todo
-	 * @param   string  $hash         @todo
-	 * @param   string  $expectation  @todo
+	 * @param   string  $password     The password to verify
+	 * @param   string  $hash         The hash
+	 * @param   string  $expectation  The expected result
 	 *
 	 * @covers        JCryptPasswordSimple::verify
 	 * @dataProvider  verifyData
@@ -100,5 +151,65 @@ class JCryptPasswordSimpleTest extends PHPUnit_Framework_TestCase
 		$hasher = new JCryptPasswordSimple;
 
 		$this->assertEquals($hasher->verify($password, $hash), $expectation);
+	}
+
+	/**
+	 * Data Provider for testDefaultType
+	 * 
+	 * @param   string   $type         The default to type of hash to be set
+	 * @param   string   $expectation  The expected result
+	 *
+	 * @return array
+	 * @since   12.3
+	 */
+	public function defaultTypeData()
+	{
+		return array(
+			'Joomla' => array('Joomla','Joomla'),
+			'Null' => array('','$2y$'),
+		);
+	}
+
+	/**
+	 * Tests the setDefaultType method.
+	 *
+	 * @param   string  $type         The proposed default type
+	 * @param   string  $expectation  The expected value of $this->defaultType
+	 *
+	 * @covers        JCryptPasswordSimple::setDefaultType
+	 * @dataProvider  defaultTypeData
+	 *
+	 * @return void
+	 * @since   12.3
+	 */
+	public function testSetDefaultType($type, $expectation)
+	{
+		$test = new JCryptPasswordSimple;
+		$test->setDefaultType($type);
+		$this->assertThat(
+		TestReflection::getValue($test, 'defaultType'),
+		$this->equalTo($expectation));
+	}
+
+	/**
+	 * Tests the getDefaultType method.
+	 *
+	 * @param   string  $type         The proposed default type
+	 * @param   string  $expectation  The expected value of $this->defaultType
+	 *
+	 * @covers        JCryptPasswordSimple::getDefaultType
+	 * @dataProvider  defaultTypeData
+	 *
+	 * @return void
+	 * @since   12.3
+	 */
+	public function testGetDefaultType($type, $expectation)
+	{
+		$test = new JCryptPasswordSimple;
+		$test->setDefaultType($type);
+
+		$this->assertThat(
+		$test->getDefaultType(),
+		$this->equalTo($expectation));
 	}
 }


### PR DESCRIPTION
Add a default hash type property to JCryptPassword and implement it in JCryptPasswordSimple.

Previously the default was always $2a$ (Blowfish), but with the the application can set (and get) a default. In the absence of a default being set Blowfish is used. 

This pull request also cleans up some small issue elsewhere in the class that emerged when testing and makes the argument name consistent in the interface and implementations to make it more readable.
