### PR TITLE
Remove patch method from JGithubHttp

### DIFF
--- a/libraries/joomla/github/http.php
+++ b/libraries/joomla/github/http.php
@@ -55,20 +55,4 @@ class JGithubHttp extends JHttp
 		// Set the default timeout to 120 seconds.
 		$this->options->def('timeout', 120);
 	}
-
-	/**
-	 * Method to send the PATCH command to the server.
-	 *
-	 * @param   string  $url      Path to the resource.
-	 * @param   mixed   $data     Either an associative array or a string to be sent with the request.
-	 * @param   array   $headers  An array of name-value pairs to include in the header of the request.
-	 *
-	 * @return  JHttpResponse
-	 *
-	 * @since   11.3
-	 */
-	public function patch($url, $data, array $headers = null)
-	{
-		return $this->transport->request('PATCH', new JUri($url), $data, $headers);
-	}
 }

--- a/tests/suites/unit/joomla/github/JGithubHttpTest.php
+++ b/tests/suites/unit/joomla/github/JGithubHttpTest.php
@@ -33,7 +33,7 @@ class JGithubHttpTest extends PHPUnit_Framework_TestCase
 	protected $transport;
 
 	/**
-	 * @var    JGithubIssues  Object under test.
+	 * @var    JGithubHttp  Object under test.
 	 * @since  11.4
 	 */
 	protected $object;
@@ -42,9 +42,9 @@ class JGithubHttpTest extends PHPUnit_Framework_TestCase
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 *
-	 * @access protected
+	 * @return  void
 	 *
-	 * @return void
+	 * @since   11.4
 	 */
 	protected function setUp()
 	{
@@ -58,31 +58,32 @@ class JGithubHttpTest extends PHPUnit_Framework_TestCase
 	 * Tears down the fixture, for example, closes a network connection.
 	 * This method is called after a test is executed.
 	 *
-	 * @access protected
+	 * @return  void
 	 *
-	 * @return void
+	 * @since   11.4
 	 */
 	protected function tearDown()
 	{
 	}
 
 	/**
-	 * Tests the patch method
+	 * Tests the __construct method
 	 *
-	 * @return void
+	 * @return  void
+	 *
+	 * @since   12.3
 	 */
-	public function testPatch()
+	public function test__Construct()
 	{
-		$uri = new JUri('https://example.com/gettest');
-
-		$this->transport->expects($this->once())
-			->method('request')
-			->with('PATCH', $uri, array())
-			->will($this->returnValue('requestResponse'));
+		// Verify the options are set in the object
+		$this->assertThat(
+			$this->object->getOption('userAgent'),
+			$this->equalTo('JGitHub/2.0')
+		);
 
 		$this->assertThat(
-			$this->object->patch('https://example.com/gettest', array()),
-			$this->equalTo('requestResponse')
+			$this->object->getOption('timeout'),
+			$this->equalTo(120)
 		);
 	}
 }


### PR DESCRIPTION
The patch method was added in to the parent JHttp class, making the method in the child JGithubHttp class no longer necessary.  Additionally, since the methods have different declarations, this causes a E_STRICT error.

Since the method is only used in the GitHub package, I've opted to totally remove the method instead of deprecating it.  Essentially, this leaves no need for the child class at this time, but I've left it for the time being.
