### PR TITLE
$options['_expire'] in JSession expects minutes not seconds

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -573,7 +573,7 @@ abstract class JFactory
 		$handler = $conf->get('session_handler', 'none');
 
 		// Config time is in minutes
-		$options['expire'] = ($conf->get('lifetime')) ? $conf->get('lifetime') * 60 : 900;
+		$options['expire'] = ($conf->get('lifetime')) ? $conf->get('lifetime') : 15;
 
 		$session = JSession::getInstance($handler, $options);
 


### PR DESCRIPTION
There is a mismatch between the factory (which is converting session expiration time to seconds when it creates a session object) and JSession where the property is described as measured in minutes in several places.

https://github.com/joomla/joomla-platform/blob/staging/libraries/joomla/session/session.php#L37

https://github.com/joomla/joomla-platform/blob/staging/libraries/joomla/session/session.php#L196

This proposes to use minutes consistently.
