### PR TITLE
Clean any white spaces and/or tabs

### DIFF
--- a/libraries/legacy/installer/adapters/component.php
+++ b/libraries/legacy/installer/adapters/component.php
@@ -1264,7 +1264,7 @@ class JInstallerComponent extends JAdapterInstance
 			$data = array();
 			$data['menutype'] = 'main';
 			$data['client_id'] = 1;
-			$data['title'] = (string) $menuElement;
+			$data['title'] = (string) trim($menuElement);
 			$data['alias'] = (string) $menuElement;
 			$data['link'] = 'index.php?option=' . $option;
 			$data['type'] = 'component';
@@ -1395,7 +1395,7 @@ class JInstallerComponent extends JAdapterInstance
 			$data = array();
 			$data['menutype'] = 'main';
 			$data['client_id'] = 1;
-			$data['title'] = (string) $child;
+			$data['title'] = (string) trim($child);
 			$data['alias'] = (string) $child;
 			$data['type'] = 'component';
 			$data['published'] = 0;


### PR DESCRIPTION
Tabs that may result from manifest source formatting after the translation element
in <submenu><menu>COM_COMPONENT_SUBMENUNAME</menu></submenu> result in invisible bugs as the translation element is saved to the #__menu table with the tabs/white spaces.
Translation will not be done and the alias will be used by the system to build the menu or submenu.
Hard to debug, since white spaces and tabs are invisible in database.
Suggestion is to trim both $menuElement and $child in the _buildAdminMenus method to avoid this issue.
