### PR TITLE
Update libraries/legacy/updater/adapters/extension.php

### DIFF
--- a/libraries/legacy/updater/adapters/extension.php
+++ b/libraries/legacy/updater/adapters/extension.php
@@ -205,7 +205,7 @@ class JUpdaterExtension extends JUpdateAdapter
 		{
 			if (isset($this->latest->client) && strlen($this->latest->client))
 			{
-				$this->latest->client_id = JApplicationHelper::getClientInfo($this->latest->client)->id;
+				$this->latest->client_id = JApplicationHelper::getClientInfo($this->latest->client, 1)->id;
 				unset($this->latest->client);
 			}
 			$updates = array($this->latest);

--- a/libraries/legacy/updater/adapters/extension.php
+++ b/libraries/legacy/updater/adapters/extension.php
@@ -205,7 +205,17 @@ class JUpdaterExtension extends JUpdateAdapter
 		{
 			if (isset($this->latest->client) && strlen($this->latest->client))
 			{
-				$this->latest->client_id = JApplicationHelper::getClientInfo($this->latest->client, 1)->id;
+				if (is_numeric($this->latest->client))
+				{
+					$byName = false;
+					// <client> has to be 'administrator' or 'site', numeric values are depreceated. See http://docs.joomla.org/Design_of_JUpdate
+					JLog::add('Using numeric values for <client> in the updater xml is deprecated. Use \'administrator\' or \'site\' instead.', JLog::WARNING, 'deprecated');
+				}
+				else
+				{
+					$byName = true;
+				}
+				$this->latest->client_id = JApplicationHelper::getClientInfo($this->latest->client, $byName)->id;
 				unset($this->latest->client);
 			}
 			$updates = array($this->latest);


### PR DESCRIPTION
The helper function "getClientInfo" takes two arguments, the search "$id" and "$byName" which decides if it should search by id or name.
In our case here we want to search by the name and thus it should be set to "1". Otherwise the function will return null and break all extension updates if the client tag is set instead of the client_id in the updater xml.
