### PR TITLE
Fixing namespace unit test failure

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -210,7 +210,7 @@ abstract class JLoader
 		$class = strtolower($class);
 
 		// If the class already exists do nothing.
-		if (class_exists($class))
+		if (class_exists($class, false))
 		{
 			return true;
 		}
@@ -239,6 +239,12 @@ abstract class JLoader
 	 */
 	public static function loadByNamespaceLowerCase($class)
 	{
+		// If the class already exists do nothing.
+		if (class_exists($class, false))
+		{
+			return true;
+		}
+
 		// Get the root namespace name.
 		$namespace = strstr($class, '\\', true);
 
@@ -280,6 +286,12 @@ abstract class JLoader
 	 */
 	public static function loadByNamespaceNaturalCase($class)
 	{
+		// If the class already exists do nothing.
+		if (class_exists($class, false))
+		{
+			return true;
+		}
+
 		// Get the root namespace name.
 		$namespace = strstr($class, '\\', true);
 
@@ -322,6 +334,12 @@ abstract class JLoader
 	 */
 	public static function loadByNamespaceMixedCase($class)
 	{
+		// If the class already exists do nothing.
+		if (class_exists($class, false))
+		{
+			return true;
+		}
+
 		// Get the root namespace name.
 		$namespace = strstr($class, '\\', true);
 


### PR DESCRIPTION
I found a problem in the JLoader Namespacing feature - if a class is already loaded, the autoloader includes the file again anyways.

I download the latest zip of the platform to make sure I didn't break it locally, and got the same errors. This PR fixes the issue by adding a `class_exists($class)` check to the `loadByNamespace*` methods.
