### PR TITLE
Add a link to main repository in Platform documentation

### DIFF
--- a/docs/manual/en-US/chapters/introduction.md
+++ b/docs/manual/en-US/chapters/introduction.md
@@ -7,7 +7,7 @@ This is the introduction to the Joomla Platform.
 ## Folder Structure
 
 The following outlines the purpose of the top-level folder structure of
-the Joomla Platform as found in the GitHub repository.
+the Joomla Platform as found in the GitHub repository ( https://github.com/joomla/joomla-platform/ ).
 
 Folder     | Description
 ---------- | --------------------

--- a/docs/manual/en-US/chapters/introduction.md
+++ b/docs/manual/en-US/chapters/introduction.md
@@ -7,7 +7,7 @@ This is the introduction to the Joomla Platform.
 ## Folder Structure
 
 The following outlines the purpose of the top-level folder structure of
-the Joomla Platform as found in the GitHub repository ( https://github.com/joomla/joomla-platform/ ).
+the Joomla Platform as found in the [GitHub repository](https://github.com/joomla/joomla-platform/ "Joomla Platform Github repository").
 
 Folder     | Description
 ---------- | --------------------


### PR DESCRIPTION
Simple improvement that links documentation to the main Github Repository. This help people reading the Platform documentation in external links like: http://joomla.github.com/joomla-platform/ to quickly find the main repository.
