### PR TITLE
Use include_once

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -332,7 +332,7 @@ abstract class JLoader
 			// Load the file if it exists.
 			if (file_exists($path))
 			{
-				return include $path;
+				return include_once $path;
 			}
 		}
 	}


### PR DESCRIPTION
I have found a bug recently, we were trying to autoload JHtmlGrid.
- We tried to autoload class JHtmlGrid
- Joomla autloader loaded libraries/joomla/html/grid.php (class in that file is JGrid)
- then JHtml tried to autoload the same class
- again the same file was included (as class expected in file was not there, so class_exists check failed)

So I propose here that for autoloading purpose, one file should be loaded once.
Added the same change here.
