### PR TITLE
Fix doc block for JRoute::_()

### DIFF
--- a/libraries/joomla/application/route.php
+++ b/libraries/joomla/application/route.php
@@ -33,8 +33,7 @@ class JRoute
 	 * @param   boolean  $xhtml  Replace & by &amp; for XML compilance.
 	 * @param   integer  $ssl    Secure state for the resolved URI.
 	 *                             1: Make URI secure using global secure site URI.
-	 *                             0: Leave URI in the same secure state as it was passed to the function.
-	 *                            -1: Make URI unsecure using the global unsecure site URI.
+	 *                             2: Make URI unsecure using the global unsecure site URI.
 	 *
 	 * @return  The translated humanly readible URL.
 	 *


### PR DESCRIPTION
As written, the doc block for `JRoute::_()` does not work as advertised.  The 0 value advertised to use the current scheme never passes the `if ((int) $ssl)` check at line 76 in the unchanged file.  As written, the only solid integer that is expected is a 1 for SSL schemes, so the parameter will accept any other integer for a non-SSL schemes.  We can also look at making the 0 value work for the third param, but as written, the code would never accomodate for that anyways.
