### PR TITLE
Fix some methods in JTableNested when alias field does not exist.

### DIFF
--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -430,6 +430,7 @@ class JTableNested extends JTable
 		/*
 		 * Create space in the nested sets at the new location for the moved sub-tree.
 		 */
+
 		// Shift left values.
 		$query = $this->_db->getQuery(true);
 		$query->update($this->_tbl)
@@ -473,11 +474,14 @@ class JTableNested extends JTable
 			$query->update($this->_tbl);
 
 			// Update the title and alias fields if they exist for the table.
+			$fields = $this->getFields();
+
 			if (property_exists($this, 'title') && $this->title !== null)
 			{
 				$query->set('title = ' . $this->_db->Quote($this->title));
 			}
-			if (property_exists($this, 'alias') && $this->alias !== null)
+
+			if (array_key_exists('alias', $fields)  && $this->alias !== null)
 			{
 				$query->set('alias = ' . $this->_db->Quote($this->alias));
 			}
@@ -1186,7 +1190,9 @@ class JTableNested extends JTable
 			return $result[0];
 		}
 
-		if (property_exists($this, 'alias'))
+		$fields = $this->getFields();
+
+		if (array_key_exists('alias', $fields))
 		{
 			// Test for a unique record alias = root
 			$query = $this->_db->getQuery(true);
@@ -1311,8 +1317,10 @@ class JTableNested extends JTable
 	 */
 	public function rebuildPath($pk = null)
 	{
+		$fields = $this->getFields();
+
 		// If there is no alias or path field, just return true.
-		if (!property_exists($this, 'alias') || !property_exists($this, 'path'))
+		if (!array_key_exists('alias', $fields) || !array_key_exists('path', $fields))
 		{
 			return true;
 		}


### PR DESCRIPTION
The alias property always exists in JTableNested (it is explicit in the class definition) so the property_exists test will always return true. (In contrast the path and title properties only exist if the table includes those fields.)  If an alias field does not exist, this will result in errors when it is referred to by name such as in the query in getRootId().  This change instead checks for the presence of a field called alias. 
