### PR TITLE
Refactoring JFormField & Co.

### DIFF
--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -447,8 +447,8 @@ abstract class JFormField
 		}
 
 		// Determine whether to translate the field label and/or description.
-		$this->translateLabel = !($translateLabel == 'false' || $translateLabel == 0);
-		$this->translateDescription = !($translateDescription == 'false' || $translateDescription == '0');
+		$this->translateLabel = !($translateLabel === 'false' || $translateLabel === '0');
+		$this->translateDescription = !($translateDescription === 'false' || $translateDescription === '0');
 
 		// Build the class string.
 		$this->class = trim($this->prependToClass . ' ' . $class);

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -25,6 +25,7 @@ abstract class JFormField
 	 * @since  11.1
 	 */
 	protected $autocomplete;
+
 	/**
 	 * The description text for the form field.  Usually used in tooltips.
 	 *

--- a/libraries/joomla/form/fields/accesslevel.php
+++ b/libraries/joomla/form/fields/accesslevel.php
@@ -43,13 +43,11 @@ class JFormFieldAccessLevel extends JFormFieldList
 		$attr = '';
 
 		// Initialize some field attributes.
-		$attr .= $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
-		$attr .= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
-		$attr .= $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
-		$attr .= $this->multiple ? ' multiple="multiple"' : '';
-
-		// Initialize JavaScript field attributes.
-		$attr .= $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
+		$attr .= !empty($this->class) ? ' class="' . $this->class . '"' : '';
+		$attr .= !empty($this->disabled) ? ' disabled="disabled"' : '';
+		$attr .= !empty($this->size) ? ' size="' . $this->size . '"' : '';
+		$attr .= !empty($this->multiple) ? ' multiple="multiple"' : '';
+		$attr .= !empty($this->onchange) ? ' onchange="' . $this->onchange . '"' : '';
 
 		// Get the field options.
 		$options = $this->getOptions();

--- a/libraries/joomla/form/fields/cachehandler.php
+++ b/libraries/joomla/form/fields/cachehandler.php
@@ -47,8 +47,6 @@ class JFormFieldCacheHandler extends JFormFieldList
 			$options[] = JHtml::_('select.option', $store, JText::_('JLIB_FORM_VALUE_CACHE_' . $store), 'value', 'text');
 		}
 
-		$options = array_merge(parent::getOptions(), $options);
-
-		return $options;
+		return array_merge(parent::getOptions(), $options);
 	}
 }

--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -21,14 +21,60 @@ defined('JPATH_PLATFORM') or die;
  */
 class JFormFieldCalendar extends JFormField
 {
-
 	/**
 	 * The form field type.
 	 *
 	 * @var    string
 	 * @since  11.1
 	 */
-	public $type = 'Calendar';
+	protected $type = 'Calendar';
+
+	/**
+	 * The form field date format.
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	protected $format = '%Y-%m-%d';
+
+	/**
+	 * The form field date filter.
+	 *
+	 * @var    string
+	 * @since  11.1
+	 */
+	public $filter;
+
+	/**
+	 * Method to attach a JForm object to the field.
+	 *
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     JFormField::setup()
+	 * @since   12.3
+	 */
+	public function setup(SimpleXMLElement $element, $value, $group = null)
+	{
+		parent::setup($element, $value, $group);
+
+		if (!empty($element['format']))
+		{
+			$this->format = (string) $element['format'];
+		}
+
+		if (!empty($element['filter']))
+		{
+			$this->filter = (string) $element['filter'];
+		}
+
+		return true;
+	}
 
 	/**
 	 * Method to get the field input markup.
@@ -39,41 +85,20 @@ class JFormFieldCalendar extends JFormField
 	 */
 	protected function getInput()
 	{
-		// Initialize some field attributes.
-		$format = $this->element['format'] ? (string) $this->element['format'] : '%Y-%m-%d';
-
 		// Build the attributes array.
-		$attributes = array();
-
-		if ($this->element['size'])
-		{
-			$attributes['size'] = (int) $this->element['size'];
-		}
-		if ($this->element['maxlength'])
-		{
-			$attributes['maxlength'] = (int) $this->element['maxlength'];
-		}
-		if ($this->element['class'])
-		{
-			$attributes['class'] = (string) $this->element['class'];
-		}
-		if ((string) $this->element['readonly'] == 'true')
-		{
-			$attributes['readonly'] = 'readonly';
-		}
-		if ((string) $this->element['disabled'] == 'true')
-		{
-			$attributes['disabled'] = 'disabled';
-		}
-		if ($this->element['onchange'])
-		{
-			$attributes['onchange'] = (string) $this->element['onchange'];
-		}
+		$attributes = array(
+			'size' => $this->size,
+			'maxlength' => $this->maxlength,
+			'class' => $this->class,
+			'readonly' => $this->readonly,
+			'disabled' => $this->disabled,
+			'onchange' => $this->onchange
+		);
 
 		// Handle the special case for "now".
 		if (strtoupper($this->value) == 'NOW')
 		{
-			$this->value = strftime($format);
+			$this->value = strftime($this->format);
 		}
 
 		// Get some system objects.
@@ -81,7 +106,7 @@ class JFormFieldCalendar extends JFormField
 		$user = JFactory::getUser();
 
 		// If a known filter is given use it.
-		switch (strtoupper((string) $this->element['filter']))
+		switch (strtoupper($this->filter))
 		{
 			case 'SERVER_UTC':
 				// Convert a date to UTC based on the server timezone.
@@ -110,6 +135,6 @@ class JFormFieldCalendar extends JFormField
 				break;
 		}
 
-		return JHtml::_('calendar', $this->value, $this->name, $this->id, $format, $attributes);
+		return JHtml::_('calendar', $this->value, $this->name, $this->id, $this->format, $attributes);
 	}
 }

--- a/libraries/joomla/form/fields/checkbox.php
+++ b/libraries/joomla/form/fields/checkbox.php
@@ -28,7 +28,41 @@ class JFormFieldCheckbox extends JFormField
 	 * @var    string
 	 * @since  11.1
 	 */
-	public $type = 'Checkbox';
+	protected $type = 'Checkbox';
+
+	/**
+	 * The checked options for this field.
+	 *
+	 * @var    string
+	 * @since  12.3
+	 */
+	protected $checked = null;
+
+	/**
+	 * Method to attach a JForm object to the field.
+	 *
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     JFormField::setup()
+	 * @since   12.3
+	 */
+	public function setup(SimpleXMLElement $element, $value, $group = null)
+	{
+		parent::setup($element, $value, $group);
+
+		if (!empty($element['checked']))
+		{
+			$this->checked = (string) $element['checked'];
+		}
+
+		return true;
+	}
 
 	/**
 	 * Method to get the field input markup.
@@ -41,21 +75,21 @@ class JFormFieldCheckbox extends JFormField
 	protected function getInput()
 	{
 		// Initialize some field attributes.
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
-		$disabled = ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
-		$value = $this->element['value'] ? (string) $this->element['value'] : '1';
+		$disabled = !empty($this->disabled) ? ' disabled="disabled"' : '';
+		$class = !empty($this->class) ? ' class="' . $this->class . '"' : '';
+		$onclick = !empty($this->onclick) ? ' onclick="' . $this->onclick . '"' : '';
+
+		// This is the exception to the rule. The rule being, don't access $this->element
+		$value = !empty($this->element['value']) ? $this->element['value'] : '1';
 
 		if (empty($this->value))
 		{
-			$checked = (isset($this->element['checked'] )) ? ' checked="checked"' : '';
+			$checked = !empty($this->checked) ? ' checked="checked"' : '';
 		}
 		else
 		{
 			$checked = ' checked="checked"';
 		}
-
-		// Initialize JavaScript field attributes.
-		$onclick = $this->element['onclick'] ? ' onclick="' . (string) $this->element['onclick'] . '"' : '';
 
 		return '<input type="checkbox" name="' . $this->name . '" id="' . $this->id . '"' . ' value="'
 			. htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"' . $class . $checked . $disabled . $onclick . ' />';

--- a/libraries/joomla/form/fields/checkboxes.php
+++ b/libraries/joomla/form/fields/checkboxes.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+JFormHelper::loadFieldClass('checkbox');
+
 /**
  * Form Field class for the Joomla Platform.
  * Displays options as a list of check boxes.
@@ -19,7 +21,7 @@ defined('JPATH_PLATFORM') or die;
  * @see         JFormFieldCheckbox
  * @since       11.1
  */
-class JFormFieldCheckboxes extends JFormField
+class JFormFieldCheckboxes extends JFormFieldCheckbox
 {
 	/**
 	 * The form field type.
@@ -35,7 +37,15 @@ class JFormFieldCheckboxes extends JFormField
 	 * @var    boolean
 	 * @since  11.1
 	 */
-	protected $forceMultiple = true;
+	protected $multiple = true;
+
+	/**
+	 * The text to prepend to class for the form field.
+	 *
+	 * @var    string
+	 * @since  12.3
+	 */
+	protected $prependToClass = 'checkboxes';
 
 	/**
 	 * Method to get the field input markup for check boxes.
@@ -49,8 +59,8 @@ class JFormFieldCheckboxes extends JFormField
 		$html = array();
 
 		// Initialize some field attributes.
-		$class = $this->element['class'] ? ' class="checkboxes ' . (string) $this->element['class'] . '"' : ' class="checkboxes"';
-		$checkedOptions = explode(',', (string) $this->element['checked']);
+		$class = !empty($this->class) ? ' class="' . $this->class . '"' : '';
+		$checkedOptions = explode(',', $this->checked);
 
 		// Start the checkbox field output.
 		$html[] = '<fieldset id="' . $this->id . '"' . $class . '>';
@@ -107,7 +117,6 @@ class JFormFieldCheckboxes extends JFormField
 
 		foreach ($this->element->children() as $option)
 		{
-
 			// Only add <option /> elements.
 			if ($option->getName() != 'option')
 			{

--- a/libraries/joomla/form/fields/color.php
+++ b/libraries/joomla/form/fields/color.php
@@ -18,7 +18,7 @@ defined('JPATH_PLATFORM') or die;
  * @link        http://www.w3.org/TR/html-markup/input.color.html
  * @since       11.3
  */
-class JFormFieldColor extends JFormField
+class JFormFieldColor extends JFormFieldText
 {
 	/**
 	 * The form field type.
@@ -29,37 +29,42 @@ class JFormFieldColor extends JFormField
 	protected $type = 'Color';
 
 	/**
-	 * Method to get the field input markup.
+	 * The text to prepend to class for the form field.
 	 *
-	 * @return  string  The field input markup.
-	 *
-	 * @since   11.3
+	 * @var    string
+	 * @since  12.3
 	 */
-	protected function getInput()
+	protected $prependToClass = 'input-colorpicker';
+
+	/**
+	 * Method to attach a JForm object to the field.
+	 *
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     JFormField::setup()
+	 * @since   12.3
+	 */
+	public function setup(SimpleXMLElement $element, $value, $group = null)
 	{
-		// Initialize some field attributes.
-		$size = $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
-		$classes = (string) $this->element['class'];
-		$disabled = ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
+		parent::setup($element, $value, $group);
 
-		if (!$disabled)
-		{
-			JHtml::_('behavior.colorpicker');
-			$classes .= ' input-colorpicker';
-		}
-
+		// A color field can't be empty, we default to black. This is the same as the HTML5 spec.
 		if (empty($this->value))
 		{
-			// A color field can't be empty, we default to black. This is the same as the HTML5 spec.
 			$this->value = '#000000';
 		}
 
-		// Initialize JavaScript field attributes.
-		$onchange = $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
+		if (empty($this->disabled))
+		{
+			JHtml::_('behavior.colorpicker');
+		}
 
-		$class = $classes ? ' class="' . trim($classes) . '"' : '';
-
-		return '<input type="text" name="' . $this->name . '" id="' . $this->id . '"' . ' value="'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $class . $size . $disabled . $onchange . '/>';
+		return true;
 	}
 }

--- a/libraries/joomla/form/fields/combo.php
+++ b/libraries/joomla/form/fields/combo.php
@@ -30,6 +30,14 @@ class JFormFieldCombo extends JFormFieldList
 	public $type = 'Combo';
 
 	/**
+	 * The text to prepend to class for the form field.
+	 *
+	 * @var    string
+	 * @since  12.3
+	 */
+	protected $prependToClass = 'combobox';
+
+	/**
 	 * Method to get the field input markup for a combo box field.
 	 *
 	 * @return  string   The field input markup.
@@ -42,13 +50,11 @@ class JFormFieldCombo extends JFormFieldList
 		$attr = '';
 
 		// Initialize some field attributes.
-		$attr .= $this->element['class'] ? ' class="combobox ' . (string) $this->element['class'] . '"' : ' class="combobox"';
-		$attr .= ((string) $this->element['readonly'] == 'true') ? ' readonly="readonly"' : '';
-		$attr .= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
-		$attr .= $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
-
-		// Initialize JavaScript field attributes.
-		$attr .= $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
+		$attr .= !empty($this->class) ? ' class="' . $this->class . '"' : '';
+		$attr .= !empty($this->readonly) ? ' readonly="readonly"' : '';
+		$attr .= !empty($this->disabled) ? ' disabled="disabled"' : '';
+		$attr .= !empty($this->size) ? ' size="' . $this->size . '"' : '';
+		$attr .= !empty($this->onchange) ? ' onchange="' . $this->onchange . '"' : '';
 
 		// Get the field options.
 		$options = $this->getOptions();

--- a/libraries/joomla/form/fields/email.php
+++ b/libraries/joomla/form/fields/email.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+JFormHelper::loadFieldClass('text');
+
 /**
  * Form Field class for the Joomla Platform.
  * Provides and input field for e-mail addresses
@@ -19,7 +21,7 @@ defined('JPATH_PLATFORM') or die;
  * @see         JFormRuleEmail
  * @since       11.1
  */
-class JFormFieldEMail extends JFormField
+class JFormFieldEMail extends JFormFieldText
 {
 	/**
 	 * The form field type.
@@ -30,25 +32,10 @@ class JFormFieldEMail extends JFormField
 	protected $type = 'Email';
 
 	/**
-	 * Method to get the field input markup for e-mail addresses.
+	 * The text to prepend to class for the form field.
 	 *
-	 * @return  string  The field input markup.
-	 *
-	 * @since   11.1
+	 * @var    string
+	 * @since  12.3
 	 */
-	protected function getInput()
-	{
-		// Initialize some field attributes.
-		$size = $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
-		$maxLength = $this->element['maxlength'] ? ' maxlength="' . (int) $this->element['maxlength'] . '"' : '';
-		$class = $this->element['class'] ? ' ' . (string) $this->element['class'] : '';
-		$readonly = ((string) $this->element['readonly'] == 'true') ? ' readonly="readonly"' : '';
-		$disabled = ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
-
-		// Initialize JavaScript field attributes.
-		$onchange = $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
-
-		return '<input type="text" name="' . $this->name . '" class="validate-email' . $class . '" id="' . $this->id . '"' . ' value="'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $size . $disabled . $readonly . $onchange . $maxLength . '/>';
-	}
+	protected $prependToClass = 'validate-email';
 }

--- a/libraries/joomla/form/fields/file.php
+++ b/libraries/joomla/form/fields/file.php
@@ -29,6 +29,41 @@ class JFormFieldFile extends JFormField
 	public $type = 'File';
 
 	/**
+	 * A comma separated list of accepted
+	 * file types for the file input field
+	 *
+	 * @var    string
+	 * @since  12.3
+	 */
+	protected $accept;
+
+	/**
+	 * Method to attach a JForm object to the field.
+	 *
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     JFormField::setup()
+	 * @since   12.3
+	 */
+	public function setup(SimpleXMLElement $element, $value, $group = null)
+	{
+		parent::setup($element, $value, $group);
+
+		if (!empty($this->element['accept']))
+		{
+			$this->accept = (string) $this->element['accept'];
+		}
+
+		return true;
+	}
+
+	/**
 	 * Method to get the field input markup for the file field.
 	 * Field attributes allow specification of a maximum file size and a string
 	 * of accepted file extensions.
@@ -43,15 +78,13 @@ class JFormFieldFile extends JFormField
 	protected function getInput()
 	{
 		// Initialize some field attributes.
-		$accept = $this->element['accept'] ? ' accept="' . (string) $this->element['accept'] . '"' : '';
-		$size = $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
-		$disabled = ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
+		$size = !empty($this->size) ? ' size="' . $this->size . '"' : '';
+		$class = !empty($this->class) ? ' class="' . $this->class . '"' : '';
+		$disabled = !empty($this->disabled) ? ' disabled="disabled"' : '';
+		$accept = !empty($this->accept) ? ' accept="' . $this->accept . '"' : '';
+		$onchange = !empty($this->onchange) ? ' onchange="' . $this->onchange . '"' : '';
 
-		// Initialize JavaScript field attributes.
-		$onchange = $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
-
-		return '<input type="file" name="' . $this->name . '" id="' . $this->id . '"' . ' value=""' . $accept . $disabled . $class . $size
-			. $onchange . ' />';
+		return '<input type="file" name="' . $this->name . '" id="' . $this->id . '"' . ' value=""'
+			. $accept . $disabled . $class . $size . $onchange . ' />';
 	}
 }

--- a/libraries/joomla/form/fields/filelist.php
+++ b/libraries/joomla/form/fields/filelist.php
@@ -22,7 +22,6 @@ JFormHelper::loadFieldClass('list');
  */
 class JFormFieldFileList extends JFormFieldList
 {
-
 	/**
 	 * The form field type.
 	 *

--- a/libraries/joomla/form/fields/folderlist.php
+++ b/libraries/joomla/form/fields/folderlist.php
@@ -21,7 +21,6 @@ JFormHelper::loadFieldClass('list');
  */
 class JFormFieldFolderList extends JFormFieldList
 {
-
 	/**
 	 * The form field type.
 	 *

--- a/libraries/joomla/form/fields/groupedlist.php
+++ b/libraries/joomla/form/fields/groupedlist.php
@@ -139,19 +139,17 @@ class JFormFieldGroupedList extends JFormField
 		$attr = '';
 
 		// Initialize some field attributes.
-		$attr .= $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
-		$attr .= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
-		$attr .= $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
-		$attr .= $this->multiple ? ' multiple="multiple"' : '';
-
-		// Initialize JavaScript field attributes.
-		$attr .= $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
+		$attr .= !empty($this->class) ? ' class="' . $this->class . '"' : '';
+		$attr .= !empty($this->disabled) ? ' disabled="disabled"' : '';
+		$attr .= !empty($this->size) ? ' size="' . $this->size . '"' : '';
+		$attr .= !empty($this->multiple) ? ' multiple="multiple"' : '';
+		$attr .= !empty($this->onchange) ? ' onchange="' . $this->onchange . '"' : '';
 
 		// Get the field groups.
 		$groups = (array) $this->getGroups();
 
 		// Create a read-only list (no name) with a hidden input to store the value.
-		if ((string) $this->element['readonly'] == 'true')
+		if ($this->readonly)
 		{
 			$html[] = JHtml::_(
 				'select.groupedlist', $groups, null,

--- a/libraries/joomla/form/fields/hidden.php
+++ b/libraries/joomla/form/fields/hidden.php
@@ -38,11 +38,9 @@ class JFormFieldHidden extends JFormField
 	protected function getInput()
 	{
 		// Initialize some field attributes.
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
-		$disabled = ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
-
-		// Initialize JavaScript field attributes.
-		$onchange = $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
+		$class = !empty($this->class) ? ' class="' . $this->class . '"' : '';
+		$disabled = !empty($this->disabled) ? ' disabled="disabled"' : '';
+		$onchange = !empty($this->onchange) ? ' onchange="' . $this->onchange . '"' : '';
 
 		return '<input type="hidden" name="' . $this->name . '" id="' . $this->id . '"' . ' value="'
 			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $class . $disabled . $onchange . ' />';

--- a/libraries/joomla/form/fields/integer.php
+++ b/libraries/joomla/form/fields/integer.php
@@ -80,8 +80,6 @@ class JFormFieldInteger extends JFormFieldList
 		}
 
 		// Merge any additional options in the XML definition.
-		$options = array_merge(parent::getOptions(), $options);
-
-		return $options;
+		return array_merge(parent::getOptions(), $options);
 	}
 }

--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -41,25 +41,23 @@ class JFormFieldList extends JFormField
 		$attr = '';
 
 		// Initialize some field attributes.
-		$attr .= $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$attr .= !empty($this->class) ? ' class="' . $this->class . '"' : '';
 
 		// To avoid user's confusion, readonly="true" should imply disabled="true".
-		if ((string) $this->element['readonly'] == 'true' || (string) $this->element['disabled'] == 'true')
+		if ($this->readonly || $this->disabled)
 		{
 			$attr .= ' disabled="disabled"';
 		}
 
-		$attr .= $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
-		$attr .= $this->multiple ? ' multiple="multiple"' : '';
-
-		// Initialize JavaScript field attributes.
-		$attr .= $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
+		$attr .= !empty($this->size) ? ' size="' . $this->size . '"' : '';
+		$attr .= !empty($this->multiple) ? ' multiple="multiple"' : '';
+		$attr .= !empty($this->onchange) ? ' onchange="' . $this->onchange . '"' : '';
 
 		// Get the field options.
 		$options = (array) $this->getOptions();
 
 		// Create a read-only list (no name) with a hidden input to store the value.
-		if ((string) $this->element['readonly'] == 'true')
+		if ($this->readonly)
 		{
 			$html[] = JHtml::_('select.genericlist', $options, '', trim($attr), 'value', 'text', $this->value, $this->id);
 			$html[] = '<input type="hidden" name="' . $this->name . '" value="' . $this->value . '"/>';

--- a/libraries/joomla/form/fields/password.php
+++ b/libraries/joomla/form/fields/password.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+JFormHelper::loadFieldClass('text');
+
 /**
  * Form Field class for the Joomla Platform.
  * Text field for passwords
@@ -19,7 +21,7 @@ defined('JPATH_PLATFORM') or die;
  * @note        Two password fields may be validated as matching using JFormRuleEquals
  * @since       11.1
  */
-class JFormFieldPassword extends JFormField
+class JFormFieldPassword extends JFormFieldText
 {
 	/**
 	 * The form field type.
@@ -28,6 +30,53 @@ class JFormFieldPassword extends JFormField
 	 * @since  11.1
 	 */
 	protected $type = 'Password';
+
+	/**
+	 * Whether or not to use the strength meter
+	 *
+	 * @var    boolean
+	 * @since  12.3
+	 */
+	protected $strengthmeter;
+
+	/**
+	 * Strength threshold for the strength meter
+	 *
+	 * @var    string
+	 * @since  12.3
+	 */
+	protected $threshold;
+
+	/**
+	 * Method to attach a JForm object to the field.
+	 *
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     JFormField::setup()
+	 * @since   12.3
+	 */
+	public function setup(SimpleXMLElement $element, $value, $group = null)
+	{
+		parent::setup($element, $value, $group);
+
+		if (!empty($this->element['strengthmeter']))
+		{
+			$this->strengthmeter = (string) $this->element['strengthmeter'];
+		}
+
+		if (!empty($this->element['threshold']))
+		{
+			$this->threshold = (string) $this->element['threshold'];
+		}
+
+		return true;
+	}
 
 	/**
 	 * Method to get the field input markup for password.
@@ -39,18 +88,17 @@ class JFormFieldPassword extends JFormField
 	protected function getInput()
 	{
 		// Initialize some field attributes.
-		$size		= $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
-		$maxLength	= $this->element['maxlength'] ? ' maxlength="' . (int) $this->element['maxlength'] . '"' : '';
-		$class		= $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
-		$auto		= ((string) $this->element['autocomplete'] == 'off') ? ' autocomplete="off"' : '';
-		$readonly	= ((string) $this->element['readonly'] == 'true') ? ' readonly="readonly"' : '';
-		$disabled	= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
-		$meter		= ((string) $this->element['strengthmeter'] == 'true');
-		$threshold	= $this->element['threshold'] ? (int) $this->element['threshold'] : 66;
+		$size		= !empty($this->size) ? ' size="' . $this->size . '"' : '';
+		$maxLength	= !empty($this->maxlength) ? ' maxlength="' . $this->maxlength . '"' : '';
+		$class		= !empty($this->class) ? ' class="' . (string) $this->element['class'] . '"' : '';
+		$readonly	= !empty($this->readonly) ? ' readonly="readonly"' : '';
+		$disabled	= !empty($this->disabled) ? ' disabled="disabled"' : '';
+		$auto		= !empty($this->autocomplete) ? ' autocomplete="off"' : '';
+		$threshold	= !empty($this->threshold) ? $this->threshold : 66;
 
 		$script = '';
 
-		if ($meter)
+		if ($this->strengthmeter)
 		{
 			JHtml::_('script', 'system/passwordstrength.js', true, true);
 			$script = '<script type="text/javascript">new Form.PasswordStrength("' . $this->id . '",

--- a/libraries/joomla/form/fields/password.php
+++ b/libraries/joomla/form/fields/password.php
@@ -45,7 +45,7 @@ class JFormFieldPassword extends JFormFieldText
 	 * @var    string
 	 * @since  12.3
 	 */
-	protected $threshold;
+	protected $threshold = 66;
 
 	/**
 	 * Method to attach a JForm object to the field.
@@ -72,7 +72,7 @@ class JFormFieldPassword extends JFormFieldText
 
 		if (!empty($this->element['threshold']))
 		{
-			$this->threshold = (string) $this->element['threshold'];
+			$this->threshold = (int) $this->element['threshold'];
 		}
 
 		return true;
@@ -94,7 +94,6 @@ class JFormFieldPassword extends JFormFieldText
 		$readonly	= !empty($this->readonly) ? ' readonly="readonly"' : '';
 		$disabled	= !empty($this->disabled) ? ' disabled="disabled"' : '';
 		$auto		= !empty($this->autocomplete) ? ' autocomplete="off"' : '';
-		$threshold	= !empty($this->threshold) ? $this->threshold : 66;
 
 		$script = '';
 
@@ -103,7 +102,7 @@ class JFormFieldPassword extends JFormFieldText
 			JHtml::_('script', 'system/passwordstrength.js', true, true);
 			$script = '<script type="text/javascript">new Form.PasswordStrength("' . $this->id . '",
 				{
-					threshold: ' . $threshold . ',
+					threshold: ' . $this->threshold . ',
 					onUpdate: function(element, strength, threshold) {
 						element.set("data-passwordstrength", strength);
 					}
@@ -113,6 +112,6 @@ class JFormFieldPassword extends JFormFieldText
 
 		return '<input type="password" name="' . $this->name . '" id="' . $this->id . '"' .
 			' value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' .
-			$auto . $class . $readonly . $disabled . $size . $maxLength . '/>' . $script;
+			$auto . $class . $readonly . $disabled . $size . $maxLength . $placeholder . '/>' . $script;
 	}
 }

--- a/libraries/joomla/form/fields/password.php
+++ b/libraries/joomla/form/fields/password.php
@@ -88,12 +88,13 @@ class JFormFieldPassword extends JFormFieldText
 	protected function getInput()
 	{
 		// Initialize some field attributes.
-		$size		= !empty($this->size) ? ' size="' . $this->size . '"' : '';
-		$maxLength	= !empty($this->maxlength) ? ' maxlength="' . $this->maxlength . '"' : '';
-		$class		= !empty($this->class) ? ' class="' . (string) $this->element['class'] . '"' : '';
-		$readonly	= !empty($this->readonly) ? ' readonly="readonly"' : '';
-		$disabled	= !empty($this->disabled) ? ' disabled="disabled"' : '';
-		$auto		= !empty($this->autocomplete) ? ' autocomplete="off"' : '';
+		$size = !empty($this->size) ? ' size="' . $this->size . '"' : '';
+		$maxLength = !empty($this->maxlength) ? ' maxlength="' . $this->maxlength . '"' : '';
+		$class = !empty($this->class) ? ' class="' . $this->class . '"' : '';
+		$readonly = !empty($this->readonly) ? ' readonly="readonly"' : '';
+		$disabled = !empty($this->disabled) ? ' disabled="disabled"' : '';
+		$auto = !empty($this->autocomplete) ? ' autocomplete="off"' : '';
+		$placeholder = !empty($this->placeholder) ? ' placeholder="' . $this->placeholder . '"' : '';
 
 		$script = '';
 

--- a/libraries/joomla/form/fields/radio.php
+++ b/libraries/joomla/form/fields/radio.php
@@ -29,6 +29,14 @@ class JFormFieldRadio extends JFormField
 	protected $type = 'Radio';
 
 	/**
+	 * The text to prepend to class for the form field.
+	 *
+	 * @var    string
+	 * @since  12.3
+	 */
+	protected $prependToClass = 'radio';
+
+	/**
 	 * Method to get the radio button field input markup.
 	 *
 	 * @return  string  The field input markup.
@@ -40,7 +48,7 @@ class JFormFieldRadio extends JFormField
 		$html = array();
 
 		// Initialize some field attributes.
-		$class = $this->element['class'] ? ' class="radio ' . (string) $this->element['class'] . '"' : ' class="radio"';
+		$class = !empty($this->class) ? ' class="' . $this->class . '"' : '';
 
 		// Start the radio field output.
 		$html[] = '<fieldset id="' . $this->id . '"' . $class . '>';
@@ -51,7 +59,6 @@ class JFormFieldRadio extends JFormField
 		// Build the radio field output.
 		foreach ($options as $i => $option)
 		{
-
 			// Initialize some option attributes.
 			$checked = ((string) $option->value == (string) $this->value) ? ' checked="checked"' : '';
 			$class = !empty($option->class) ? ' class="' . $option->class . '"' : '';

--- a/libraries/joomla/form/fields/sessionhandler.php
+++ b/libraries/joomla/form/fields/sessionhandler.php
@@ -48,8 +48,6 @@ class JFormFieldSessionHandler extends JFormFieldList
 		}
 
 		// Merge any additional options in the XML definition.
-		$options = array_merge(parent::getOptions(), $options);
-
-		return $options;
+		return array_merge(parent::getOptions(), $options);
 	}
 }

--- a/libraries/joomla/form/fields/spacer.php
+++ b/libraries/joomla/form/fields/spacer.php
@@ -52,15 +52,14 @@ class JFormFieldSpacer extends JFormField
 	protected function getLabel()
 	{
 		$html = array();
-		$class = $this->element['class'] ? (string) $this->element['class'] : '';
 
 		$html[] = '<span class="spacer">';
 		$html[] = '<span class="before"></span>';
-		$html[] = '<span class="' . $class . '">';
+		$html[] = '<span class="' . $this->class . '">';
 
 		if ((string) $this->element['hr'] == 'true')
 		{
-			$html[] = '<hr class="' . $class . '" />';
+			$html[] = '<hr class="' . $this->class . '" />';
 		}
 		else
 		{
@@ -72,7 +71,7 @@ class JFormFieldSpacer extends JFormField
 
 			// Build the class for the label.
 			$class = !empty($this->description) ? 'hasTip' : '';
-			$class = $this->required == true ? $class . ' required' : $class;
+			$class = !empty($this->required) ? $class . ' required' : $class;
 
 			// Add the opening label tag and main attributes attributes.
 			$label .= '<label id="' . $this->id . '-lbl" class="' . $class . '"';
@@ -95,7 +94,7 @@ class JFormFieldSpacer extends JFormField
 		$html[] = '<span class="after"></span>';
 		$html[] = '</span>';
 
-		return implode('', $html);
+		return implode($html);
 	}
 
 	/**

--- a/libraries/joomla/form/fields/sql.php
+++ b/libraries/joomla/form/fields/sql.php
@@ -29,6 +29,79 @@ class JFormFieldSQL extends JFormFieldList
 	public $type = 'SQL';
 
 	/**
+	 * The item key name
+	 *
+	 * @var    string
+	 * @since  12.3
+	 */
+	protected $keyField;
+
+	/**
+	 * The item field containing the value
+	 *
+	 * @var    string
+	 * @since  12.3
+	 */
+	protected $valueField;
+
+	/**
+	 * Whether or not to translate the field
+	 *
+	 * @var    boolean
+	 * @since  12.3
+	 */
+	protected $translate = false;
+
+	/**
+	 * Whether or not to translate the field
+	 *
+	 * @var    boolean
+	 * @since  12.3
+	 */
+	protected $query = false;
+
+	/**
+	 * Method to attach a JForm object to the field.
+	 *
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     JFormField::setup()
+	 * @since   12.3
+	 */
+	public function setup(SimpleXMLElement $element, $value, $group = null)
+	{
+		parent::setup($element, $value, $group);
+
+		if (!empty($this->element['key_field']))
+		{
+			$this->keyField = (string) $this->element['key_field'];
+		}
+
+		if (!empty($this->element['value_field']))
+		{
+			$this->valueField = (string) $this->element['value_field'];
+		}
+
+		if (!empty($this->element['translate']))
+		{
+			$this->translate = (boolean) $this->element['translate'];
+		}
+
+		if (!empty($this->element['query']))
+		{
+			$this->query = (string) $this->element['query'];
+		}
+
+		return true;
+	}
+
+	/**
 	 * Method to get the custom field options.
 	 * Use the query attribute to supply a query to generate the list.
 	 *
@@ -41,16 +114,14 @@ class JFormFieldSQL extends JFormFieldList
 		$options = array();
 
 		// Initialize some field attributes.
-		$key = $this->element['key_field'] ? (string) $this->element['key_field'] : 'value';
-		$value = $this->element['value_field'] ? (string) $this->element['value_field'] : (string) $this->element['name'];
-		$translate = $this->element['translate'] ? (string) $this->element['translate'] : false;
-		$query = (string) $this->element['query'];
+		$key = $this->keyField;
+		$value = !empty($this->valueField) ? $this->valueField : (string) $this->element['name'];
 
 		// Get the database object.
 		$db = JFactory::getDBO();
 
 		// Set the query and get the result list.
-		$db->setQuery($query);
+		$db->setQuery($this->query);
 		$items = $db->loadObjectlist();
 
 		// Build the field options.
@@ -58,7 +129,7 @@ class JFormFieldSQL extends JFormFieldList
 		{
 			foreach ($items as $item)
 			{
-				if ($translate == true)
+				if ($this->translate)
 				{
 					$options[] = JHtml::_('select.option', $item->$key, JText::_($item->$value));
 				}
@@ -70,8 +141,6 @@ class JFormFieldSQL extends JFormFieldList
 		}
 
 		// Merge any additional options in the XML definition.
-		$options = array_merge(parent::getOptions(), $options);
-
-		return $options;
+		return array_merge(parent::getOptions(), $options);
 	}
 }

--- a/libraries/joomla/form/fields/text.php
+++ b/libraries/joomla/form/fields/text.php
@@ -30,6 +30,40 @@ class JFormFieldText extends JFormField
 	protected $type = 'Text';
 
 	/**
+	 * The HTML5 placeholder for this field.
+	 *
+	 * @var    string
+	 * @since  12.3
+	 */
+	protected $placeholder;
+
+	/**
+	 * Method to attach a JForm object to the field.
+	 *
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     JFormField::setup()
+	 * @since   12.3
+	 */
+	public function setup(SimpleXMLElement $element, $value, $group = null)
+	{
+		parent::setup($element, $value, $group);
+
+		if (!empty($element['placeholder']))
+		{
+			$this->placeholder = (string) $element['placeholder'];
+		}
+
+		return true;
+	}
+
+	/**
 	 * Method to get the field input markup.
 	 *
 	 * @return  string  The field input markup.
@@ -39,16 +73,15 @@ class JFormFieldText extends JFormField
 	protected function getInput()
 	{
 		// Initialize some field attributes.
-		$size = $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
-		$maxLength = $this->element['maxlength'] ? ' maxlength="' . (int) $this->element['maxlength'] . '"' : '';
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
-		$readonly = ((string) $this->element['readonly'] == 'true') ? ' readonly="readonly"' : '';
-		$disabled = ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
+		$size = !empty($this->size) ? ' size="' . $this->size . '"' : '';
+		$readonly = !empty($this->readonly) ? ' readonly="readonly"' : '';
+		$disabled = !empty($this->disabled) ? ' disabled="disabled"' : '';
+		$class = !empty($this->class) ? ' class="' . $this->class . '"' : '';
+		$onchange = !empty($this->onchange) ? ' onchange="' . $this->onchange . '"' : '';
+		$maxLength = !empty($this->maxlength) ? ' maxlength="' . $this->maxlength . '"' : '';
+		$placeholder = !empty($this->placeholder) ? ' placeholder="' . $this->placeholder . '"' : '';
 
-		// Initialize JavaScript field attributes.
-		$onchange = $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
-
-		return '<input type="text" name="' . $this->name . '" id="' . $this->id . '"' . ' value="'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $class . $size . $disabled . $readonly . $onchange . $maxLength . '/>';
+		return '<input type="text" name="' . $this->name . '" id="' . $this->id . '"' . ' value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8')
+			. '"' . $class . $size . $disabled . $readonly . $onchange . $maxLength . $placeholder . '/>';
 	}
 }

--- a/libraries/joomla/form/fields/textarea.php
+++ b/libraries/joomla/form/fields/textarea.php
@@ -29,6 +29,66 @@ class JFormFieldTextarea extends JFormField
 	protected $type = 'Textarea';
 
 	/**
+	 * The number of cols for the field
+	 *
+	 * @var    string
+	 * @since  12.3
+	 */
+	protected $cols;
+
+	/**
+	 * The number of rows for the field
+	 *
+	 * @var    string
+	 * @since  12.3
+	 */
+	protected $rows;
+
+	/**
+	 * The HTML5 placeholder for this field.
+	 *
+	 * @var    string
+	 * @since  12.3
+	 */
+	protected $placeholder = null;
+
+	/**
+	 * Method to attach a JForm object to the field.
+	 *
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     JFormField::setup()
+	 * @since   12.3
+	 */
+	public function setup(SimpleXMLElement $element, $value, $group = null)
+	{
+		parent::setup($element, $value, $group);
+
+		if (!empty($this->element['cols']))
+		{
+			$this->cols = (int) $this->element['cols'];
+		}
+
+		if (!empty($this->element['rows']))
+		{
+			$this->rows = (int) $this->element['rows'];
+		}
+
+		if (!empty($this->element['placeholder']))
+		{
+			$this->placeholder = (int) $this->element['placeholder'];
+		}
+
+		return true;
+	}
+
+	/**
 	 * Method to get the textarea field input markup.
 	 * Use the rows and columns attributes to specify the dimensions of the area.
 	 *
@@ -39,15 +99,14 @@ class JFormFieldTextarea extends JFormField
 	protected function getInput()
 	{
 		// Initialize some field attributes.
-		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
-		$disabled = ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
-		$columns = $this->element['cols'] ? ' cols="' . (int) $this->element['cols'] . '"' : '';
-		$rows = $this->element['rows'] ? ' rows="' . (int) $this->element['rows'] . '"' : '';
+		$class = !empty($this->class) ? ' class="' . $this->class . '"' : '';
+		$disabled = !empty($this->disabled) ? ' disabled="disabled"' : '';
+		$columns = !empty($this->cols) ? ' cols="' . $this->cols . '"' : '';
+		$rows = !empty($this->rows) ? ' rows="' . $this->rows . '"' : '';
+		$onchange = !empty($this->onchange) ? ' onchange="' . $this->onchange . '"' : '';
+		$placeholder = !empty($this->placeholder) ? ' placeholder="' . $this->placeholder . '"' : '';
 
-		// Initialize JavaScript field attributes.
-		$onchange = $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
-
-		return '<textarea name="' . $this->name . '" id="' . $this->id . '"' . $columns . $rows . $class . $disabled . $onchange . '>'
+		return '<textarea name="' . $this->name . '" id="' . $this->id . '"' . $columns . $rows . $class . $disabled . $onchange . $placeholder . '>'
 			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '</textarea>';
 	}
 }

--- a/libraries/joomla/form/fields/textarea.php
+++ b/libraries/joomla/form/fields/textarea.php
@@ -82,7 +82,7 @@ class JFormFieldTextarea extends JFormField
 
 		if (!empty($this->element['placeholder']))
 		{
-			$this->placeholder = (int) $this->element['placeholder'];
+			$this->placeholder = (string) $this->element['placeholder'];
 		}
 
 		return true;

--- a/libraries/joomla/form/fields/timezone.php
+++ b/libraries/joomla/form/fields/timezone.php
@@ -30,6 +30,40 @@ class JFormFieldTimezone extends JFormFieldGroupedList
 	protected $type = 'Timezone';
 
 	/**
+	 * The field containing the key for the input field.
+	 *
+	 * @var    string
+	 * @since  12.3
+	 */
+	protected $keyField = 'id';
+
+	/**
+	 * Method to attach a JForm object to the field.
+	 *
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     JFormField::setup()
+	 * @since   12.3
+	 */
+	public function setup(SimpleXMLElement $element, $value, $group = null)
+	{
+		parent::setup($element, $value, $group);
+
+		if (!empty($this->element['key_field']))
+		{
+			$this->keyField = (string) $this->element['key_field'];
+		}
+
+		return true;
+	}
+
+	/**
 	 * The list of available timezone groups to use.
 	 *
 	 * @var    array
@@ -48,9 +82,7 @@ class JFormFieldTimezone extends JFormFieldGroupedList
 	protected function getGroups()
 	{
 		$groups = array();
-
-		$keyField = $this->element['key_field'] ? (string) $this->element['key_field'] : 'id';
-		$keyValue = $this->form->getValue($keyField);
+		$keyValue = $this->form->getValue($this->keyField);
 
 		// If the timezone is not set use the server setting.
 		if (strlen($this->value) == 0 && empty($keyValue))
@@ -101,8 +133,6 @@ class JFormFieldTimezone extends JFormFieldGroupedList
 		}
 
 		// Merge any additional groups in the XML definition.
-		$groups = array_merge(parent::getGroups(), $groups);
-
-		return $groups;
+		return array_merge(parent::getGroups(), $groups);
 	}
 }

--- a/libraries/joomla/form/fields/usergroup.php
+++ b/libraries/joomla/form/fields/usergroup.php
@@ -41,18 +41,15 @@ class JFormFieldUsergroup extends JFormField
 		$attr = '';
 
 		// Initialize some field attributes.
-		$attr .= $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
-		$attr .= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
-		$attr .= $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
-		$attr .= $this->multiple ? ' multiple="multiple"' : '';
-
-		// Initialize JavaScript field attributes.
-		$attr .= $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
+		$attr .= !empty($this->class) ? ' class="' . $this->class . '"' : '';
+		$attr .= !empty($this->disabled) ? ' disabled="disabled"' : '';
+		$attr .= !empty($this->size) ? ' size="' . $this->size . '"' : '';
+		$attr .= !empty($this->multiple) ? ' multiple="multiple"' : '';
+		$attr .= !empty($this->onchange) ? ' onchange="' . $this->onchange . '"' : '';
 
 		// Iterate through the children and build an array of options.
 		foreach ($this->element->children() as $option)
 		{
-
 			// Only add <option /> elements.
 			if ($option->getName() != 'option')
 			{

--- a/tests/suites/unit/joomla/form/JFormFieldTest.php
+++ b/tests/suites/unit/joomla/form/JFormFieldTest.php
@@ -345,12 +345,14 @@ class JFormFieldTest extends TestCase
 			'Line:' . __LINE__ . ' XML string should load successfully.'
 		);
 
-		$field = new JFormFieldInspector($form);
+		//$field = new JFormFieldInspector($form);
 
 		// Standard usage.
 
 		$xml = $form->getXML();
 		$title = array_pop($xml->xpath('fields/field[@name="title"]'));
+		$class = JFormHelper::loadFieldClass($title['type']);
+		$field = new $class($form);
 
 		$this->assertThat(
 			$field->setup($title, 'The title'),
@@ -402,7 +404,7 @@ class JFormFieldTest extends TestCase
 
 		$this->assertThat(
 			$field->input,
-			$this->equalTo(''),
+			$this->equalTo('<input type="text" name="title" id="title_id" value="The title" class="inputbox required"/>'),
 			'Line:' . __LINE__ . ' The property should be computed from the XML.'
 		);
 
@@ -427,6 +429,8 @@ class JFormFieldTest extends TestCase
 		// Test multiple attribute and form group name.
 
 		$colours = array_pop($xml->xpath('fields/fields[@name="params"]/field[@name="colours"]'));
+		$class = JFormHelper::loadFieldClass($colours['type']);
+		$field = new $class($form);
 
 		$this->assertThat(
 			$field->setup($colours, 'green', 'params'),
@@ -461,6 +465,8 @@ class JFormFieldTest extends TestCase
 		// Test hidden field type.
 
 		$id = array_pop($xml->xpath('fields/field[@name="id"]'));
+		$class = JFormHelper::loadFieldClass($id['type']);
+		$field = new $class($form);
 
 		$this->assertThat(
 			$field->setup($id, 42),
@@ -477,6 +483,8 @@ class JFormFieldTest extends TestCase
 		// Test hidden attribute.
 
 		$createdDate = array_pop($xml->xpath('fields/field[@name="created_date"]'));
+		$class = JFormHelper::loadFieldClass($createdDate['type']);
+		$field = new $class($form);
 
 		$this->assertThat(
 			$field->setup($createdDate, '0000-00-00 00:00:00'),
@@ -493,6 +501,8 @@ class JFormFieldTest extends TestCase
 		// Test automatic generated name.
 
 		$spacer = array_pop($xml->xpath('fields/field[@type="spacer"]'));
+		$class = JFormHelper::loadFieldClass($spacer['type']);
+		$field = new $class($form);
 
 		$this->assertThat(
 			$field->setup($spacer, ''),
@@ -509,7 +519,9 @@ class JFormFieldTest extends TestCase
 		// Test nested groups and forced multiple.
 
 		$comment = array_pop($xml->xpath('fields/fields[@name="params"]/fields[@name="subparams"]/field[@name="comment"]'));
-		$field->forceMultiple = true;
+		$class = JFormHelper::loadFieldClass($comment['type']);
+		$field = new $class($form);
+		TestReflection::setValue($field, 'multiple', true);
 
 		$this->assertThat(
 			$field->setup($comment, 'My comment', 'params.subparams'),

--- a/tests/suites/unit/joomla/form/fields/JFormFieldCalendarTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldCalendarTest.php
@@ -73,10 +73,12 @@ class JFormFieldCalendarTest extends TestCase
 					'myCalendarId',
 					'%m-%Y-%d',
 					array(
-						'size' => '25',
-						'maxlength' => '45',
+						'size' => 25,
+						'maxlength' => 45,
 						'class' => 'myClass',
-						'readonly' => 'readonly',
+						'readonly' => true,
+						'disabled' => false,
+						'onchange' => ''
 					)
 				)
 			),
@@ -104,10 +106,12 @@ class JFormFieldCalendarTest extends TestCase
 					'myCalendarId',
 					'%m-%Y-%d',
 					array(
-						'size' => '25',
-						'maxlength' => '0',
+						'size' => 25,
+						'maxlength' => 0,
 						'class' => 'myClass',
-						'readonly' => 'readonly',
+						'readonly' => true,
+						'disabled' => false,
+						'onchange' => ''
 					)
 				)
 			),
@@ -135,10 +139,12 @@ class JFormFieldCalendarTest extends TestCase
 					'myCalendarId',
 					'%Y-%m-%d',
 					array(
-						'size' => '25',
-						'maxlength' => '0',
+						'size' => 25,
+						'maxlength' => 0,
 						'class' => 'myClass',
-						'readonly' => 'readonly',
+						'readonly' => true,
+						'disabled' => false,
+						'onchange' => ''
 					)
 				)
 			),
@@ -166,11 +172,12 @@ class JFormFieldCalendarTest extends TestCase
 					'myCalendarId',
 					'%Y-%m-%d',
 					array(
-						'size' => '25',
-						'maxlength' => '0',
+						'size' => 25,
+						'maxlength' => 0,
 						'class' => 'myClass',
-						'onchange' => 'This is my onchange value',
-						'readonly' => 'readonly',
+						'readonly' => true,
+						'disabled' => false,
+						'onchange' => 'This is my onchange value'
 					)
 				)
 			),
@@ -198,10 +205,12 @@ class JFormFieldCalendarTest extends TestCase
 					'myCalendarId',
 					'%Y-%m-%d',
 					array(
-						'size' => '25',
-						'maxlength' => '0',
+						'size' => 25,
+						'maxlength' => 0,
 						'class' => 'myClass',
-						'onchange' => 'This is my onchange value',
+						'readonly' => true,
+						'disabled' => false,
+						'onchange' => 'This is my onchange value'
 					)
 				)
 			),
@@ -229,10 +238,12 @@ class JFormFieldCalendarTest extends TestCase
 					'myCalendarId',
 					'%Y-%m-%d',
 					array(
-						'size' => '25',
-						'maxlength' => '0',
-						'disabled' => 'disabled',
-						'onchange' => 'This is my onchange value',
+						'size' => 25,
+						'maxlength' => 0,
+						'class' => '',
+						'readonly' => true,
+						'disabled' => true,
+						'onchange' => 'This is my onchange value'
 					)
 				)
 			),
@@ -260,14 +271,39 @@ class JFormFieldCalendarTest extends TestCase
 					'myCalendarId',
 					'%Y-%m-%d',
 					array(
-						'size' => '25',
-						'maxlength' => '0',
-						'disabled' => 'disabled',
-						'onchange' => 'This is my onchange value',
+						'size' => 25,
+						'maxlength' => 0,
+						'class' => '',
+						'readonly' => true,
+						'disabled' => true,
+						'onchange' => 'This is my onchange value'
 					)
 				)
 			)
 		);
+	}
+
+	/**
+	 * Convert an array into XML for use with simplexml_load_string
+	 *
+	 * @param   array  $array  The array to convert to an XML string
+	 *
+	 * @return  object  SimpleXMLElement
+	 *
+	 * @since   12.3
+	 */
+	protected function arrayToFieldXml(array $array)
+	{
+		$xml = '<field ';
+
+		foreach ($array as $key => $value)
+		{
+			$xml .= $key . '="' . $value . '" ';
+		}
+
+		$xml .= '/>';
+
+		return simplexml_load_string($xml);
 	}
 
 	/**
@@ -313,11 +349,16 @@ class JFormFieldCalendarTest extends TestCase
 			$expectedParameters[0] = strftime('%Y-%m-%d');
 		}
 
+		// Transform array $element into SimpleXMLElement for the setup method
+		if (is_array($element))
+		{
+			$element = $this->arrayToFieldXml($element);
+		}
+
 		// Setup our values from our data set
-		$calendar->setProtectedProperty('element', $element);
+		$calendar->setup($element, $value);
 		$calendar->setProtectedProperty('name', $name);
 		$calendar->setProtectedProperty('id', $id);
-		$calendar->setProtectedProperty('value', $value);
 
 		// Create the mock to implant into JHtml so that we can check our values
 		$mock = $this->getMock('calendarHandler', array('calendar'));
@@ -375,23 +416,19 @@ class JFormFieldCalendarTest extends TestCase
 		$calendar = new JFormFieldCalendarInspector;
 
 		// Setup our values from our data set
-		$calendar->setProtectedProperty('element',
-			array(
-				'format' => '%m-%Y-%d',
-				'size' => '25',
-				'maxlength' => '45',
-				'class' => 'myClass',
-				'readonly' => 'true',
-				'disabled' => 'false',
-				'onchange' => '',
-				'filter' => 'SERVER_UTC'
-			)
-		);
+		$element = simplexml_load_string('<field
+			format="%m-%Y-%d"
+			size="25"
+			maxlength="45"
+			class="myClass"
+			readonly="true"
+			disabled="false"
+			onchange=""
+			filter="SERVER_UTC"
+		/>');
+		$calendar->setup($element, 1269442718);
 		$calendar->setProtectedProperty('name', 'myElementName');
 		$calendar->setProtectedProperty('id', 'myElementId');
-
-		// 1269442718
-		$calendar->setProtectedProperty('value', 1269442718);
 
 		// -5
 		$config->set('offset', 'US/Eastern');
@@ -407,10 +444,12 @@ class JFormFieldCalendarTest extends TestCase
 			->method('calendar')
 			->with('2010-03-24 10:58:38', 'myElementName', 'myElementId', '%m-%Y-%d',
 			array(
-				'size' => '25',
-				'maxlength' => '45',
+				'size' => 25,
+				'maxlength' => 45,
 				'class' => 'myClass',
-				'readonly' => 'readonly'
+				'readonly' => true,
+				'disabled' => false,
+				'onchange' => ''
 			)
 		);
 
@@ -462,23 +501,19 @@ class JFormFieldCalendarTest extends TestCase
 		$calendar = new JFormFieldCalendarInspector;
 
 		// Setup our values from our data set
-		$calendar->setProtectedProperty('element',
-			array(
-				'format' => '%m-%Y-%d',
-				'size' => '25',
-				'maxlength' => '45',
-				'class' => 'myClass',
-				'readonly' => 'true',
-				'disabled' => 'false',
-				'onchange' => '',
-				'filter' => 'USER_UTC'
-			)
-		);
+		$element = simplexml_load_string('<field
+			format="%m-%Y-%d"
+			size="25"
+			maxlength="45"
+			class="myClass"
+			readonly="true"
+			disabled="false"
+			onchange=""
+			filter="USER_UTC"
+		/>');
+		$calendar->setup($element, 1269442718);
 		$calendar->setProtectedProperty('name', 'myElementName');
 		$calendar->setProtectedProperty('id', 'myElementId');
-
-		// 1269442718
-		$calendar->setProtectedProperty('value', 1269442718);
 
 		// +4
 		$config->set('offset', 'Asia/Muscat');
@@ -493,10 +528,12 @@ class JFormFieldCalendarTest extends TestCase
 			->method('calendar')
 			->with('2010-03-24 18:58:38', 'myElementName', 'myElementId', '%m-%Y-%d',
 			array(
-				'size' => '25',
-				'maxlength' => '45',
+				'size' => 25,
+				'maxlength' => 45,
 				'class' => 'myClass',
-				'readonly' => 'readonly'
+				'readonly' => true,
+				'disabled' => false,
+				'onchange' => ''
 			)
 		);
 
@@ -517,10 +554,12 @@ class JFormFieldCalendarTest extends TestCase
 			->method('calendar')
 			->with('2010-03-24 22:58:38', 'myElementName', 'myElementId', '%m-%Y-%d',
 			array(
-				'size' => '25',
-				'maxlength' => '45',
+				'size' => 25,
+				'maxlength' => 45,
 				'class' => 'myClass',
-				'readonly' => 'readonly'
+				'readonly' => true,
+				'disabled' => false,
+				'onchange' => '',
 			)
 		);
 

--- a/tests/suites/unit/joomla/form/fields/JFormFieldCheckboxTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldCheckboxTest.php
@@ -72,10 +72,9 @@ class JFormFieldCheckboxTest extends TestCase
 		// Test with no checked element
 		$element = simplexml_load_string(
 			'<field name="color" type="checkbox" value="red" />');
-		TestReflection::setValue($formField, 'element', $element);
+		TestReflection::invoke($formField, 'setup', $element, 'red');
 		TestReflection::setValue($formField, 'id', 'myTestId');
 		TestReflection::setValue($formField, 'name', 'myTestName');
-		TestReflection::setValue($formField, 'value', 'red');
 
 		$this->assertEquals(
 			'<input type="checkbox" name="myTestName" id="myTestId" value="red" checked="checked" />',
@@ -96,9 +95,8 @@ class JFormFieldCheckboxTest extends TestCase
 		$formField = new JFormFieldCheckbox;
 
 		// Test with checked element
-		$element = simplexml_load_string(
-			'<field name="color" type="checkbox" value="red" checked="checked" />');
-		TestReflection::setValue($formField, 'element', $element);
+		$element = simplexml_load_string('<field name="color" type="checkbox" value="red" checked="checked" />');
+		TestReflection::invoke($formField, 'setup', $element, null);
 		TestReflection::setValue($formField, 'id', 'myTestId');
 		TestReflection::setValue($formField, 'name', 'myTestName');
 
@@ -121,9 +119,8 @@ class JFormFieldCheckboxTest extends TestCase
 		$formField = new JFormFieldCheckbox;
 
 		// Test with checked element
-		$element = simplexml_load_string(
-			'<field name="color" type="checkbox" value="red" disabled="true" />');
-		TestReflection::setValue($formField, 'element', $element);
+		$element = simplexml_load_string('<field name="color" type="checkbox" value="red" disabled="true" />');
+		TestReflection::invoke($formField, 'setup', $element, null);
 		TestReflection::setValue($formField, 'id', 'myTestId');
 		TestReflection::setValue($formField, 'name', 'myTestName');
 

--- a/tests/suites/unit/joomla/form/fields/JFormFieldCheckboxesTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldCheckboxesTest.php
@@ -26,6 +26,22 @@ class JFormFieldCheckboxesTest extends TestCase
 	protected function setUp()
 	{
 		require_once JPATH_PLATFORM . '/joomla/form/fields/checkboxes.php';
+		$this->mock = $this->getMock('JFormFieldCheckboxes', array('getOptions'));
+
+		$option1 = new JObject;
+		$option1->set('value', 'red');
+		$option1->set('text', 'red');
+
+		$option2 = new JObject;
+		$option2->set('value', 'blue');
+		$option2->set('text', 'blue');
+
+		$optionsReturn = array($option1, $option2);
+		$this->mock->expects($this->any())
+			->method('getOptions')
+			->will($this->returnValue($optionsReturn));
+			
+		parent::setUp();
 	}
 
 	/**
@@ -37,34 +53,19 @@ class JFormFieldCheckboxesTest extends TestCase
 	 */
 	public function testGetInputNoValueNoChecked()
 	{
-		$formFieldCheckboxes = $this->getMock('JFormFieldCheckboxes', array('getOptions'));
-
-		$option1 = new JObject;
-		$option1->set('value', 'red');
-		$option1->set('text', 'red');
-
-		$option2 = new JObject;
-		$option2->set('value', 'blue');
-		$option2->set('text', 'blue');
-
-		$optionsReturn = array($option1, $option2);
-		$formFieldCheckboxes->expects($this->any())
-			->method('getOptions')
-			->will($this->returnValue($optionsReturn));
-
 		// Test with no value, no checked element
 		$element = simplexml_load_string(
 			'<field name="color" type="checkboxes">
 			<option value="red">red</option>
 			<option value="blue">blue</option>
 			</field>');
-		TestReflection::setValue($formFieldCheckboxes, 'element', $element);
-		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
-		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
+		TestReflection::invoke($this->mock, 'setup', $element, '', null);
+		TestReflection::setValue($this->mock, 'id', 'myTestId');
+		TestReflection::setValue($this->mock, 'name', 'myTestName');
 
 		$this->assertEquals(
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
-			TestReflection::invoke($formFieldCheckboxes, 'getInput'),
+			TestReflection::invoke($this->mock, 'getInput'),
 			'The field with no value and no checked values did not produce the right html'
 		);
 	}
@@ -78,35 +79,19 @@ class JFormFieldCheckboxesTest extends TestCase
 	 */
 	public function testGetInputValueNoChecked()
 	{
-		$formFieldCheckboxes = $this->getMock('JFormFieldCheckboxes', array('getOptions'));
-
-		$option1 = new JObject;
-		$option1->set('value', 'red');
-		$option1->set('text', 'red');
-
-		$option2 = new JObject;
-		$option2->set('value', 'blue');
-		$option2->set('text', 'blue');
-
-		$optionsReturn = array($option1, $option2);
-		$formFieldCheckboxes->expects($this->any())
-			->method('getOptions')
-			->will($this->returnValue($optionsReturn));
-
 		// Test with one value checked, no checked element
 		$element = simplexml_load_string(
 			'<field name="color" type="checkboxes">
 			<option value="red">red</option>
 			<option value="blue">blue</option>
 			</field>');
-		TestReflection::setValue($formFieldCheckboxes, 'element', $element);
-		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
-		TestReflection::setValue($formFieldCheckboxes, 'value', 'red');
-		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
+		TestReflection::invoke($this->mock, 'setup', $element, 'red', null);
+		TestReflection::setValue($this->mock, 'id', 'myTestId');
+		TestReflection::setValue($this->mock, 'name', 'myTestName');
 
 		$this->assertEquals(
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red" checked="checked"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
-			TestReflection::invoke($formFieldCheckboxes, 'getInput'),
+			TestReflection::invoke($this->mock, 'getInput'),
 			'The field with one value did not produce the right html'
 		);
 	}
@@ -120,21 +105,6 @@ class JFormFieldCheckboxesTest extends TestCase
 	 */
 	public function testGetInputValueArrayNoChecked()
 	{
-		$formFieldCheckboxes = $this->getMock('JFormFieldCheckboxes', array('getOptions'));
-
-		$option1 = new JObject;
-		$option1->set('value', 'red');
-		$option1->set('text', 'red');
-
-		$option2 = new JObject;
-		$option2->set('value', 'blue');
-		$option2->set('text', 'blue');
-
-		$optionsReturn = array($option1, $option2);
-		$formFieldCheckboxes->expects($this->any())
-			->method('getOptions')
-			->will($this->returnValue($optionsReturn));
-
 		// Test with one value checked, no checked element
 		$element = simplexml_load_string(
 			'<field name="color" type="checkboxes">
@@ -142,14 +112,13 @@ class JFormFieldCheckboxesTest extends TestCase
 			<option value="blue">blue</option>
 			</field>');
 		$valuearray = array('red');
-		TestReflection::setValue($formFieldCheckboxes, 'element', $element);
-		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
-		TestReflection::setValue($formFieldCheckboxes, 'value', $valuearray);
-		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
+		TestReflection::invoke($this->mock, 'setup', $element, $valuearray, null);
+		TestReflection::setValue($this->mock, 'id', 'myTestId');
+		TestReflection::setValue($this->mock, 'name', 'myTestName');
 
 		$this->assertEquals(
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red" checked="checked"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
-			TestReflection::invoke($formFieldCheckboxes, 'getInput'),
+			TestReflection::invoke($this->mock, 'getInput'),
 			'The field with one value did not produce the right html'
 		);
 	}
@@ -163,34 +132,19 @@ class JFormFieldCheckboxesTest extends TestCase
 	 */
 	public function testGetInputNoValueOneChecked()
 	{
-		$formFieldCheckboxes = $this->getMock('JFormFieldCheckboxes', array('getOptions'));
-
-		$option1 = new JObject;
-		$option1->set('value', 'red');
-		$option1->set('text', 'red');
-
-		$option2 = new JObject;
-		$option2->set('value', 'blue');
-		$option2->set('text', 'blue');
-
-		$optionsReturn = array($option1, $option2);
-		$formFieldCheckboxes->expects($this->any())
-			->method('getOptions')
-			->will($this->returnValue($optionsReturn));
-
 		// Test with nothing checked, one value in checked element
 		$element = simplexml_load_string(
 			'<field name="color" type="checkboxes" checked="blue">
 			<option value="red">red</option>
 			<option value="blue">blue</option>
 			</field>');
-		TestReflection::setValue($formFieldCheckboxes, 'element', $element);
-		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
-		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
+		TestReflection::invoke($this->mock, 'setup', $element, null, null);
+		TestReflection::setValue($this->mock, 'id', 'myTestId');
+		TestReflection::setValue($this->mock, 'name', 'myTestName');
 
 		$this->assertEquals(
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue" checked="checked"/><label for="myTestId1">blue</label></li></ul></fieldset>',
-			TestReflection::invoke($formFieldCheckboxes, 'getInput'),
+			TestReflection::invoke($this->mock, 'getInput'),
 			'The field with no values and one value in the checked element did not produce the right html'
 		);
 	}
@@ -204,35 +158,19 @@ class JFormFieldCheckboxesTest extends TestCase
 	 */
 	public function testGetInputNoValueTwoChecked()
 	{
-		$formFieldCheckboxes = $this->getMock('JFormFieldCheckboxes', array('getOptions'));
-
-		$option1 = new JObject;
-		$option1->set('value', 'red');
-		$option1->set('text', 'red');
-
-		$option2 = new JObject;
-		$option2->set('value', 'blue');
-		$option2->set('text', 'blue');
-
-		$optionsReturn = array($option1, $option2);
-		$formFieldCheckboxes->expects($this->any())
-			->method('getOptions')
-			->will($this->returnValue($optionsReturn));
-
 		// Test with nothing checked, two values in checked element
 		$element = simplexml_load_string(
 			'<field name="color" type="checkboxes" checked="red,blue">
 			<option value="red">red</option>
 			<option value="blue">blue</option>
 			</field>');
-		TestReflection::setValue($formFieldCheckboxes, 'element', $element);
-		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
-		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
-		TestReflection::setValue($formFieldCheckboxes, 'value', '""');
+		TestReflection::invoke($this->mock, 'setup', $element, '""', null);
+		TestReflection::setValue($this->mock, 'id', 'myTestId');
+		TestReflection::setValue($this->mock, 'name', 'myTestName');
 
 		$this->assertEquals(
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
-			TestReflection::invoke($formFieldCheckboxes, 'getInput'),
+			TestReflection::invoke($this->mock, 'getInput'),
 			'The field with no values and two items in the checked element did not produce the right html'
 		);
 	}
@@ -246,35 +184,19 @@ class JFormFieldCheckboxesTest extends TestCase
 	 */
 	public function testGetInputValueChecked()
 	{
-		$formFieldCheckboxes = $this->getMock('JFormFieldCheckboxes', array('getOptions'));
-
-		$option1 = new JObject;
-		$option1->set('value', 'red');
-		$option1->set('text', 'red');
-
-		$option2 = new JObject;
-		$option2->set('value', 'blue');
-		$option2->set('text', 'blue');
-
-		$optionsReturn = array($option1, $option2);
-		$formFieldCheckboxes->expects($this->any())
-			->method('getOptions')
-			->will($this->returnValue($optionsReturn));
-
 		// Test with one item checked, a different value in checked element
 		$element = simplexml_load_string(
 			'<field name="color" type="checkboxes" checked="blue">
 			<option value="red">red</option>
 			<option value="blue">blue</option>
 			</field>');
-		TestReflection::setValue($formFieldCheckboxes, 'element', $element);
-		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
-		TestReflection::setValue($formFieldCheckboxes, 'value', 'red');
-		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
+		TestReflection::invoke($this->mock, 'setup', $element, 'red', null);
+		TestReflection::setValue($this->mock, 'id', 'myTestId');
+		TestReflection::setValue($this->mock, 'name', 'myTestName');
 
 		$this->assertEquals(
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red" checked="checked"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
-			TestReflection::invoke($formFieldCheckboxes, 'getInput'),
+			TestReflection::invoke($this->mock, 'getInput'),
 			'The field with one value and a different value in the checked element did not produce the right html'
 		);
 	}
@@ -288,35 +210,19 @@ class JFormFieldCheckboxesTest extends TestCase
 	 */
 	public function testGetInputValuesNoChecked()
 	{
-		$formFieldCheckboxes = $this->getMock('JFormFieldCheckboxes', array('getOptions'));
-
-		$option1 = new JObject;
-		$option1->set('value', 'red');
-		$option1->set('text', 'red');
-
-		$option2 = new JObject;
-		$option2->set('value', 'blue');
-		$option2->set('text', 'blue');
-
-		$optionsReturn = array($option1, $option2);
-		$formFieldCheckboxes->expects($this->any())
-			->method('getOptions')
-			->will($this->returnValue($optionsReturn));
-
 		// Test with two values checked, no checked element
 		$element = simplexml_load_string(
 			'<field name="color" type="checkboxes">
 			<option value="red">red</option>
 			<option value="blue">blue</option>
 			</field>');
-		TestReflection::setValue($formFieldCheckboxes, 'element', $element);
-		TestReflection::setValue($formFieldCheckboxes, 'id', 'myTestId');
-		TestReflection::setValue($formFieldCheckboxes, 'value', 'yellow,green');
-		TestReflection::setValue($formFieldCheckboxes, 'name', 'myTestName');
+		TestReflection::invoke($this->mock, 'setup', $element, 'yellow,green', null);
+		TestReflection::setValue($this->mock, 'id', 'myTestId');
+		TestReflection::setValue($this->mock, 'name', 'myTestName');
 
 		$this->assertEquals(
 			'<fieldset id="myTestId" class="checkboxes"><ul><li><input type="checkbox" id="myTestId0" name="myTestName" value="red"/><label for="myTestId0">red</label></li><li><input type="checkbox" id="myTestId1" name="myTestName" value="blue"/><label for="myTestId1">blue</label></li></ul></fieldset>',
-			TestReflection::invoke($formFieldCheckboxes, 'getInput'),
+			TestReflection::invoke($this->mock, 'getInput'),
 			'The field with two values did not produce the right html'
 		);
 	}

--- a/tests/suites/unit/joomla/form/fields/JFormFieldColorTest.php
+++ b/tests/suites/unit/joomla/form/fields/JFormFieldColorTest.php
@@ -48,7 +48,8 @@ class JFormFieldColorTest extends TestCase
 			'Line:' . __LINE__ . ' XML string should load successfully.'
 		);
 
-		$field = new JFormFieldColor($form);
+		$class = JFormHelper::loadFieldClass('color');
+		$field = new $class($form);
 
 		$this->assertThat(
 			$field->setup($form->getXml()->field, 'value'),


### PR DESCRIPTION
After several varying discussions on the topic with @elinw and others, and some of my own frustrations, I decided to give a go at refactoing JFormField and it's sister elements. The reason I did this is that a lot of times, the field specific implementation of `getInput()` would process some logic that was already completed by `JFormField`, such as deciding if an element is readonly or disabled.

Doubling up on the workload like that is never good. Now, `JFormField::setup()` does most of the heavy lifting when it comes to determining what settings are active/inactive,  and the child classes simply worry about the html markup that those determinations require. This allows for broader, more expressive rulesets to determine functionality in the parent class, without having to be overly verbose in the child class. For example:

```
/**
 * instead of the child class doing this
 * (which is insufficient, what if the field was disabled="disabled"?)
 */
$disabled = $this->element['disabled'] == true ? 'some html' : '';

// it now does this
$disabled = !empty($this->disabled) ? 'some html' : '';
```

I did this to make it easy to add new features. In my case, I added the `$placeholder` attribute as a protected property to `JFormFieldText` and then extended similar fields that would use said attribute from that parent class.

Another new features is the `$prependToClass` property in `JFormField`. This allows you to set a class name that will always be prepended to the field. For example, look at `JFormFieldEmail`. It extends `JFormFieldText`, but also overrides the `getInput()` method, just to put in a `validate-email` class at the beginning of the input class. This also occurs in  a couple other places, and adding his feature cuts down on that code bloat. Instead of rewriting `getInput()`, do this instead:

```
protected $prependToClass = 'validate-email';
```

Also new to the mix is that each child `JFormField*` class that has it's own specific attributes now has it's own `setup()` method that handles assigning those specific attributes to the field object. See `JFormFieldTextarea` for a good example of that - https://github.com/dongilbert/joomla-platform/blob/abf409ad2feeee98005c0e779dd6c20d4b3eb249/libraries/joomla/form/fields/textarea.php#L69

Last thing - I deprectated the `$forceMultiple` property. It has it's use, but that use can be fulfilled by the `$multiple` property instead. See the `JFormField::setup()` for how I implemented this - https://github.com/dongilbert/joomla-platform/blob/abf409ad2feeee98005c0e779dd6c20d4b3eb249/libraries/joomla/form/field.php#L427

I'm not claiming this is perfect, but it does pass all the tests. And it _shouldn't_ break any backwards compatibility. I just want to start the conversation, since code speaks louder than words. :)
