### PR TITLE
Cleaning up structure of JPathway Tests

### DIFF
--- a/tests/suites/legacy/pathway/JPathwayInspector.php
+++ b/tests/suites/legacy/pathway/JPathwayInspector.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Pathway
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * General inspector class for JPathway.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Pathway
+ *
+ * @since       12.3
+ */
+class JPathwayInspector extends JPathway
+{
+	/**
+	 * Method for inspecting protected variables.
+	 *
+	 * @param   string  $name  The name of the class property.
+	 *
+	 * @return  mixed   The value of the class variable.
+	 */
+	public function __get($name)
+	{
+		if (property_exists($this, $name))
+		{
+			return $this->$name;
+		}
+		else
+		{
+			trigger_error('Undefined or private property: ' . __CLASS__ . '::' . $name, E_USER_ERROR);
+
+			return null;
+		}
+	}
+
+	/**
+	 * Sets any property from the class.
+	 *
+	 * @param   string  $property  The name of the class property.
+	 * @param   string  $value     The value of the class property.
+	 *
+	 * @return  void
+	 */
+	public function __set($property, $value)
+	{
+		$this->$property = $value;
+	}
+
+	/**
+	 * Calls any inaccessible method from the class.
+	 *
+	 * @param   string  $name        Name of the method to invoke
+	 * @param   array   $parameters  Parameters to be handed over to the original method
+	 *
+	 * @return  mixed   The return value of the method
+	 */
+	public function __call($name, $parameters = false)
+	{
+		return call_user_func_array(array($this, $name), $parameters);
+	}
+}

--- a/tests/suites/legacy/pathway/JPathwayTest.php
+++ b/tests/suites/legacy/pathway/JPathwayTest.php
@@ -7,63 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
-/**
- * General inspector class for JPathway.
- *
- * @package     Joomla.UnitTest
- * @subpackage  Pathway
- *
- * @since       12.3
- */
-class JPathwayInspector extends JPathway
-{
-	/**
-	 * Method for inspecting protected variables.
-	 *
-	 * @param   string  $name  The name of the class property.
-	 *
-	 * @return  mixed   The value of the class variable.
-	 */
-	public function __get($name)
-	{
-		if (property_exists($this, $name))
-		{
-			return $this->$name;
-		}
-		else
-		{
-			trigger_error('Undefined or private property: ' . __CLASS__ . '::' . $name, E_USER_ERROR);
-
-			return null;
-		}
-	}
-
-	/**
-	 * Sets any property from the class.
-	 *
-	 * @param   string  $property  The name of the class property.
-	 * @param   string  $value     The value of the class property.
-	 *
-	 * @return  void
-	 */
-	public function __set($property, $value)
-	{
-		$this->$property = $value;
-	}
-
-	/**
-	 * Calls any inaccessible method from the class.
-	 *
-	 * @param   string  $name        Name of the method to invoke
-	 * @param   array   $parameters  Parameters to be handed over to the original method
-	 *
-	 * @return  mixed   The return value of the method
-	 */
-	public function __call($name, $parameters = false)
-	{
-		return call_user_func_array(array($this, $name), $parameters);
-	}
-}
+require_once __DIR__ . '/JPathwayInspector.php';
 
 /**
  * Test class for JPathway.
@@ -76,15 +20,38 @@ class JPathwayInspector extends JPathway
 class JPathwayTest extends TestCase
 {
 	/**
+	 * Set up the tests
+	 *
+	 * @return  void
+	 */
+	protected function setUp()
+	{
+		$this->fixture = new JPathwayInspector;
+
+		parent::setUp();
+	}
+
+	/**
+	 * Tear down the tests
+	 *
+	 * @return  void
+	 */
+	protected function tearDown()
+	{
+		unset($this->fixture);
+
+		parent::tearDown();
+	}
+
+	/**
 	 * Test JPathway::__construct().
 	 *
 	 * @return  void
 	 */
 	public function test__construct()
 	{
-		$class = new JPathwayInspector;
 		$this->assertThat(
-			$class->_pathway,
+			$this->fixture->_pathway,
 			$this->equalTo(array())
 		);
 	}
@@ -154,9 +121,8 @@ class JPathwayTest extends TestCase
 	 */
 	public function testGetPathway()
 	{
-		$class = new JPathwayInspector;
-		$class->addItem('Item1', 'index.php?key=item1');
-		$class->addItem('Item2', 'index.php?key=item2');
+		$this->fixture->addItem('Item1', 'index.php?key=item1');
+		$this->fixture->addItem('Item2', 'index.php?key=item2');
 
 		$pathway = array();
 		$object1 = new stdClass;
@@ -169,7 +135,7 @@ class JPathwayTest extends TestCase
 		$pathway[] = $object2;
 
 		$this->assertThat(
-			$class->getPathway(),
+			$this->fixture->getPathway(),
 			$this->equalTo($pathway)
 		);
 	}
@@ -181,8 +147,6 @@ class JPathwayTest extends TestCase
 	 */
 	public function testSetPathway()
 	{
-		$class = new JPathwayInspector;
-
 		$pathway = array();
 		$object1 = new stdClass;
 		$object1->name = 'Item1';
@@ -194,22 +158,22 @@ class JPathwayTest extends TestCase
 		$pathway[4] = $object2;
 
 		$this->assertThat(
-			$class->setPathway($pathway),
+			$this->fixture->setPathway($pathway),
 			$this->equalTo(array())
 		);
 
 		$this->assertThat(
-			$class->_pathway,
+			$this->fixture->_pathway,
 			$this->equalTo(array_values($pathway))
 		);
 
 		$this->assertThat(
-			$class->setPathway(array()),
+			$this->fixture->setPathway(array()),
 			$this->equalTo(array_values($pathway))
 		);
 
 		$this->assertThat(
-			$class->_pathway,
+			$this->fixture->_pathway,
 			$this->equalTo(array())
 		);
 	}
@@ -221,8 +185,6 @@ class JPathwayTest extends TestCase
 	 */
 	public function testGetPathwayNames()
 	{
-		$class = new JPathwayInspector;
-
 		$pathway = array();
 		$object1 = new stdClass;
 		$object1->name = 'Item1';
@@ -233,10 +195,10 @@ class JPathwayTest extends TestCase
 		$object2->link = 'index.php?key=item2';
 		$pathway[] = $object2;
 
-		$class->_pathway = $pathway;
+		$this->fixture->_pathway = $pathway;
 
 		$this->assertThat(
-			$class->getPathwayNames(),
+			$this->fixture->getPathwayNames(),
 			$this->equalTo(array('Item1', 'Item2'))
 		);
 	}
@@ -248,8 +210,6 @@ class JPathwayTest extends TestCase
 	 */
 	public function testAddItem()
 	{
-		$class = new JPathwayInspector;
-
 		$pathway = array();
 		$object1 = new stdClass;
 		$object1->name = 'Item1';
@@ -260,11 +220,11 @@ class JPathwayTest extends TestCase
 		$object2->link = 'index.php?key=item2';
 		$pathway[] = $object2;
 
-		$class->addItem('Item1', 'index.php?key=item1');
-		$class->addItem('Item2', 'index.php?key=item2');
+		$this->fixture->addItem('Item1', 'index.php?key=item1');
+		$this->fixture->addItem('Item2', 'index.php?key=item2');
 
 		$this->assertThat(
-			$class->_pathway,
+			$this->fixture->_pathway,
 			$this->equalTo($pathway)
 		);
 	}
@@ -276,8 +236,6 @@ class JPathwayTest extends TestCase
 	 */
 	public function testSetItemName()
 	{
-		$class = new JPathwayInspector;
-
 		$pathway = array();
 		$object1 = new stdClass;
 		$object1->name = 'Item1';
@@ -288,24 +246,24 @@ class JPathwayTest extends TestCase
 		$object2->link = 'index.php?key=item2';
 		$pathway[] = $object2;
 
-		$class->_pathway = $pathway;
+		$this->fixture->_pathway = $pathway;
 
 		$this->assertTrue(
-			$class->setItemName(1, 'Item3')
+			$this->fixture->setItemName(1, 'Item3')
 		);
 
 		$pathway[1]->name = 'Item3';
 		$this->assertThat(
-			$class->_pathway,
+			$this->fixture->_pathway,
 			$this->equalTo($pathway)
 		);
 
 		$this->assertFalse(
-			$class->setItemName(3, 'False')
+			$this->fixture->setItemName(3, 'False')
 		);
 
 		$this->assertThat(
-			$class->_pathway,
+			$this->fixture->_pathway,
 			$this->equalTo($pathway)
 		);
 	}
@@ -317,14 +275,12 @@ class JPathwayTest extends TestCase
 	 */
 	public function test_makeItem()
 	{
-		$class = new JPathwayInspector;
-
 		$object = new stdClass;
 		$object->link = 'index.php?key=value1';
 		$object->name = 'Value1';
 
 		$this->assertThat(
-			$class->_makeItem('Value1', 'index.php?key=value1'),
+			$this->fixture->_makeItem('Value1', 'index.php?key=value1'),
 			$this->equalTo($object)
 		);
 	}


### PR DESCRIPTION
Changing JPathwayTest to use a fixture. Each method currently creates a new instance of `JPathwayInspector`, so I abstracted that to the `setUp()` method instead. Also moved inspector class to it's own file.
