### PR TITLE
sprintf complains unless the correct number of arguments are passed

### DIFF
--- a/libraries/legacy/component/helper.php
+++ b/libraries/legacy/component/helper.php
@@ -397,7 +397,8 @@ class JComponentHelper
 		if (empty(self::$components[$option]))
 		{
 			// Fatal error.
-			JLog::add(JText::sprintf('JLIB_APPLICATION_ERROR_COMPONENT_NOT_LOADING', $option), JLog::WARNING, 'jerror');
+			$error = JText::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND');
+			JLog::add(JText::sprintf('JLIB_APPLICATION_ERROR_COMPONENT_NOT_LOADING', $option, $error), JLog::WARNING, 'jerror');
 
 			return false;
 		}


### PR DESCRIPTION
An undefined variable was being passed to `JText::sprintf` in two places. This was fixed a little while ago, in one case it was replaced but in another it was omitted. Since `sprintf` throws a warning when the format uses numbered arguments but insufficient arguments are passed to the function... we need to pass something. Luckily, there is already a suitable string: `JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND`
