### PR TITLE
Adding _e method to compliment commonly echo'd class underscore methods

### DIFF
--- a/libraries/joomla/application/route.php
+++ b/libraries/joomla/application/route.php
@@ -105,4 +105,24 @@ class JRoute
 
 		return $url;
 	}
+
+	/**
+	 * Translates an internal Joomla URL to a humanly readible URL, and echo's it back.
+	 *
+	 * @param   string   $url    Absolute or Relative URI to Joomla resource.
+	 * @param   boolean  $xhtml  Replace & by &amp; for XML compilance.
+	 * @param   integer  $ssl    Secure state for the resolved URI.
+	 *                             1: Make URI secure using global secure site URI.
+	 *                             0: Leave URI in the same secure state as it was passed to the function.
+	 *                            -1: Make URI unsecure using the global unsecure site URI.
+	 *
+	 * @return  The translated humanly readible URL.
+	 *
+	 * @see     JRoute::_()
+	 * @since   12.3
+	 */
+	public static function _e($url, $xhtml = true, $ssl = null)
+	{
+		echo self::_($url, $xhtml, $ssl);
+	}
 }

--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -145,6 +145,24 @@ abstract class JHtml
 	}
 
 	/**
+	 * Class loader method that echo's back the returned value from the class.
+	 *
+	 * @param   string  $key  The name of helper method to load, (prefix).(class).function
+	 *                        prefix and class are optional and can be used to load custom
+	 *                        html helpers.
+	 *
+	 * @return  mixed  JHtml::call($function, $args) or False on error
+	 *
+	 * @see     JHtml::_()
+	 * @since   12.3
+	 * @throws  InvalidArgumentException
+	 */
+	public static function _e($key)
+	{
+		echo self::call(array('JHtml', '_'), func_get_args());
+	}
+
+	/**
 	 * Registers a function to be called with a specific key
 	 *
 	 * @param   string  $key       The name of the key

--- a/libraries/joomla/language/text.php
+++ b/libraries/joomla/language/text.php
@@ -79,6 +79,24 @@ class JText
 	}
 
 	/**
+	 * Translates a string into the current language, and echo's it back.
+	 *
+	 * @param   string   $string                The string to translate.
+	 * @param   mixed    $jsSafe                Boolean: Make the result javascript safe.
+	 * @param   boolean  $interpretBackSlashes  To interpret backslashes (\\=\, \n=carriage return, \t=tabulation)
+	 * @param   boolean  $script                To indicate that the string will be push in the javascript language store
+	 *
+	 * @return  string  The translated string or the key is $script is true
+	 *
+	 * @see     JText::_()
+	 * @since   12.3
+	 */
+	public static function _e($string, $jsSafe = false, $interpretBackSlashes = true, $script = false)
+	{
+		echo self::_($string, $jsSafe, $interpretBackSlashes, $script);
+	}
+
+	/**
 	 * Translates a string into the current language.
 	 *
 	 * Examples:


### PR DESCRIPTION
The static underscore methods of `JHtml`, `JRoute` and `JText` are (IMHO) preceded by the `echo` command more often than not.

This PR adds some syntatic sugar to those underscore methods, making it nicer for developers. If implemented, you would replace calls like this:

```
echo JHtml::_('tabs.start', 'tab_id', $options);
// would become
JHtml::_e('tabs.start', 'tab_id', $options);

echo JRoute::_('index.php?option=com_content');
// would become
JRoute::_e('index.php?option=com_content');

echo JText::_('JDEFAULT');
// would become
JText::_e('JDEFAULT');
```

This isn't a huge change, but I think it's a nice addition, and something that I would use extensively.
