### PR TITLE
Add deprecation tags to legacy classes.

### DIFF
--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -21,6 +21,7 @@ jimport('joomla.environment.response');
  * @package     Joomla.Legacy
  * @subpackage  Application
  * @since       11.1
+ * @deprecated  13.3
  */
 class JApplication extends JApplicationBase
 {

--- a/libraries/legacy/application/helper.php
+++ b/libraries/legacy/application/helper.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Application
  * @since       11.1
+ * @deprecated  13.3
  */
 class JApplicationHelper
 {

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Categories
  * @since       11.1
+ * @deprecated  13.3
  */
 class JCategories
 {

--- a/libraries/legacy/component/helper.php
+++ b/libraries/legacy/component/helper.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Component
  * @since       11.1
+ * @deprecated  13.3
  */
 class JComponentHelper
 {

--- a/libraries/legacy/controller/admin.php
+++ b/libraries/legacy/controller/admin.php
@@ -18,6 +18,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Controller
  * @since       12.2
+ * @deprecated  13.3
  */
 class JControllerAdmin extends JControllerLegacy
 {

--- a/libraries/legacy/controller/form.php
+++ b/libraries/legacy/controller/form.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Controller
  * @since       12.2
+ * @deprecated  13.3
  * @todo        Add ability to set redirect manually to better cope with frontend usage.
  */
 class JControllerForm extends JControllerLegacy

--- a/libraries/legacy/controller/legacy.php
+++ b/libraries/legacy/controller/legacy.php
@@ -18,6 +18,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Controller
  * @since       12.2
+ * @deprecated  13.3
  */
 class JControllerLegacy extends JObject
 {

--- a/libraries/legacy/error/error.php
+++ b/libraries/legacy/error/error.php
@@ -31,7 +31,7 @@ const JERROR_ILLEGAL_MODE = 3;
  * @package     Joomla.Legacy
  * @subpackage  Error
  * @since       11.1
- * @deprecated  12.1   Use PHP Exception
+ * @deprecated  13.1   Use PHP Exception
  */
 abstract class JError
 {

--- a/libraries/legacy/exception/exception.php
+++ b/libraries/legacy/exception/exception.php
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Exception
  * @since       11.1
- * @deprecated  12.1
+ * @deprecated  13.1
  */
 class JException extends Exception
 {

--- a/libraries/legacy/form/field/category.php
+++ b/libraries/legacy/form/field/category.php
@@ -18,6 +18,7 @@ JFormHelper::loadFieldClass('list');
  * @package     Joomla.Legacy
  * @subpackage  Form
  * @since       11.1
+ * @deprecated  13.3
  */
 class JFormFieldCategory extends JFormFieldList
 {

--- a/libraries/legacy/form/field/componentlayout.php
+++ b/libraries/legacy/form/field/componentlayout.php
@@ -18,6 +18,7 @@ jimport('joomla.filesystem.folder');
  * @package     Joomla.Legacy
  * @subpackage  Form
  * @since       11.1
+ * @deprecated  13.3
  */
 class JFormFieldComponentlayout extends JFormField
 {

--- a/libraries/legacy/form/field/modulelayout.php
+++ b/libraries/legacy/form/field/modulelayout.php
@@ -17,6 +17,7 @@ jimport('joomla.filesystem.folder');
  * @package     Joomla.Legacy
  * @subpackage  Form
  * @since       11.1
+ * @deprecated  13.3
  */
 class JFormFieldModulelayout extends JFormField
 {

--- a/libraries/legacy/html/contentlanguage.php
+++ b/libraries/legacy/html/contentlanguage.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  HTML
  * @since       11.1
+ * @deprecated  13.3
  */
 abstract class JHtmlContentLanguage
 {

--- a/libraries/legacy/html/menu.php
+++ b/libraries/legacy/html/menu.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  HTML
  * @since       11.1
+ * @deprecated  13.3
  */
 abstract class JHtmlMenu
 {

--- a/libraries/legacy/installer/adapters/component.php
+++ b/libraries/legacy/installer/adapters/component.php
@@ -18,6 +18,7 @@ jimport('joomla.filesystem.folder');
  * @package     Joomla.Platform
  * @subpackage  Installer
  * @since       11.1
+ * @deprecated  13.3
  */
 class JInstallerComponent extends JAdapterInstance
 {

--- a/libraries/legacy/installer/adapters/file.php
+++ b/libraries/legacy/installer/adapters/file.php
@@ -19,6 +19,7 @@ jimport('joomla.filesystem.folder');
  * @package     Joomla.Platform
  * @subpackage  Installer
  * @since       11.1
+ * @deprecated  13.3
  */
 class JInstallerFile extends JAdapterInstance
 {

--- a/libraries/legacy/installer/adapters/language.php
+++ b/libraries/legacy/installer/adapters/language.php
@@ -18,6 +18,7 @@ jimport('joomla.filesystem.folder');
  * @package     Joomla.Platform
  * @subpackage  Installer
  * @since       11.1
+ * @deprecated  13.3
  */
 class JInstallerLanguage extends JAdapterInstance
 {

--- a/libraries/legacy/installer/adapters/library.php
+++ b/libraries/legacy/installer/adapters/library.php
@@ -18,6 +18,7 @@ jimport('joomla.filesystem.folder');
  * @package     Joomla.Platform
  * @subpackage  Installer
  * @since       11.1
+ * @deprecated  13.3
  */
 class JInstallerLibrary extends JAdapterInstance
 {

--- a/libraries/legacy/installer/adapters/module.php
+++ b/libraries/legacy/installer/adapters/module.php
@@ -18,6 +18,7 @@ jimport('joomla.filesystem.folder');
  * @package     Joomla.Platform
  * @subpackage  Installer
  * @since       11.1
+ * @deprecated  13.3
  */
 class JInstallerModule extends JAdapterInstance
 {

--- a/libraries/legacy/installer/adapters/package.php
+++ b/libraries/legacy/installer/adapters/package.php
@@ -17,6 +17,7 @@ jimport('joomla.base.adapterinstance');
  * @package     Joomla.Platform
  * @subpackage  Installer
  * @since       11.1
+ * @deprecated  13.3
  */
 class JInstallerPackage extends JAdapterInstance
 {

--- a/libraries/legacy/installer/adapters/plugin.php
+++ b/libraries/legacy/installer/adapters/plugin.php
@@ -18,6 +18,7 @@ jimport('joomla.filesystem.folder');
  * @package     Joomla.Platform
  * @subpackage  Installer
  * @since       11.1
+ * @deprecated  13.3
  */
 class JInstallerPlugin extends JAdapterInstance
 {

--- a/libraries/legacy/installer/adapters/template.php
+++ b/libraries/legacy/installer/adapters/template.php
@@ -19,6 +19,7 @@ jimport('joomla.filesystem.folder');
  * @package     Joomla.Platform
  * @subpackage  Installer
  * @since       11.1
+ * @deprecated  13.3
  */
 class JInstallerTemplate extends JAdapterInstance
 {

--- a/libraries/legacy/installer/extension.php
+++ b/libraries/legacy/installer/extension.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Platform
  * @subpackage  Installer
  * @since       11.1
+ * @deprecated  13.3
  */
 class JExtension extends JObject
 {

--- a/libraries/legacy/installer/helper.php
+++ b/libraries/legacy/installer/helper.php
@@ -19,6 +19,7 @@ jimport('joomla.filesystem.path');
  * @package     Joomla.Platform
  * @subpackage  Installer
  * @since       11.1
+ * @deprecated  13.3
  */
 abstract class JInstallerHelper
 {

--- a/libraries/legacy/installer/installer.php
+++ b/libraries/legacy/installer/installer.php
@@ -20,6 +20,7 @@ jimport('joomla.base.adapter');
  * @package     Joomla.Platform
  * @subpackage  Installer
  * @since       11.1
+ * @deprecated  13.3
  */
 class JInstaller extends JAdapter
 {

--- a/libraries/legacy/installer/manifest.php
+++ b/libraries/legacy/installer/manifest.php
@@ -17,6 +17,7 @@ jimport('joomla.filesystem.file');
  * @package     Joomla.Platform
  * @subpackage  Installer
  * @since       12.2
+ * @deprecated  13.3
  */
 abstract class JInstallerManifest
 {

--- a/libraries/legacy/installer/manifest/library.php
+++ b/libraries/legacy/installer/manifest/library.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Platform
  * @subpackage  Installer
  * @since       11.1
+ * @deprecated  13.3
  */
 class JInstallerManifestLibrary extends JInstallerManifest
 {

--- a/libraries/legacy/installer/manifest/package.php
+++ b/libraries/legacy/installer/manifest/package.php
@@ -17,6 +17,7 @@ jimport('joomla.installer.extension');
  * @package     Joomla.Platform
  * @subpackage  Installer
  * @since       11.1
+ * @deprecated  13.3
  */
 class JInstallerManifestPackage extends JInstallerManifest
 {

--- a/libraries/legacy/menu/menu.php
+++ b/libraries/legacy/menu/menu.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Menu
  * @since       11.1
+ * @deprecated  13.3
  */
 class JMenu
 {

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Model
  * @since       12.2
+ * @deprecated  13.3
  */
 abstract class JModelAdmin extends JModelForm
 {

--- a/libraries/legacy/model/form.php
+++ b/libraries/legacy/model/form.php
@@ -18,6 +18,7 @@ defined('JPATH_PLATFORM') or die;
  * @see         JFormField
  * @see         JFormRule
  * @since       12.2
+ * @deprecated  13.3
  */
 abstract class JModelForm extends JModelLegacy
 {

--- a/libraries/legacy/model/item.php
+++ b/libraries/legacy/model/item.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Model
  * @since       12.2
+ * @deprecated  13.3
  */
 abstract class JModelItem extends JModelLegacy
 {

--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -18,6 +18,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Model
  * @since       12.2
+ * @deprecated  13.3
  */
 abstract class JModelLegacy extends JObject
 {

--- a/libraries/legacy/model/list.php
+++ b/libraries/legacy/model/list.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Model
  * @since       12.2
+ * @deprecated  13.3
  */
 class JModelList extends JModelLegacy
 {

--- a/libraries/legacy/module/helper.php
+++ b/libraries/legacy/module/helper.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Module
  * @since       11.1
+ * @deprecated  13.3
  */
 abstract class JModuleHelper
 {

--- a/libraries/legacy/pathway/pathway.php
+++ b/libraries/legacy/pathway/pathway.php
@@ -17,6 +17,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Pathway
  * @since       11.1
+ * @deprecated  13.3
  */
 class JPathway
 {

--- a/libraries/legacy/request/request.php
+++ b/libraries/legacy/request/request.php
@@ -33,7 +33,7 @@ JLog::add('JRequest is deprecated.', JLog::WARNING, 'deprecated');
  * @package     Joomla.Legacy
  * @subpackage  Request
  * @since       11.1
- * @deprecated  12.1  Get the JInput object from the application instead
+ * @deprecated  13.1  Get the JInput object from the application instead
  */
 class JRequest
 {

--- a/libraries/legacy/table/category.php
+++ b/libraries/legacy/table/category.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Table
  * @since       11.1
+ * @deprecated  13.3
  */
 class JTableCategory extends JTableNested
 {

--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Table
  * @since       11.1
+ * @deprecated  13.3
  */
 class JTableContent extends JTable
 {

--- a/libraries/legacy/table/menu.php
+++ b/libraries/legacy/table/menu.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Table
  * @since       11.1
+ * @deprecated  13.3
  */
 class JTableMenu extends JTableNested
 {

--- a/libraries/legacy/table/menu/type.php
+++ b/libraries/legacy/table/menu/type.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Table
  * @since       11.1
+ * @deprecated  13.3
  */
 class JTableMenuType extends JTable
 {

--- a/libraries/legacy/table/module.php
+++ b/libraries/legacy/table/module.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  Table
  * @since       11.1
+ * @deprecated  13.3
  */
 class JTableModule extends JTable
 {

--- a/libraries/legacy/updater/adapters/collection.php
+++ b/libraries/legacy/updater/adapters/collection.php
@@ -17,6 +17,7 @@ jimport('joomla.updater.updateadapter');
  * @package     Joomla.Platform
  * @subpackage  Updater
  * @since       11.1
+ * @deprecated  13.3
  */
 class JUpdaterCollection extends JUpdateAdapter
 {

--- a/libraries/legacy/updater/adapters/extension.php
+++ b/libraries/legacy/updater/adapters/extension.php
@@ -16,6 +16,7 @@ jimport('joomla.updater.updateadapter');
  * @package     Joomla.Platform
  * @subpackage  Updater
  * @since       11.1
+ * @deprecated  13.3
  * */
 class JUpdaterExtension extends JUpdateAdapter
 {

--- a/libraries/legacy/updater/update.php
+++ b/libraries/legacy/updater/update.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Platform
  * @subpackage  Updater
  * @since       11.1
+ * @deprecated  13.3
  */
 class JUpdate extends JObject
 {

--- a/libraries/legacy/updater/updateadapter.php
+++ b/libraries/legacy/updater/updateadapter.php
@@ -17,6 +17,7 @@ jimport('joomla.base.adapterinstance');
  * @package     Joomla.Platform
  * @subpackage  Updater
  * @since       11.1
+ * @deprecated  13.3
  */
 class JUpdateAdapter extends JAdapterInstance
 {

--- a/libraries/legacy/updater/updater.php
+++ b/libraries/legacy/updater/updater.php
@@ -21,6 +21,7 @@ jimport('joomla.utilities.arrayhelper');
  * @package     Joomla.Platform
  * @subpackage  Updater
  * @since       11.1
+ * @deprecated  13.3
  */
 class JUpdater extends JAdapter
 {

--- a/libraries/legacy/view/legacy.php
+++ b/libraries/legacy/view/legacy.php
@@ -17,6 +17,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Legacy
  * @subpackage  View
  * @since       12.2
+ * @deprecated  13.3
  */
 class JViewLegacy extends JObject
 {


### PR DESCRIPTION
Most of these have been marked for removal at 13.3.  This is roughly a year of having them stick around in the legacy tree.  My suspicion is that most -- if not all -- of these classes will end up being picked up and maintained by the CMS project for much longer than Q3 of 2013.
