### PR TITLE
Allow change of user properties when JUser exists

### DIFF
--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -1003,7 +1003,7 @@ class JSession implements IteratorAggregate
 			}
 		}
 
-		// Check for clients browser
+		// Check for client's browser
 		if (in_array('fix_browser', $this->_security) && isset($_SERVER['HTTP_USER_AGENT']))
 		{
 			$browser = $this->get('session.client.browser');

--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -193,7 +193,7 @@ abstract class JUserHelper
 	 *
 	 * @param   integer  $userId  The id of the user.
 	 *
-	 * @return  object
+	 * @return  JObject
 	 *
 	 * @since   11.1
 	 */
@@ -205,7 +205,7 @@ abstract class JUserHelper
 			$userId	= $user->id;
 		}
 
-		// Get the dispatcher and load the user's plugins.
+		// Get the dispatcher and load the user plugins.
 		$dispatcher	= JEventDispatcher::getInstance();
 		JPluginHelper::importPlugin('user');
 

--- a/tests/suites/unit/joomla/JFactoryTest.php
+++ b/tests/suites/unit/joomla/JFactoryTest.php
@@ -34,6 +34,18 @@ class JFactoryTest extends TestCase
 	}
 
 	/**
+	 * Gets the data set to be loaded into the database during setup
+	 *
+	 * @return  xml dataset
+	 *
+	 * @since   12.3
+	 */
+	protected function getDataSet()
+	{
+		return $this->createXMLDataSet(__DIR__ . '/user/JUserTest.xml');
+	}
+
+	/**
 	 * Tears down the fixture.
 	 *
 	 * This method is called after a test is executed.

--- a/tests/suites/unit/joomla/session/JSessionTest.php
+++ b/tests/suites/unit/joomla/session/JSessionTest.php
@@ -122,7 +122,7 @@ class JSessionTest extends TestCase
 	}
 
 	/**
-	 * Test...
+	 * Tests...
 	 *
 	 * @covers  JSession::getExpire
 	 *
@@ -134,7 +134,7 @@ class JSessionTest extends TestCase
 	}
 
 	/**
-	 * Test...
+	 * Tests...
 	 *
 	 * @covers  JSession::getToken
 	 *


### PR DESCRIPTION
One ongoing issue with the advent of flexible user groups has been that if a JUser object has already been created for a logged in user and the user group assignments are changed elsewhere (either by code such as when a payment is made or manually by another user who has the rights to do so) the JUser is not updated since JUser already exists. The same is also true of user parameters such as time zone. Currently the only solution is to have the user logout which is both awkward and loses potentially useful data.

This pull requests adds a check in JFactory to compare the user groups, authorised view levels, and user parameters that are stored against those in JUser.  If they are different the stored values are then used. 

As a consequence of implementing this I also wrote a number of tests, added a method and modified a number of other tests. 
