### PR TITLE
Fix E_STRICT error with child method declarations from JTable::_getAssetParentId()

### DIFF
--- a/libraries/legacy/table/category.php
+++ b/libraries/legacy/table/category.php
@@ -70,7 +70,7 @@ class JTableCategory extends JTableNested
 	 *
 	 * @since   11.1
 	 */
-	protected function _getAssetParentId($table = null, $id = null)
+	protected function _getAssetParentId(JTable $table = null, $id = null)
 	{
 		$assetId = null;
 

--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -68,7 +68,7 @@ class JTableContent extends JTable
 	 *
 	 * @since   11.1
 	 */
-	protected function _getAssetParentId($table = null, $id = null)
+	protected function _getAssetParentId(JTable $table = null, $id = null)
 	{
 		$assetId = null;
 


### PR DESCRIPTION
Resolves an E_STRICT error:  Declaration of JTableCategory::_getAssetParentId() should be compatible with that of JTable::_getAssetParentId()
