### PR TITLE
cache strict standards issue when using system plugin cache in CMS

### DIFF
--- a/libraries/joomla/cache/controller.php
+++ b/libraries/joomla/cache/controller.php
@@ -204,15 +204,14 @@ class JCacheController
 	/**
 	 * Store data to cache by id and group
 	 *
-	 * @param   mixed   $data   The data to store
-	 * @param   string  $id     The cache data id
-	 * @param   string  $group  The cache data group
-	 *
-	 * @return  boolean  True if cache was stored
+	 * @param   mixed    $data        The data to store
+	 * @param   string   $id          The cache data id
+	 * @param   string   $group       The cache data group
+	 * @param   boolean  $wrkarounds  True to use wrkarounds
 	 *
 	 * @since   11.1
 	 */
-	public function store($data, $id, $group = null)
+	public function store($data, $id, $group = null, $wrkarounds = true)
 	{
 		$locktest = new stdClass;
 		$locktest->locked = null;

--- a/libraries/joomla/cache/controller.php
+++ b/libraries/joomla/cache/controller.php
@@ -209,6 +209,8 @@ class JCacheController
 	 * @param   string   $group       The cache data group
 	 * @param   boolean  $wrkarounds  True to use wrkarounds
 	 *
+	 * @return  boolean  True if cache stored
+	 * 
 	 * @since   11.1
 	 */
 	public function store($data, $id, $group = null, $wrkarounds = true)

--- a/libraries/joomla/cache/controller/page.php
+++ b/libraries/joomla/cache/controller/page.php
@@ -117,8 +117,8 @@ class JCacheControllerPage extends JCacheController
 	 * Stop the cache buffer and store the cached data
 	 *
 	 * @param   mixed    $data        The data to store
-+	 * @param   string   $id          The cache data id
-+	 * @param   string   $group       The cache data group
+	 * @param   string   $id          The cache data id
+	 * @param   string   $group       The cache data group
 	 * @param   boolean  $wrkarounds  True to use wrkarounds
 	 *
 	 * @return  boolean  True if cache stored

--- a/libraries/joomla/cache/controller/page.php
+++ b/libraries/joomla/cache/controller/page.php
@@ -125,7 +125,7 @@ class JCacheControllerPage extends JCacheController
 	 *
 	 * @since   11.1
 	 */
-	public function store($data = null, $id = null, $group = null, $wrkarounds = true)
+	public function store($data, $id, $group = null, $wrkarounds = true)
 	{
 		// Get page data from JResponse body
 		$data = JResponse::getBody();

--- a/libraries/joomla/cache/controller/page.php
+++ b/libraries/joomla/cache/controller/page.php
@@ -116,13 +116,16 @@ class JCacheControllerPage extends JCacheController
 	/**
 	 * Stop the cache buffer and store the cached data
 	 *
+	 * @param   mixed    $data        The data to store
++	 * @param   string   $id          The cache data id
++	 * @param   string   $group       The cache data group
 	 * @param   boolean  $wrkarounds  True to use wrkarounds
 	 *
 	 * @return  boolean  True if cache stored
 	 *
 	 * @since   11.1
 	 */
-	public function store($wrkarounds = true)
+	public function store($data = null, $id = null, $group = null, $wrkarounds = true)
 	{
 		// Get page data from JResponse body
 		$data = JResponse::getBody();


### PR DESCRIPTION
Solving Strict standards issue in CMS
See tracker http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=29665

Strict Standards: Declaration of JCacheControllerPage::store() should be
compatible with JCacheController::store($data, $id, $group = NULL) in
ROOT/libraries/joomla/cache/controller/page.php
on line 196
