### PR TITLE
Native Namespace Code Prep

### DIFF
--- a/docs/manual/en-US/coding-standards/chapters/namespacing.md
+++ b/docs/manual/en-US/coding-standards/chapters/namespacing.md
@@ -7,7 +7,7 @@ This chapter outlines things to remember when dealing with namespacing. Full nat
 
 When writing code to contribute back to the platform, there are some things to keep in mind.
 
-* Preface internal PHP or SPL classes with a forward slash. This tells PHP to saearch the global namespace. More information here: [Using Global Classes in Namespaces on php.net](http://www.php.net/manual/en/language.namespaces.faq.php#language.namespaces.faq.globalclass)
+* Preface internal PHP or SPL classes with a backslash. This tells PHP to search the global namespace. More information here: [Using Global Classes in Namespaces on php.net](http://www.php.net/manual/en/language.namespaces.faq.php#language.namespaces.faq.globalclass)
 
 ```php
 /**
@@ -37,13 +37,13 @@ $obj->property = 'bar';
 throw new \RuntimeException('Yay namespaces!')
 ```
 
-* Calls to included libraries must also follow proper namespacing rules. If you wanted to use the `PDO` classes, you'll need to preface that with a forward slash as well.
+* Calls to included libraries must also follow proper namespacing rules. If you wanted to use the `PDO` classes, you'll need to preface that with a backslash as well.
 
 ```php
 \PDO::query();
 ```
 
-* When using callables, use the magic `__CLASS__` constant whenever possible. For example, in `JLoader` we call `spl_autoload_register()` several times. This function takes a callable as it's argument, which is passed as an array of class name and method name. (See example below.) The reason this is important is that the `__CLASS__` constant returns the calling class name. If that class is in a namespace, it returns the fully qualified class name. This means the code you write in this fashion will not need to be re-written when full namespacing is achieved. It will just work. More information here: [__CLASS__ on php.net](http://php.net/manual/en/language.constants.predefined.php)
+* When using callables, use the magic `__CLASS__` constant whenever possible. For example, in `JLoader` we call `spl_autoload_register()` several times. This function takes a callable as it's argument, which is passed as an array of class name and method name. (See example below.) The reason this is important is that the `__CLASS__` constant returns the calling class name. If that class is in a namespace, it returns the fully qualified class name. This means the code you write in this fashion will not need to be re-written when full namespacing is achieved. It will just work. More information here: [`__CLASS__` on php.net](http://php.net/manual/en/language.constants.predefined.php)
 
 ```php
 // This is the old way
@@ -55,7 +55,7 @@ spl_autoload_register(array(__CLASS__, 'load'));
 
 ### Namespace Compatibility Layer
 
-When full namespacing is achieved, there will be a compatibility layer that you can enable. This will allow you to use the latest platform code base with your existing app, without requiring a full re-write. By allowing users to make the transition as time allows, we reduce headaches without reducing our user base. All type hinting, `is_subclass_of()`, `instanceof`, etc works with this approach as well. It's much more seamless than importing all the classes at the top of each file where they are used.
+When full namespacing is achieved, there will be a compatibility layer that you can enable. This will allow you to use the latest platform code base with your existing app, without requiring a full re-write. By allowing users to make the transition as time allows, we reduce headaches without reducing our user base. All type hinting, `is_subclass_of()`, `instanceof`, etc continues to work with this approach as well. It's much more seamless than importing all the classes at the top of each file where they are used.
 
 This compatibility layer will consist of basically a class map that will use the `class_alias` function to create aliases to all the class names as they exist now. One of the bigger benefits of this approach is that it requires little interaction from the end-user/developer. Simply enable the compatibility later, and your app will continue to function as it always has (in theory).
 

--- a/docs/manual/en-US/coding-standards/chapters/namespacing.md
+++ b/docs/manual/en-US/coding-standards/chapters/namespacing.md
@@ -1,0 +1,62 @@
+## Namespacing
+
+This chapter outlines things to remember when dealing with namespacing. Full native namespacing has not yet been implemented in the Joomla! Platform. So far, there are some preparations being made to make the transition, but we are a long way from making that large change.
+
+
+### Things to Remember When Contributing
+
+When writing code to contribute back to the platform, there are some things to keep in mind.
+
+* Preface internal PHP or SPL classes with a forward slash. This tells PHP to saearch the global namespace. More information here: [Using Global Classes in Namespaces on php.net](http://www.php.net/manual/en/language.namespaces.faq.php#language.namespaces.faq.globalclass)
+
+```php
+/**
+ * This is the wrong way to call the class.
+ * When full namespacing is achieved, this
+ * will result in a class load error.
+ * Ex. "Class \Foo\Bar\stdClass not found"
+ */
+$obj = new stdClass;
+$obj->property = 'foo';
+
+/**
+ * Same when working with Exceptions. This
+ * will fail in a fully namespaced environment.
+ */
+throw new RuntimeException('Error Message Here.');
+
+/**
+ * This is the correct way to call it. The
+ * The forward slash tells it to search for
+ * the class in the global namespace
+ */
+$obj = new \stdClass;
+$obj->property = 'bar';
+
+// And Exceptions
+throw new \RuntimeException('Yay namespaces!')
+```
+
+* Calls to included libraries must also follow proper namespacing rules. If you wanted to use the `PDO` classes, you'll need to preface that with a forward slash as well.
+
+```php
+\PDO::query();
+```
+
+* When using callables, use the magic `__CLASS__` constant whenever possible. For example, in `JLoader` we call `spl_autoload_register()` several times. This function takes a callable as it's argument, which is passed as an array of class name and method name. (See example below.) The reason this is important is that the `__CLASS__` constant returns the calling class name. If that class is in a namespace, it returns the fully qualified class name. This means the code you write in this fashion will not need to be re-written when full namespacing is achieved. It will just work. More information here: [__CLASS__ on php.net](http://php.net/manual/en/language.constants.predefined.php)
+
+```php
+// This is the old way
+spl_autoload_register(array('JLoader', 'load'));
+
+// This is the namespaced way
+spl_autoload_register(array(__CLASS__, 'load'));
+```
+
+### Namespace Compatibility Layer
+
+When full namespacing is achieved, there will be a compatibility layer that you can enable. This will allow you to use the latest platform code base with your existing app, without requiring a full re-write. By allowing users to make the transition as time allows, we reduce headaches without reducing our user base. All type hinting, `is_subclass_of()`, `instanceof`, etc works with this approach as well. It's much more seamless than importing all the classes at the top of each file where they are used.
+
+This compatibility layer will consist of basically a class map that will use the `class_alias` function to create aliases to all the class names as they exist now. One of the bigger benefits of this approach is that it requires little interaction from the end-user/developer. Simply enable the compatibility later, and your app will continue to function as it always has (in theory).
+
+This layer will be available at least for 2 platform releases after achieving full namespace compatibility, after which it may be retained by any applications that are using it, such as the CMS if it chooses to implement these changes.

--- a/docs/manual/en-US/menu.md
+++ b/docs/manual/en-US/menu.md
@@ -20,6 +20,7 @@
 - [Basic Guidelines](coding-standards/chapters/basic-guidelines.md)
 - [Comments](coding-standards/chapters/comments.md)
 - [PHP Code](coding-standards/chapters/php.md)
+- [Namespacing](coding-standards/chapters/namespacing.md)
 
 - Appendices
 - [Code Analysis](appendices/analysis.md)

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -488,7 +488,7 @@ class JAccess
 	public static function getActionsFromData($data, $xpath = "/access/section[@name='component']/")
 	{
 		// If the data to load isn't already an XML element or string return false.
-		if ((!($data instanceof SimpleXMLElement)) && (!is_string($data)))
+		if ((!($data instanceof \SimpleXMLElement)) && (!is_string($data)))
 		{
 			return false;
 		}
@@ -498,7 +498,7 @@ class JAccess
 		{
 			try
 			{
-				$data = new SimpleXMLElement($data);
+				$data = new \SimpleXMLElement($data);
 			}
 			catch (Exception $e)
 			{

--- a/libraries/joomla/application/cli.php
+++ b/libraries/joomla/application/cli.php
@@ -271,7 +271,7 @@ class JApplicationCli extends JApplicationBase
 			}
 			else
 			{
-				throw new RuntimeException('Configuration class does not exist.');
+				throw new \RuntimeException('Configuration class does not exist.');
 			}
 		}
 

--- a/libraries/joomla/application/cli.php
+++ b/libraries/joomla/application/cli.php
@@ -126,13 +126,13 @@ class JApplicationCli extends JApplicationBase
 		// Only create the object if it doesn't exist.
 		if (empty(self::$instance))
 		{
-			if (class_exists($name) && (is_subclass_of($name, 'JApplicationCli')))
+			if (class_exists($name) && (is_subclass_of($name, __CLASS__)))
 			{
 				self::$instance = new $name;
 			}
 			else
 			{
-				self::$instance = new JApplicationCli;
+				self::$instance = new static;
 			}
 		}
 

--- a/libraries/joomla/application/daemon.php
+++ b/libraries/joomla/application/daemon.php
@@ -157,7 +157,7 @@ class JApplicationDaemon extends JApplicationCli
 		JLog::add('Received signal: ' . $signal, JLog::DEBUG);
 
 		// Let's make sure we have an application instance.
-		if (!is_subclass_of(static::$instance, 'JApplicationDaemon'))
+		if (!is_subclass_of(static::$instance, __CLASS__))
 		{
 			JLog::add('Cannot find the application instance.', JLog::EMERGENCY);
 			throw new \RuntimeException('Cannot find the application instance.');
@@ -706,7 +706,7 @@ class JApplicationDaemon extends JApplicationCli
 			}
 
 			// Attach the signal handler for the signal.
-			if (!$this->pcntlSignal(constant($signal), array('JApplicationDaemon', 'signal')))
+			if (!$this->pcntlSignal(constant($signal), array(__CLASS__, 'signal')))
 			{
 				JLog::add(sprintf('Unable to reroute signal handler: %s', $signal), JLog::EMERGENCY);
 

--- a/libraries/joomla/application/daemon.php
+++ b/libraries/joomla/application/daemon.php
@@ -114,14 +114,14 @@ class JApplicationDaemon extends JApplicationCli
 		if (!defined('SIGHUP'))
 		{
 			JLog::add('The PCNTL extension for PHP is not available.', JLog::ERROR);
-			throw new RuntimeException('The PCNTL extension for PHP is not available.');
+			throw new \RuntimeException('The PCNTL extension for PHP is not available.');
 		}
 
 		// Verify that POSIX support for PHP is available.
 		if (!function_exists('posix_getpid'))
 		{
 			JLog::add('The POSIX extension for PHP is not available.', JLog::ERROR);
-			throw new RuntimeException('The POSIX extension for PHP is not available.');
+			throw new \RuntimeException('The POSIX extension for PHP is not available.');
 		}
 		// @codeCoverageIgnoreEnd
 
@@ -160,7 +160,7 @@ class JApplicationDaemon extends JApplicationCli
 		if (!is_subclass_of(static::$instance, 'JApplicationDaemon'))
 		{
 			JLog::add('Cannot find the application instance.', JLog::EMERGENCY);
-			throw new RuntimeException('Cannot find the application instance.');
+			throw new \RuntimeException('Cannot find the application instance.');
 		}
 
 		// Fire the onReceiveSignal event.
@@ -535,7 +535,7 @@ class JApplicationDaemon extends JApplicationCli
 				$this->parentId = $this->processId;
 			}
 		}
-		catch (RuntimeException $e)
+		catch (\RuntimeException $e)
 		{
 			JLog::add('Unable to fork.', JLog::EMERGENCY);
 
@@ -641,7 +641,7 @@ class JApplicationDaemon extends JApplicationCli
 		// If the fork failed, throw an exception.
 		if ($pid === -1)
 		{
-			throw new RuntimeException('The process could not be forked.');
+			throw new \RuntimeException('The process could not be forked.');
 		}
 		// Update the process id for the child.
 		elseif ($pid === 0)

--- a/libraries/joomla/application/router.php
+++ b/libraries/joomla/application/router.php
@@ -149,7 +149,7 @@ class JRouter
 			}
 			else
 			{
-				throw new RuntimeException(JText::sprintf('JLIB_APPLICATION_ERROR_ROUTER_LOAD', $client), 500);
+				throw new \RuntimeException(JText::sprintf('JLIB_APPLICATION_ERROR_ROUTER_LOAD', $client), 500);
 			}
 		}
 

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -920,7 +920,7 @@ class JApplicationWeb extends JApplicationBase
 			}
 			else
 			{
-				throw new RuntimeException('Configuration class does not exist.');
+				throw new \RuntimeException('Configuration class does not exist.');
 			}
 		}
 

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -136,7 +136,7 @@ class JApplicationWeb extends JApplicationBase
 		$this->set('execution.timestamp', time());
 
 		// Setup the response object.
-		$this->response = new stdClass;
+		$this->response = new \stdClass;
 		$this->response->cachable = false;
 		$this->response->headers = array();
 		$this->response->body = array();
@@ -161,13 +161,13 @@ class JApplicationWeb extends JApplicationBase
 		// Only create the object if it doesn't exist.
 		if (empty(self::$instance))
 		{
-			if (class_exists($name) && (is_subclass_of($name, 'JApplicationWeb')))
+			if (class_exists($name) && (is_subclass_of($name, __CLASS__)))
 			{
 				self::$instance = new $name;
 			}
 			else
 			{
-				self::$instance = new JApplicationWeb;
+				self::$instance = new static;
 			}
 		}
 

--- a/libraries/joomla/application/web/router.php
+++ b/libraries/joomla/application/web/router.php
@@ -142,7 +142,7 @@ abstract class JApplicationWebRouter
 		// If the controller class does not exist panic.
 		if (!class_exists($class) || !is_subclass_of($class, 'JController'))
 		{
-			throw new RuntimeException(sprintf('Unable to locate controller `%s`.', $class), 404);
+			throw new \RuntimeException(sprintf('Unable to locate controller `%s`.', $class), 404);
 		}
 
 		// Instantiate the controller.

--- a/libraries/joomla/application/web/router/base.php
+++ b/libraries/joomla/application/web/router/base.php
@@ -169,7 +169,7 @@ class JApplicationWebRouterBase extends JApplicationWebRouter
 		// We were unable to find a route match for the request.  Panic.
 		if (!$controller)
 		{
-			throw new InvalidArgumentException(sprintf('Unable to handle request for route `%s`.', $route), 404);
+			throw new \InvalidArgumentException(sprintf('Unable to handle request for route `%s`.', $route), 404);
 		}
 
 		return $controller;

--- a/libraries/joomla/application/web/router/rest.php
+++ b/libraries/joomla/application/web/router/rest.php
@@ -121,7 +121,7 @@ class JApplicationWebRouterRest extends JApplicationWebRouterBase
 		// Validate that we have a map to handle the given HTTP method.
 		if (!isset($this->suffixMap[$this->input->getMethod()]))
 		{
-			throw new RuntimeException(sprintf('Unable to support the HTTP method `%s`.', $this->input->getMethod()), 404);
+			throw new \RuntimeException(sprintf('Unable to support the HTTP method `%s`.', $this->input->getMethod()), 404);
 		}
 
 		// Check if request method is POST

--- a/libraries/joomla/archive/archive.php
+++ b/libraries/joomla/archive/archive.php
@@ -128,7 +128,7 @@ class JArchive
 					$tmpfname = $config->get('tmp_path') . '/' . uniqid('bzip2');
 					$bzresult = $adapter->extract($archivename, $tmpfname);
 
-					if ($bzresult instanceof Exception)
+					if ($bzresult instanceof \Exception)
 					{
 						@unlink($tmpfname);
 
@@ -157,10 +157,10 @@ class JArchive
 				break;
 
 			default:
-				throw new InvalidArgumentException('Unknown Archive Type');
+				throw new \InvalidArgumentException('Unknown Archive Type');
 		}
 
-		if (!$result || $result instanceof Exception)
+		if (!$result || $result instanceof \Exception)
 		{
 			return false;
 		}
@@ -187,7 +187,7 @@ class JArchive
 
 			if (!class_exists($class))
 			{
-				throw new UnexpectedValueException('Unable to load archive', 500);
+				throw new \UnexpectedValueException('Unable to load archive', 500);
 			}
 
 			self::$adapters[$type] = new $class;

--- a/libraries/joomla/archive/bzip2.php
+++ b/libraries/joomla/archive/bzip2.php
@@ -52,7 +52,7 @@ class JArchiveBzip2 implements JArchiveExtractable
 			}
 			else
 			{
-				throw new RuntimeException('The bz2 extension is not available.');
+				throw new \RuntimeException('The bz2 extension is not available.');
 			}
 		}
 
@@ -69,7 +69,7 @@ class JArchiveBzip2 implements JArchiveExtractable
 				}
 				else
 				{
-					throw new RuntimeException('Unable to read archive');
+					throw new \RuntimeException('Unable to read archive');
 				}
 			}
 
@@ -84,7 +84,7 @@ class JArchiveBzip2 implements JArchiveExtractable
 				}
 				else
 				{
-					throw new RuntimeException('Unable to decompress data');
+					throw new \RuntimeException('Unable to decompress data');
 				}
 			}
 
@@ -96,7 +96,7 @@ class JArchiveBzip2 implements JArchiveExtractable
 				}
 				else
 				{
-					throw new RuntimeException('Unable to write archive');
+					throw new \RuntimeException('Unable to write archive');
 				}
 			}
 
@@ -117,7 +117,7 @@ class JArchiveBzip2 implements JArchiveExtractable
 				}
 				else
 				{
-					throw new RuntimeException('Unable to read archive (bz2)');
+					throw new \RuntimeException('Unable to read archive (bz2)');
 				}
 			}
 
@@ -133,7 +133,7 @@ class JArchiveBzip2 implements JArchiveExtractable
 				}
 				else
 				{
-					throw new RuntimeException('Unable to write archive (bz2)');
+					throw new \RuntimeException('Unable to write archive (bz2)');
 				}
 			}
 
@@ -153,7 +153,7 @@ class JArchiveBzip2 implements JArchiveExtractable
 						}
 						else
 						{
-							throw new RuntimeException('Unable to write archive (bz2)');
+							throw new \RuntimeException('Unable to write archive (bz2)');
 						}
 					}
 				}

--- a/libraries/joomla/archive/gzip.php
+++ b/libraries/joomla/archive/gzip.php
@@ -64,7 +64,7 @@ class JArchiveGzip implements JArchiveExtractable
 			}
 			else
 			{
-				throw new RuntimeException('The zlib extension is not available.');
+				throw new \RuntimeException('The zlib extension is not available.');
 			}
 		}
 
@@ -80,7 +80,7 @@ class JArchiveGzip implements JArchiveExtractable
 				}
 				else
 				{
-					throw new RuntimeException('Unable to read archive');
+					throw new \RuntimeException('Unable to read archive');
 				}
 			}
 
@@ -95,7 +95,7 @@ class JArchiveGzip implements JArchiveExtractable
 				}
 				else
 				{
-					throw new RuntimeException('Unable to decompress data');
+					throw new \RuntimeException('Unable to decompress data');
 				}
 			}
 
@@ -107,7 +107,7 @@ class JArchiveGzip implements JArchiveExtractable
 				}
 				else
 				{
-					throw new RuntimeException('Unable to write archive');
+					throw new \RuntimeException('Unable to write archive');
 				}
 			}
 		}
@@ -127,7 +127,7 @@ class JArchiveGzip implements JArchiveExtractable
 				}
 				else
 				{
-					throw new RuntimeException('Unable to read archive (gz)');
+					throw new \RuntimeException('Unable to read archive (gz)');
 				}
 			}
 
@@ -143,7 +143,7 @@ class JArchiveGzip implements JArchiveExtractable
 				}
 				else
 				{
-					throw new RuntimeException('Unable to write archive (gz)');
+					throw new \RuntimeException('Unable to write archive (gz)');
 				}
 			}
 
@@ -163,7 +163,7 @@ class JArchiveGzip implements JArchiveExtractable
 						}
 						else
 						{
-							throw new RuntimeException('Unable to write file (gz)');
+							throw new \RuntimeException('Unable to write file (gz)');
 						}
 					}
 				}
@@ -210,7 +210,7 @@ class JArchiveGzip implements JArchiveExtractable
 			}
 			else
 			{
-				throw new RuntimeException('Unable to decompress data.');
+				throw new \RuntimeException('Unable to decompress data.');
 			}
 		}
 

--- a/libraries/joomla/archive/tar.php
+++ b/libraries/joomla/archive/tar.php
@@ -86,7 +86,7 @@ class JArchiveTar implements JArchiveExtractable
 			}
 			else
 			{
-				throw new RuntimeException('Unable to read archive');
+				throw new \RuntimeException('Unable to read archive');
 			}
 		}
 
@@ -110,7 +110,7 @@ class JArchiveTar implements JArchiveExtractable
 					}
 					else
 					{
-						throw new RuntimeException('Unable to create destination');
+						throw new \RuntimeException('Unable to create destination');
 					}
 				}
 				if (JFile::write($path, $buffer) === false)
@@ -121,7 +121,7 @@ class JArchiveTar implements JArchiveExtractable
 					}
 					else
 					{
-						throw new RuntimeException('Unable to write entry');
+						throw new \RuntimeException('Unable to write entry');
 					}
 				}
 			}
@@ -179,7 +179,7 @@ class JArchiveTar implements JArchiveExtractable
 				}
 				else
 				{
-					throw new RuntimeException('Unable to decompress data');
+					throw new \RuntimeException('Unable to decompress data');
 				}
 			}
 

--- a/libraries/joomla/archive/zip.php
+++ b/libraries/joomla/archive/zip.php
@@ -133,7 +133,7 @@ class JArchiveZip implements JArchiveExtractable
 			}
 			else
 			{
-				throw new RuntimeException('Archive does not exist');
+				throw new \RuntimeException('Archive does not exist');
 			}
 		}
 
@@ -216,7 +216,7 @@ class JArchiveZip implements JArchiveExtractable
 			}
 			else
 			{
-				throw new RuntimeException('Zlib not supported');
+				throw new \RuntimeException('Zlib not supported');
 			}
 		}
 
@@ -230,7 +230,7 @@ class JArchiveZip implements JArchiveExtractable
 			}
 			else
 			{
-				throw new RuntimeException('Unable to read archive (zip)');
+				throw new \RuntimeException('Unable to read archive (zip)');
 			}
 		}
 
@@ -242,7 +242,7 @@ class JArchiveZip implements JArchiveExtractable
 			}
 			else
 			{
-				throw new RuntimeException('Get ZIP Information failed');
+				throw new \RuntimeException('Get ZIP Information failed');
 			}
 		}
 
@@ -264,7 +264,7 @@ class JArchiveZip implements JArchiveExtractable
 					}
 					else
 					{
-						throw new RuntimeException('Unable to create destination');
+						throw new \RuntimeException('Unable to create destination');
 					}
 				}
 
@@ -276,7 +276,7 @@ class JArchiveZip implements JArchiveExtractable
 					}
 					else
 					{
-						throw new RuntimeException('Unable to write entry');
+						throw new \RuntimeException('Unable to write entry');
 					}
 				}
 			}
@@ -311,7 +311,7 @@ class JArchiveZip implements JArchiveExtractable
 				}
 				else
 				{
-					throw new RuntimeException('Unable to create destination');
+					throw new \RuntimeException('Unable to create destination');
 				}
 			}
 
@@ -332,7 +332,7 @@ class JArchiveZip implements JArchiveExtractable
 							}
 							else
 							{
-								throw new RuntimeException('Unable to write entry');
+								throw new \RuntimeException('Unable to write entry');
 							}
 						}
 
@@ -347,7 +347,7 @@ class JArchiveZip implements JArchiveExtractable
 					}
 					else
 					{
-						throw new RuntimeException('Unable to read entry');
+						throw new \RuntimeException('Unable to read entry');
 					}
 				}
 			}
@@ -362,7 +362,7 @@ class JArchiveZip implements JArchiveExtractable
 			}
 			else
 			{
-				throw new RuntimeException('Unable to open archive');
+				throw new \RuntimeException('Unable to open archive');
 			}
 		}
 
@@ -431,7 +431,7 @@ class JArchiveZip implements JArchiveExtractable
 				}
 				else
 				{
-					throw new RuntimeException('Invalid Zip Data');
+					throw new \RuntimeException('Invalid Zip Data');
 				}
 			}
 
@@ -468,7 +468,7 @@ class JArchiveZip implements JArchiveExtractable
 				}
 				else
 				{
-					throw new RuntimeException('Invalid ZIP data');
+					throw new \RuntimeException('Invalid ZIP data');
 				}
 			}
 
@@ -490,7 +490,7 @@ class JArchiveZip implements JArchiveExtractable
 				}
 				else
 				{
-					throw new RuntimeException('Invalid Zip Data');
+					throw new \RuntimeException('Invalid Zip Data');
 				}
 			}
 

--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -94,7 +94,7 @@ class JCache
 		$handlers = array();
 
 		// Get an iterator and loop trough the driver classes.
-		$iterator = new DirectoryIterator(__DIR__ . '/storage');
+		$iterator = new \DirectoryIterator(__DIR__ . '/storage');
 
 		foreach ($iterator as $file)
 		{
@@ -232,7 +232,7 @@ class JCache
 		// Get the storage and store the cached data
 		$handler = $this->_getStorage();
 
-		if (!($handler instanceof Exception) && $this->_options['caching'])
+		if (!($handler instanceof \Exception) && $this->_options['caching'])
 		{
 			$handler->_lifetime = $this->_options['lifetime'];
 
@@ -259,7 +259,7 @@ class JCache
 		// Get the storage
 		$handler = $this->_getStorage();
 
-		if (!($handler instanceof Exception))
+		if (!($handler instanceof \Exception))
 		{
 			return $handler->remove($id, $group);
 		}
@@ -287,7 +287,7 @@ class JCache
 		// Get the storage handler
 		$handler = $this->_getStorage();
 
-		if (!($handler instanceof Exception))
+		if (!($handler instanceof \Exception))
 		{
 			return $handler->clean($group, $mode);
 		}
@@ -306,7 +306,7 @@ class JCache
 		// Get the storage handler
 		$handler = $this->_getStorage();
 
-		if (!($handler instanceof Exception))
+		if (!($handler instanceof \Exception))
 		{
 			return $handler->gc();
 		}
@@ -339,7 +339,7 @@ class JCache
 		// NOTE drivers with lock need also unlock or unlocking will fail because of false $id
 		$handler = $this->_getStorage();
 
-		if (!($handler instanceof Exception) && $this->_options['locking'] == true && $this->_options['caching'] == true)
+		if (!($handler instanceof \Exception) && $this->_options['locking'] == true && $this->_options['caching'] == true)
 		{
 			$locked = $handler->lock($id, $group, $locktime);
 
@@ -422,7 +422,7 @@ class JCache
 		// Allow handlers to perform unlocking on their own
 		$handler = $this->_getStorage();
 
-		if (!($handler instanceof Exception) && $this->_options['caching'])
+		if (!($handler instanceof \Exception) && $this->_options['caching'])
 		{
 			$unlocked = $handler->unlock($id, $group);
 
@@ -679,7 +679,7 @@ class JCache
 		$registeredurlparams->tpl = 'CMD';
 		$registeredurlparams->id = 'INT';
 
-		$safeuriaddon = new stdClass;
+		$safeuriaddon = new \stdClass;
 
 		foreach ($registeredurlparams as $key => $value)
 		{

--- a/libraries/joomla/cache/controller.php
+++ b/libraries/joomla/cache/controller.php
@@ -99,7 +99,7 @@ class JCacheController
 			}
 			else
 			{
-				throw new RuntimeException('Unable to load Cache Controller: ' . $type, 500);
+				throw new \RuntimeException('Unable to load Cache Controller: ' . $type, 500);
 			}
 		}
 
@@ -177,7 +177,7 @@ class JCacheController
 
 		if ($data === false)
 		{
-			$locktest = new stdClass;
+			$locktest = new \stdClass;
 			$locktest->locked = null;
 			$locktest->locklooped = null;
 			$locktest = $this->cache->lock($id, $group);
@@ -214,7 +214,7 @@ class JCacheController
 	 */
 	public function store($data, $id, $group = null)
 	{
-		$locktest = new stdClass;
+		$locktest = new \stdClass;
 		$locktest->locked = null;
 		$locktest->locklooped = null;
 

--- a/libraries/joomla/cache/storage.php
+++ b/libraries/joomla/cache/storage.php
@@ -117,7 +117,7 @@ class JCacheStorage
 
 			if (empty($handler))
 			{
-				throw new UnexpectedValueException('Cache Storage Handler not set.');
+				throw new \UnexpectedValueException('Cache Storage Handler not set.');
 			}
 		}
 
@@ -144,7 +144,7 @@ class JCacheStorage
 			}
 			else
 			{
-				throw new RuntimeException(sprintf('Unable to load Cache Storage: %s', $handler));
+				throw new \RuntimeException(sprintf('Unable to load Cache Storage: %s', $handler));
 			}
 		}
 

--- a/libraries/joomla/cache/storage/cachelite.php
+++ b/libraries/joomla/cache/storage/cachelite.php
@@ -111,7 +111,7 @@ class JCacheStorageCachelite extends JCacheStorage
 		parent::getAll();
 
 		$path = $this->_root;
-		$folders = new DirectoryIterator($path);
+		$folders = new \DirectoryIterator($path);
 		$data = array();
 
 		foreach ($folders as $folder)
@@ -123,7 +123,7 @@ class JCacheStorageCachelite extends JCacheStorage
 
 			$foldername = $folder->getFilename();
 
-			$files = new DirectoryIterator($path . '/' . $foldername);
+			$files = new \DirectoryIterator($path . '/' . $foldername);
 			$item  = new JCacheStorageHelper($foldername);
 
 			foreach ($files as $file)

--- a/libraries/joomla/cache/storage/memcache.php
+++ b/libraries/joomla/cache/storage/memcache.php
@@ -90,7 +90,7 @@ class JCacheStorageMemcache extends JCacheStorage
 
 		if ($memcachetest == false)
 		{
-			throw new RuntimeException('Could not connect to memcache server', 404);
+			throw new \RuntimeException('Could not connect to memcache server', 404);
 		}
 
 		// Memcahed has no list keys, we do our own accounting, initialise key index
@@ -316,7 +316,7 @@ class JCacheStorageMemcache extends JCacheStorage
 		$host = $config->get('memcache_server_host', 'localhost');
 		$port = $config->get('memcache_server_port', 11211);
 
-		$memcache = new Memcache;
+		$memcache = new \Memcache;
 		$memcachetest = @$memcache->connect($host, $port);
 
 		if (!$memcachetest)

--- a/libraries/joomla/cache/storage/memcached.php
+++ b/libraries/joomla/cache/storage/memcached.php
@@ -90,13 +90,13 @@ class JCacheStorageMemcached extends JCacheStorage
 		}
 		else
 		{
-			self::$_db = new Memcached;
+			self::$_db = new \Memcached;
 		}
 		$memcachedtest = self::$_db->addServer($server['host'], $server['port']);
 
 		if ($memcachedtest == false)
 		{
-			throw new RuntimeException('Could not connect to memcached server', 404);
+			throw new \RuntimeException('Could not connect to memcached server', 404);
 		}
 
 		self::$_db->setOption(Memcached::OPT_COMPRESSION, $this->_compress);
@@ -207,7 +207,7 @@ class JCacheStorageMemcached extends JCacheStorage
 			$index = array();
 		}
 
-		$tmparr = new stdClass;
+		$tmparr = new \stdClass;
 		$tmparr->name = $cache_id;
 		$tmparr->size = strlen($data);
 		$index[] = $tmparr;
@@ -324,7 +324,7 @@ class JCacheStorageMemcached extends JCacheStorage
 		$host = $config->get('memcache_server_host', 'localhost');
 		$port = $config->get('memcache_server_port', 11211);
 
-		$memcached = new Memcached;
+		$memcached = new \Memcached;
 		$memcachedtest = @$memcached->addServer($host, $port);
 
 		if (!$memcachedtest)
@@ -369,7 +369,7 @@ class JCacheStorageMemcached extends JCacheStorage
 			$index = array();
 		}
 
-		$tmparr = new stdClass;
+		$tmparr = new \stdClass;
 		$tmparr->name = $cache_id;
 		$tmparr->size = 1;
 

--- a/libraries/joomla/client/helper.php
+++ b/libraries/joomla/client/helper.php
@@ -225,7 +225,7 @@ class JClientHelper
 				}
 				else
 				{
-					throw new InvalidArgumentException('Invalid user credentials');
+					throw new \InvalidArgumentException('Invalid user credentials');
 				}
 			}
 		}

--- a/libraries/joomla/controller/base.php
+++ b/libraries/joomla/controller/base.php
@@ -105,7 +105,7 @@ abstract class JControllerBase implements JController
 
 		if (!($this->input instanceof JInput))
 		{
-			throw new UnexpectedValueException(sprintf('%s::unserialize would not accept a `%s`.', get_class($this), gettype($this->input)));
+			throw new \UnexpectedValueException(sprintf('%s::unserialize would not accept a `%s`.', get_class($this), gettype($this->input)));
 		}
 
 		return $this;

--- a/libraries/joomla/controller/controller.php
+++ b/libraries/joomla/controller/controller.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Controller
  * @since       12.1
  */
-interface JController extends Serializable
+interface JController extends \Serializable
 {
 	/**
 	 * Execute the controller.

--- a/libraries/joomla/crypt/cipher/mcrypt.php
+++ b/libraries/joomla/crypt/cipher/mcrypt.php
@@ -48,7 +48,7 @@ abstract class JCryptCipherMcrypt implements JCryptCipher
 	{
 		if (!is_callable('mcrypt_encrypt'))
 		{
-			throw new RuntimeException('The mcrypt extension is not available.');
+			throw new \RuntimeException('The mcrypt extension is not available.');
 		}
 	}
 
@@ -67,7 +67,7 @@ abstract class JCryptCipherMcrypt implements JCryptCipher
 		// Validate key.
 		if ($key->type != $this->keyType)
 		{
-			throw new InvalidArgumentException('Invalid key of type: ' . $key->type . '.  Expected ' . $this->keyType . '.');
+			throw new \InvalidArgumentException('Invalid key of type: ' . $key->type . '.  Expected ' . $this->keyType . '.');
 		}
 
 		// Decrypt the data.
@@ -91,7 +91,7 @@ abstract class JCryptCipherMcrypt implements JCryptCipher
 		// Validate key.
 		if ($key->type != $this->keyType)
 		{
-			throw new InvalidArgumentException('Invalid key of type: ' . $key->type . '.  Expected ' . $this->keyType . '.');
+			throw new \InvalidArgumentException('Invalid key of type: ' . $key->type . '.  Expected ' . $this->keyType . '.');
 		}
 
 		// Encrypt the data.

--- a/libraries/joomla/crypt/cipher/simple.php
+++ b/libraries/joomla/crypt/cipher/simple.php
@@ -34,7 +34,7 @@ class JCryptCipherSimple implements JCryptCipher
 		// Validate key.
 		if ($key->type != 'simple')
 		{
-			throw new InvalidArgumentException('Invalid key of type: ' . $key->type . '.  Expected simple.');
+			throw new \InvalidArgumentException('Invalid key of type: ' . $key->type . '.  Expected simple.');
 		}
 
 		$decrypted = '';
@@ -75,7 +75,7 @@ class JCryptCipherSimple implements JCryptCipher
 		// Validate key.
 		if ($key->type != 'simple')
 		{
-			throw new InvalidArgumentException('Invalid key of type: ' . $key->type . '.  Expected simple.');
+			throw new \InvalidArgumentException('Invalid key of type: ' . $key->type . '.  Expected simple.');
 		}
 
 		$encrypted = '';

--- a/libraries/joomla/crypt/password/simple.php
+++ b/libraries/joomla/crypt/password/simple.php
@@ -78,7 +78,7 @@ class JCryptPasswordSimple implements JCryptPassword
 			return md5($password . $salt) . ':' . $salt;
 
 			default:
-				throw new InvalidArgumentException(sprintf('Hash type %s is not supported', $type));
+				throw new \InvalidArgumentException(sprintf('Hash type %s is not supported', $type));
 				break;
 		}
 	}

--- a/libraries/joomla/data/data.php
+++ b/libraries/joomla/data/data.php
@@ -17,7 +17,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Data
  * @since       12.3
  */
-class JData implements JDataDumpable, IteratorAggregate, JsonSerializable, Countable
+class JData implements \JDataDumpable, \IteratorAggregate, \JsonSerializable, \Countable
 {
 	/**
 	 * The data properties.
@@ -130,11 +130,11 @@ class JData implements JDataDumpable, IteratorAggregate, JsonSerializable, Count
 		// Check the properties data type.
 		if (!is_array($properties) && !is_object($properties))
 		{
-			throw new InvalidArgumentException(sprintf('%s(%s)', __METHOD__, gettype($properties)));
+			throw new \InvalidArgumentException(sprintf('%s(%s)', __METHOD__, gettype($properties)));
 		}
 
 		// Check if the object is traversable.
-		if ($properties instanceof Traversable)
+		if ($properties instanceof \Traversable)
 		{
 			// Convert iterator to array.
 			$properties = iterator_to_array($properties);
@@ -174,19 +174,19 @@ class JData implements JDataDumpable, IteratorAggregate, JsonSerializable, Count
 	 *
 	 * @since   12.3
 	 */
-	public function dump($depth = 3, SplObjectStorage $dumped = null)
+	public function dump($depth = 3, \SplObjectStorage $dumped = null)
 	{
 		// Check if we should initialise the recursion tracker.
 		if ($dumped === null)
 		{
-			$dumped = new SplObjectStorage;
+			$dumped = new \SplObjectStorage;
 		}
 
 		// Add this object to the dumped stack.
 		$dumped->attach($this);
 
 		// Setup a container.
-		$dump = new stdClass;
+		$dump = new \stdClass;
 
 		// Dump all object properties.
 		foreach (array_keys($this->_properties) as $property)
@@ -210,7 +210,7 @@ class JData implements JDataDumpable, IteratorAggregate, JsonSerializable, Count
 	 */
 	public function getIterator()
 	{
-		return new ArrayIterator($this->dump(0));
+		return new \ArrayIterator($this->dump(0));
 	}
 
 	/**
@@ -239,7 +239,7 @@ class JData implements JDataDumpable, IteratorAggregate, JsonSerializable, Count
 	 *
 	 * @since   12.3
 	 */
-	protected function dumpProperty($property, $depth, SplObjectStorage $dumped)
+	protected function dumpProperty($property, $depth, \SplObjectStorage $dumped)
 	{
 		$value = $this->getProperty($property);
 

--- a/libraries/joomla/data/data.php
+++ b/libraries/joomla/data/data.php
@@ -17,7 +17,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Data
  * @since       12.3
  */
-class JData implements \JDataDumpable, \IteratorAggregate, \JsonSerializable, \Countable
+class JData implements JDataDumpable, \IteratorAggregate, \JsonSerializable, \Countable
 {
 	/**
 	 * The data properties.

--- a/libraries/joomla/data/dumpable.php
+++ b/libraries/joomla/data/dumpable.php
@@ -30,5 +30,5 @@ interface JDataDumpable
 	 *
 	 * @since   12.3
 	 */
-	public function dump($depth = 3, SplObjectStorage $dumped = null);
+	public function dump($depth = 3, \SplObjectStorage $dumped = null);
 }

--- a/libraries/joomla/data/set.php
+++ b/libraries/joomla/data/set.php
@@ -17,7 +17,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Data
  * @since       12.3
  */
-class JDataSet implements JDataDumpable, ArrayAccess, Countable, Iterator
+class JDataSet implements JDataDumpable, \ArrayAccess, \Countable, \Iterator
 {
 	/**
 	 * The current position of the iterator.
@@ -226,12 +226,12 @@ class JDataSet implements JDataDumpable, ArrayAccess, Countable, Iterator
 	 * @see     JData::dump()
 	 * @since   12.3
 	 */
-	public function dump($depth = 3, SplObjectStorage $dumped = null)
+	public function dump($depth = 3, \SplObjectStorage $dumped = null)
 	{
 		// Check if we should initialise the recursion tracker.
 		if ($dumped === null)
 		{
-			$dumped = new SplObjectStorage;
+			$dumped = new \SplObjectStorage;
 		}
 
 		// Add this object to the dumped stack.
@@ -371,7 +371,7 @@ class JDataSet implements JDataDumpable, ArrayAccess, Countable, Iterator
 		// Check if the object is a JData object.
 		if (!($object instanceof JData))
 		{
-			throw new InvalidArgumentException(sprintf('%s("%s", *%s*)', __METHOD__, $offset, gettype($object)));
+			throw new \InvalidArgumentException(sprintf('%s("%s", *%s*)', __METHOD__, $offset, gettype($object)));
 		}
 
 		// Set the offset.

--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -184,7 +184,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 		$connectors = array();
 
 		// Get an iterator and loop trough the driver classes.
-		$iterator = new DirectoryIterator(__DIR__ . '/driver');
+		$iterator = new \DirectoryIterator(__DIR__ . '/driver');
 
 		foreach ($iterator as $file)
 		{
@@ -253,7 +253,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 			// If the class still doesn't exist we have nothing left to do but throw an exception.  We did our best.
 			if (!class_exists($class))
 			{
-				throw new RuntimeException(sprintf('Unable to load Database Driver: %s', $options['driver']));
+				throw new \RuntimeException(sprintf('Unable to load Database Driver: %s', $options['driver']));
 			}
 
 			// Create our new JDatabaseDriver connector based on the options given.
@@ -261,9 +261,9 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 			{
 				$instance = new $class($options);
 			}
-			catch (RuntimeException $e)
+			catch (\RuntimeException $e)
 			{
-				throw new RuntimeException(sprintf('Unable to connect to the Database: %s', $e->getMessage()));
+				throw new \RuntimeException(sprintf('Unable to connect to the Database: %s', $e->getMessage()));
 			}
 
 			// Set the new connector to the global instances based on signature.
@@ -621,7 +621,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 		if (!class_exists($class))
 		{
 			// If it doesn't exist we are at an impasse so throw an exception.
-			throw new RuntimeException('Database Exporter not found.');
+			throw new \RuntimeException('Database Exporter not found.');
 		}
 
 		$o = new $class;
@@ -647,7 +647,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 		if (!class_exists($class))
 		{
 			// If it doesn't exist we are at an impasse so throw an exception.
-			throw new RuntimeException('Database Importer not found');
+			throw new \RuntimeException('Database Importer not found');
 		}
 
 		$o = new $class;
@@ -677,7 +677,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 			if (!class_exists($class))
 			{
 				// If it doesn't exist we are at an impasse so throw an exception.
-				throw new RuntimeException('Database Query Class not found.');
+				throw new \RuntimeException('Database Query Class not found.');
 			}
 
 			return new $class($this);
@@ -708,7 +708,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 		if (!class_exists($iteratorClass))
 		{
 			// If it doesn't exist we are at an impasse so throw an exception.
-			throw new RuntimeException(sprintf('class *%s* is not defined', $iteratorClass));
+			throw new \RuntimeException(sprintf('class *%s* is not defined', $iteratorClass));
 		}
 
 		// Return a new iterator

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -78,13 +78,13 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		// Make sure the MySQL extension for PHP is installed and enabled.
 		if (!function_exists('mysql_connect'))
 		{
-			throw new RuntimeException('Could not connect to MySQL.');
+			throw new \RuntimeException('Could not connect to MySQL.');
 		}
 
 		// Attempt to connect to the server.
 		if (!($this->connection = @ mysql_connect($this->options['host'], $this->options['user'], $this->options['password'], true)))
 		{
-			throw new RuntimeException('Could not connect to MySQL.');
+			throw new \RuntimeException('Could not connect to MySQL.');
 		}
 
 		// Set sql_mode to non_strict mode
@@ -241,7 +241,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		if (!is_resource($this->connection))
 		{
 			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database');
-			throw new RuntimeException($this->errorMsg, $this->errorNum);
+			throw new \RuntimeException($this->errorMsg, $this->errorNum);
 		}
 
 		// Take a local copy so that we don't modify the original query and cause issues later
@@ -284,7 +284,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 					$this->connect();
 				}
 				// If connect fails, ignore that exception and throw the normal exception.
-				catch (RuntimeException $e)
+				catch (\RuntimeException $e)
 				{
 					// Get the error number and message.
 					$this->errorNum = (int) mysql_errno($this->connection);
@@ -292,7 +292,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
-					throw new RuntimeException($this->errorMsg, $this->errorNum);
+					throw new \RuntimeException($this->errorMsg, $this->errorNum);
 				}
 
 				// Since we were able to reconnect, run the query again.
@@ -307,7 +307,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 
 				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
-				throw new RuntimeException($this->errorMsg, $this->errorNum);
+				throw new \RuntimeException($this->errorMsg, $this->errorNum);
 			}
 		}
 
@@ -335,7 +335,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 
 		if (!mysql_select_db($database, $this->connection))
 		{
-			throw new RuntimeException('Could not connect to database');
+			throw new \RuntimeException('Could not connect to database');
 		}
 
 		return true;

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -134,7 +134,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		// Make sure the MySQLi extension for PHP is installed and enabled.
 		if (!function_exists('mysqli_connect'))
 		{
-			throw new RuntimeException('The MySQL adapter mysqli is not available');
+			throw new \RuntimeException('The MySQL adapter mysqli is not available');
 		}
 
 		$this->connection = @mysqli_connect(
@@ -144,7 +144,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		// Attempt to connect to the server.
 		if (!$this->connection)
 		{
-			throw new RuntimeException('Could not connect to MySQL.');
+			throw new \RuntimeException('Could not connect to MySQL.');
 		}
 
 		// Set sql_mode to non_strict mode
@@ -475,7 +475,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		if (!is_object($this->connection))
 		{
 			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database');
-			throw new RuntimeException($this->errorMsg, $this->errorNum);
+			throw new \RuntimeException($this->errorMsg, $this->errorNum);
 		}
 
 		// Take a local copy so that we don't modify the original query and cause issues later
@@ -521,10 +521,10 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 					$this->connect();
 				}
 				// If connect fails, ignore that exception and throw the normal exception.
-				catch (RuntimeException $e)
+				catch (\RuntimeException $e)
 				{
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
-					throw new RuntimeException($this->errorMsg, $this->errorNum);
+					throw new \RuntimeException($this->errorMsg, $this->errorNum);
 				}
 
 				// Since we were able to reconnect, run the query again.
@@ -534,7 +534,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 			else
 			{
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
-				throw new RuntimeException($this->errorMsg, $this->errorNum);
+				throw new \RuntimeException($this->errorMsg, $this->errorNum);
 			}
 		}
 
@@ -582,7 +582,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 
 		if (!mysqli_select_db($this->connection, $database))
 		{
-			throw new RuntimeException('Could not connect to database.');
+			throw new \RuntimeException('Could not connect to database.');
 		}
 
 		return true;

--- a/libraries/joomla/database/driver/oracle.php
+++ b/libraries/joomla/database/driver/oracle.php
@@ -519,7 +519,7 @@ class JDatabaseDriverOracle extends JDatabaseDriverPdo
 	 */
 	public static function isSupported()
 	{
-		return class_exists('PDO') && in_array('oci', PDO::getAvailableDrivers());
+		return class_exists('PDO') && in_array('oci', \PDO::getAvailableDrivers());
 	}
 
 	/**

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -112,7 +112,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		// Make sure the PDO extension for PHP is installed and enabled.
 		if (!self::isSupported())
 		{
-			throw new RuntimeException('PDO Extension is not available.', 1);
+			throw new \RuntimeException('PDO Extension is not available.', 1);
 		}
 
 		// Initialize the connection string variable:
@@ -294,9 +294,9 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 				$this->options['driverOptions']
 			);
 		}
-		catch (PDOException $e)
+		catch (\PDOException $e)
 		{
-			throw new RuntimeException('Could not connect to PDO' . ': ' . $e->getMessage(), 2, $e);
+			throw new \RuntimeException('Could not connect to PDO' . ': ' . $e->getMessage(), 2, $e);
 		}
 	}
 
@@ -362,7 +362,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		if (!is_object($this->connection))
 		{
 			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database');
-			throw new RuntimeException($this->errorMsg, $this->errorNum);
+			throw new \RuntimeException($this->errorMsg, $this->errorNum);
 		}
 
 		// Take a local copy so that we don't modify the original query and cause issues later
@@ -393,7 +393,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		// Execute the query.
 		$this->executed = false;
 
-		if ($this->prepared instanceof PDOStatement)
+		if ($this->prepared instanceof \PDOStatement)
 		{
 			// Bind the variables:
 			if ($this->sql instanceof JDatabaseQueryPreparable)
@@ -426,7 +426,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 					$this->connect();
 				}
 				// If connect fails, ignore that exception and throw the normal exception.
-				catch (RuntimeException $e)
+				catch (\RuntimeException $e)
 				{
 					// Get the error number and message.
 					$this->errorNum = (int) $this->connection->errorCode();
@@ -434,7 +434,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
-					throw new RuntimeException($this->errorMsg, $this->errorNum);
+					throw new \RuntimeException($this->errorMsg, $this->errorNum);
 				}
 
 				// Since we were able to reconnect, run the query again.
@@ -449,7 +449,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 
 				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
-				throw new RuntimeException($this->errorMsg, $this->errorNum);
+				throw new \RuntimeException($this->errorMsg, $this->errorNum);
 			}
 		}
 
@@ -584,7 +584,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	{
 		$this->connect();
 
-		if ($this->prepared instanceof PDOStatement)
+		if ($this->prepared instanceof \PDOStatement)
 		{
 			return $this->prepared->rowCount();
 		}
@@ -607,11 +607,11 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	{
 		$this->connect();
 
-		if ($cursor instanceof PDOStatement)
+		if ($cursor instanceof \PDOStatement)
 		{
 			return $cursor->rowCount();
 		}
-		elseif ($this->prepared instanceof PDOStatement)
+		elseif ($this->prepared instanceof \PDOStatement)
 		{
 			return $this->prepared->rowCount();
 		}
@@ -781,13 +781,13 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	 */
 	protected function fetchArray($cursor = null)
 	{
-		if (!empty($cursor) && $cursor instanceof PDOStatement)
+		if (!empty($cursor) && $cursor instanceof \PDOStatement)
 		{
-			return $cursor->fetch(PDO::FETCH_NUM);
+			return $cursor->fetch(\PDO::FETCH_NUM);
 		}
-		if ($this->prepared instanceof PDOStatement)
+		if ($this->prepared instanceof \PDOStatement)
 		{
-			return $this->prepared->fetch(PDO::FETCH_NUM);
+			return $this->prepared->fetch(\PDO::FETCH_NUM);
 		}
 	}
 
@@ -802,13 +802,13 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	 */
 	protected function fetchAssoc($cursor = null)
 	{
-		if (!empty($cursor) && $cursor instanceof PDOStatement)
+		if (!empty($cursor) && $cursor instanceof \PDOStatement)
 		{
-			return $cursor->fetch(PDO::FETCH_ASSOC);
+			return $cursor->fetch(\PDO::FETCH_ASSOC);
 		}
-		if ($this->prepared instanceof PDOStatement)
+		if ($this->prepared instanceof \PDOStatement)
 		{
-			return $this->prepared->fetch(PDO::FETCH_ASSOC);
+			return $this->prepared->fetch(\PDO::FETCH_ASSOC);
 		}
 	}
 
@@ -824,11 +824,11 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	 */
 	protected function fetchObject($cursor = null, $class = 'stdClass')
 	{
-		if (!empty($cursor) && $cursor instanceof PDOStatement)
+		if (!empty($cursor) && $cursor instanceof \PDOStatement)
 		{
 			return $cursor->fetchObject($class);
 		}
-		if ($this->prepared instanceof PDOStatement)
+		if ($this->prepared instanceof \PDOStatement)
 		{
 			return $this->prepared->fetchObject($class);
 		}
@@ -847,12 +847,12 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	{
 		$this->executed = false;
 
-		if ($cursor instanceof PDOStatement)
+		if ($cursor instanceof \PDOStatement)
 		{
 			$cursor->closeCursor();
 			$cursor = null;
 		}
-		if ($this->prepared instanceof PDOStatement)
+		if ($this->prepared instanceof \PDOStatement)
 		{
 			$this->prepared->closeCursor();
 			$this->prepared = null;
@@ -971,7 +971,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	{
 		$serializedProperties = array();
 
-		$reflect = new ReflectionClass($this);
+		$reflect = new \ReflectionClass($this);
 
 		// Get properties of the current class
 		$properties = $reflect->getProperties();
@@ -979,7 +979,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		foreach ($properties as $property)
 		{
 			// Do not serialize properties that are PDO
-			if ($property->isStatic() == false && !($this->{$property->name} instanceof PDO))
+			if ($property->isStatic() == false && !($this->{$property->name} instanceof \PDO))
 			{
 				array_push($serializedProperties, $property->name);
 			}

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -108,7 +108,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		// Make sure the postgresql extension for PHP is installed and enabled.
 		if (!function_exists('pg_connect'))
 		{
-			throw new RuntimeException('PHP extension pg_connect is not available.');
+			throw new \RuntimeException('PHP extension pg_connect is not available.');
 		}
 
 		// Build the DSN for the connection.
@@ -117,7 +117,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		// Attempt to connect to the server.
 		if (!($this->connection = @pg_connect($dsn)))
 		{
-			throw new RuntimeException('Error connecting to PGSQL database.');
+			throw new \RuntimeException('Error connecting to PGSQL database.');
 		}
 
 		pg_set_error_verbosity($this->connection, PGSQL_ERRORS_DEFAULT);
@@ -282,7 +282,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 			// Make sure we have a query class for this driver.
 			if (!class_exists('JDatabaseQueryPostgresql'))
 			{
-				throw new RuntimeException('JDatabaseQueryPostgresql Class not found.');
+				throw new \RuntimeException('JDatabaseQueryPostgresql Class not found.');
 			}
 
 			$this->queryObject = new JDatabaseQueryPostgresql($this);
@@ -614,7 +614,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		if (!is_resource($this->connection))
 		{
 			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database');
-			throw new RuntimeException($this->errorMsg, $this->errorNum);
+			throw new \RuntimeException($this->errorMsg, $this->errorNum);
 		}
 
 		// Take a local copy so that we don't modify the original query and cause issues later
@@ -657,7 +657,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 					$this->connect();
 				}
 				// If connect fails, ignore that exception and throw the normal exception.
-				catch (RuntimeException $e)
+				catch (\RuntimeException $e)
 				{
 					// Get the error number and message.
 					$this->errorNum = (int) pg_result_error_field($this->cursor, PGSQL_DIAG_SQLSTATE) . ' ';
@@ -665,7 +665,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
-					throw new RuntimeException($this->errorMsg);
+					throw new \RuntimeException($this->errorMsg);
 				}
 
 				// Since we were able to reconnect, run the query again.
@@ -680,7 +680,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 
 				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
-				throw new RuntimeException($this->errorMsg);
+				throw new \RuntimeException($this->errorMsg);
 			}
 		}
 
@@ -711,7 +711,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		if ( !in_array($oldTable, $tableList) )
 		{
 			// Origin Table not found
-			throw new RuntimeException('Table not found in Postgresql database.');
+			throw new \RuntimeException('Table not found in Postgresql database.');
 		}
 		else
 		{

--- a/libraries/joomla/database/driver/sqlite.php
+++ b/libraries/joomla/database/driver/sqlite.php
@@ -105,7 +105,7 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 			return $text;
 		}
 
-		return SQLite3::escapeString($text);
+		return \SQLite3::escapeString($text);
 	}
 
 	/**
@@ -160,9 +160,9 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 		$columns = array();
 		$query = $this->getQuery(true);
 
-		$fieldCasing = $this->getOption(PDO::ATTR_CASE);
+		$fieldCasing = $this->getOption(\PDO::ATTR_CASE);
 
-		$this->setOption(PDO::ATTR_CASE, PDO::CASE_UPPER);
+		$this->setOption(\PDO::ATTR_CASE, \PDO::CASE_UPPER);
 
 		$table = strtoupper($table);
 
@@ -194,7 +194,7 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 			}
 		}
 
-		$this->setOption(PDO::ATTR_CASE, $fieldCasing);
+		$this->setOption(\PDO::ATTR_CASE, $fieldCasing);
 
 		return $columns;
 	}
@@ -216,9 +216,9 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 		$keys = array();
 		$query = $this->getQuery(true);
 
-		$fieldCasing = $this->getOption(PDO::ATTR_CASE);
+		$fieldCasing = $this->getOption(\PDO::ATTR_CASE);
 
-		$this->setOption(PDO::ATTR_CASE, PDO::CASE_UPPER);
+		$this->setOption(\PDO::ATTR_CASE, \PDO::CASE_UPPER);
 
 		$table = strtoupper($table);
 		$query->setQuery('pragma table_info( ' . $table . ')');
@@ -236,7 +236,7 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 			}
 		}
 
-		$this->setOption(PDO::ATTR_CASE, $fieldCasing);
+		$this->setOption(\PDO::ATTR_CASE, $fieldCasing);
 
 		return $keys;
 	}
@@ -379,7 +379,7 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 	 */
 	public static function isSupported()
 	{
-		return class_exists('PDO') && in_array('sqlite', PDO::getAvailableDrivers());
+		return class_exists('PDO') && in_array('sqlite', \PDO::getAvailableDrivers());
 	}
 
 	/**

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -124,13 +124,13 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		// Make sure the SQLSRV extension for PHP is installed and enabled.
 		if (!function_exists('sqlsrv_connect'))
 		{
-			throw new RuntimeException('PHP extension sqlsrv_connect is not available.');
+			throw new \RuntimeException('PHP extension sqlsrv_connect is not available.');
 		}
 
 		// Attempt to connect to the server.
 		if (!($this->connection = @ sqlsrv_connect($this->options['host'], $config)))
 		{
-			throw new RuntimeException('Database sqlsrv_connect failed');
+			throw new \RuntimeException('Database sqlsrv_connect failed');
 		}
 
 		// Make sure that DB warnings are not returned as errors.
@@ -560,7 +560,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		if (!is_resource($this->connection))
 		{
 			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database');
-			throw new RuntimeException($this->errorMsg, $this->errorNum);
+			throw new \RuntimeException($this->errorMsg, $this->errorNum);
 		}
 
 		// Take a local copy so that we don't modify the original query and cause issues later
@@ -613,7 +613,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 					$this->connect();
 				}
 				// If connect fails, ignore that exception and throw the normal exception.
-				catch (RuntimeException $e)
+				catch (\RuntimeException $e)
 				{
 					// Get the error number and message.
 					$errors = sqlsrv_errors();
@@ -622,7 +622,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 
 					// Throw the normal query exception.
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
-					throw new RuntimeException($this->errorMsg, $this->errorNum);
+					throw new \RuntimeException($this->errorMsg, $this->errorNum);
 				}
 
 				// Since we were able to reconnect, run the query again.
@@ -638,7 +638,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 
 				// Throw the normal query exception.
 				JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'databasequery');
-				throw new RuntimeException($this->errorMsg, $this->errorNum);
+				throw new \RuntimeException($this->errorMsg, $this->errorNum);
 			}
 		}
 
@@ -764,7 +764,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 
 		if (!sqlsrv_query($this->connection, 'USE ' . $database, null, array('scrollable' => SQLSRV_CURSOR_STATIC)))
 		{
-			throw new RuntimeException('Could not connect to database');
+			throw new \RuntimeException('Could not connect to database');
 		}
 
 		return true;

--- a/libraries/joomla/database/exporter/mysql.php
+++ b/libraries/joomla/database/exporter/mysql.php
@@ -32,13 +32,13 @@ class JDatabaseExporterMysql extends JDatabaseExporterMysqli
 		// Check if the db connector has been set.
 		if (!($this->db instanceof JDatabaseDriverMysql))
 		{
-			throw new Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
+			throw new \Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
 		}
 
 		// Check if the tables have been specified.
 		if (empty($this->from))
 		{
-			throw new Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
+			throw new \Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
 		}
 
 		return $this;

--- a/libraries/joomla/database/exporter/mysqli.php
+++ b/libraries/joomla/database/exporter/mysqli.php
@@ -67,7 +67,7 @@ class JDatabaseExporterMysqli extends JDatabaseExporter
 	 */
 	public function __construct()
 	{
-		$this->options = new stdClass;
+		$this->options = new \stdClass;
 
 		$this->cache = array('columns' => array(), 'keys' => array());
 
@@ -204,13 +204,13 @@ class JDatabaseExporterMysqli extends JDatabaseExporter
 		// Check if the db connector has been set.
 		if (!($this->db instanceof JDatabaseDriverMysqli))
 		{
-			throw new Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
+			throw new \Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
 		}
 
 		// Check if the tables have been specified.
 		if (empty($this->from))
 		{
-			throw new Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
+			throw new \Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
 		}
 
 		return $this;
@@ -258,7 +258,7 @@ class JDatabaseExporterMysqli extends JDatabaseExporter
 		}
 		else
 		{
-			throw new Exception('JPLATFORM_ERROR_INPUT_REQUIRES_STRING_OR_ARRAY');
+			throw new \Exception('JPLATFORM_ERROR_INPUT_REQUIRES_STRING_OR_ARRAY');
 		}
 
 		return $this;

--- a/libraries/joomla/database/exporter/postgresql.php
+++ b/libraries/joomla/database/exporter/postgresql.php
@@ -67,7 +67,7 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 	 */
 	public function __construct()
 	{
-		$this->options = new stdClass;
+		$this->options = new \stdClass;
 
 		$this->cache = array('columns' => array(), 'keys' => array());
 
@@ -219,13 +219,13 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 		// Check if the db connector has been set.
 		if (!($this->db instanceof JDatabaseDriverPostgresql))
 		{
-			throw new Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
+			throw new \Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
 		}
 
 		// Check if the tables have been specified.
 		if (empty($this->from))
 		{
-			throw new Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
+			throw new \Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
 		}
 
 		return $this;
@@ -273,7 +273,7 @@ class JDatabaseExporterPostgresql extends JDatabaseExporter
 		}
 		else
 		{
-			throw new Exception('JPLATFORM_ERROR_INPUT_REQUIRES_STRING_OR_ARRAY');
+			throw new \Exception('JPLATFORM_ERROR_INPUT_REQUIRES_STRING_OR_ARRAY');
 		}
 
 		return $this;

--- a/libraries/joomla/database/factory.php
+++ b/libraries/joomla/database/factory.php
@@ -55,7 +55,7 @@ class JDatabaseFactory
 		// If the class still doesn't exist we have nothing left to do but throw an exception.  We did our best.
 		if (!class_exists($class))
 		{
-			throw new RuntimeException(sprintf('Unable to load Database Driver: %s', $options['driver']));
+			throw new \RuntimeException(sprintf('Unable to load Database Driver: %s', $options['driver']));
 		}
 
 		// Create our new JDatabaseDriver connector based on the options given.
@@ -63,9 +63,9 @@ class JDatabaseFactory
 		{
 			$instance = new $class($options);
 		}
-		catch (RuntimeException $e)
+		catch (\RuntimeException $e)
 		{
-			throw new RuntimeException(sprintf('Unable to connect to the Database: %s', $e->getMessage()));
+			throw new \RuntimeException(sprintf('Unable to connect to the Database: %s', $e->getMessage()));
 		}
 
 		return $instance;
@@ -91,7 +91,7 @@ class JDatabaseFactory
 		if (!class_exists($class))
 		{
 			// If it doesn't exist we are at an impasse so throw an exception.
-			throw new RuntimeException('Database Exporter not found.');
+			throw new \RuntimeException('Database Exporter not found.');
 		}
 
 		$o = new $class;
@@ -124,7 +124,7 @@ class JDatabaseFactory
 		if (!class_exists($class))
 		{
 			// If it doesn't exist we are at an impasse so throw an exception.
-			throw new RuntimeException('Database importer not found.');
+			throw new \RuntimeException('Database importer not found.');
 		}
 
 		$o = new $class;
@@ -169,7 +169,7 @@ class JDatabaseFactory
 		if (!class_exists($class))
 		{
 			// If it doesn't exist we are at an impasse so throw an exception.
-			throw new RuntimeException('Database Query class not found');
+			throw new \RuntimeException('Database Query class not found');
 		}
 
 		return new $class($db);

--- a/libraries/joomla/database/importer/mysql.php
+++ b/libraries/joomla/database/importer/mysql.php
@@ -31,13 +31,13 @@ class JDatabaseImporterMysql extends JDatabaseImporterMysqli
 		// Check if the db connector has been set.
 		if (!($this->db instanceof JDatabaseDriverMysql))
 		{
-			throw new Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
+			throw new \Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
 		}
 
 		// Check if the tables have been specified.
 		if (empty($this->from))
 		{
-			throw new Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
+			throw new \Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
 		}
 
 		return $this;

--- a/libraries/joomla/database/importer/mysqli.php
+++ b/libraries/joomla/database/importer/mysqli.php
@@ -65,7 +65,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 	 */
 	public function __construct()
 	{
-		$this->options = new stdClass;
+		$this->options = new \stdClass;
 
 		$this->cache = array('columns' => array(), 'keys' => array());
 
@@ -107,13 +107,13 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 		// Check if the db connector has been set.
 		if (!($this->db instanceof JDatabaseDriverMysqli))
 		{
-			throw new Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
+			throw new \Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
 		}
 
 		// Check if the tables have been specified.
 		if (empty($this->from))
 		{
-			throw new Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
+			throw new \Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
 		}
 
 		return $this;
@@ -145,7 +145,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 	 *
 	 * @since   11.1
 	 */
-	protected function getAddColumnSQL($table, SimpleXMLElement $field)
+	protected function getAddColumnSQL($table, \SimpleXMLElement $field)
 	{
 		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' ADD COLUMN ' . $this->getColumnSQL($field);
 
@@ -178,7 +178,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 	 *
 	 * @since   11.1
 	 */
-	protected function getAlterTableSQL(SimpleXMLElement $structure)
+	protected function getAlterTableSQL(\SimpleXMLElement $structure)
 	{
 		$table = $this->getRealTableName($structure['name']);
 		$oldFields = $this->db->getTableColumns($table);
@@ -328,7 +328,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 	 *
 	 * @since   11.1
 	 */
-	protected function getChangeColumnSQL($table, SimpleXMLElement $field)
+	protected function getChangeColumnSQL($table, \SimpleXMLElement $field)
 	{
 		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' CHANGE COLUMN ' . $this->db->quoteName((string) $field['Field']) . ' '
 			. $this->getColumnSQL($field);
@@ -345,7 +345,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 	 *
 	 * @since   11.1
 	 */
-	protected function getColumnSQL(SimpleXMLElement $field)
+	protected function getColumnSQL(\SimpleXMLElement $field)
 	{
 		// TODO Incorporate into parent class and use $this.
 		$blobs = array('text', 'smalltext', 'mediumtext', 'largetext');
@@ -458,7 +458,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 
 		foreach ($keys as $key)
 		{
-			if ($key instanceof SimpleXMLElement)
+			if ($key instanceof \SimpleXMLElement)
 			{
 				$kName = (string) $key['Key_name'];
 			}
@@ -559,13 +559,13 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 		$prefix = $this->db->getPrefix();
 		$tables = $this->db->getTableList();
 
-		if ($this->from instanceof SimpleXMLElement)
+		if ($this->from instanceof \SimpleXMLElement)
 		{
 			$xml = $this->from;
 		}
 		else
 		{
-			$xml = new SimpleXMLElement($this->from);
+			$xml = new \SimpleXMLElement($this->from);
 		}
 
 		// Get all the table definitions.
@@ -591,7 +591,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 						{
 							$this->db->execute();
 						}
-						catch (RuntimeException $e)
+						catch (\RuntimeException $e)
 						{
 							$this->addLog('Fail: ' . $this->db->getQuery());
 							throw $e;
@@ -612,7 +612,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 				{
 					$this->db->execute();
 				}
-				catch (RuntimeException $e)
+				catch (\RuntimeException $e)
 				{
 					$this->addLog('Fail: ' . $this->db->getQuery());
 					throw $e;

--- a/libraries/joomla/database/importer/postgresql.php
+++ b/libraries/joomla/database/importer/postgresql.php
@@ -65,7 +65,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 	 */
 	public function __construct()
 	{
-		$this->options = new stdClass;
+		$this->options = new \stdClass;
 
 		$this->cache = array('columns' => array(), 'keys' => array());
 
@@ -107,13 +107,13 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 		// Check if the db connector has been set.
 		if (!($this->db instanceof JDatabaseDriverPostgresql))
 		{
-			throw new Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
+			throw new \Exception('JPLATFORM_ERROR_DATABASE_CONNECTOR_WRONG_TYPE');
 		}
 
 		// Check if the tables have been specified.
 		if (empty($this->from))
 		{
-			throw new Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
+			throw new \Exception('JPLATFORM_ERROR_NO_TABLES_SPECIFIED');
 		}
 
 		return $this;
@@ -145,7 +145,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 	 *
 	 * @since   12.1
 	 */
-	protected function getAddColumnSQL($table, SimpleXMLElement $field)
+	protected function getAddColumnSQL($table, \SimpleXMLElement $field)
 	{
 		$sql = 'ALTER TABLE ' . $this->db->quoteName($table) . ' ADD COLUMN ' . $this->getColumnSQL($field);
 
@@ -161,7 +161,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 	 *
 	 * @since   12.1
 	 */
-	protected function getAddIndexSQL(SimpleXMLElement $field)
+	protected function getAddIndexSQL(\SimpleXMLElement $field)
 	{
 		return (string) $field['Query'];
 	}
@@ -175,7 +175,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 	 *
 	 * @since   12.1
 	 */
-	protected function getAlterTableSQL(SimpleXMLElement $structure)
+	protected function getAlterTableSQL(\SimpleXMLElement $structure)
 	{
 		$table = $this->getRealTableName($structure['name']);
 		$oldFields = $this->db->getTableColumns($table);
@@ -504,7 +504,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 	 *
 	 * @since   12.1
 	 */
-	protected function getColumnSQL(SimpleXMLElement $field)
+	protected function getColumnSQL(\SimpleXMLElement $field)
 	{
 		// TODO Incorporate into parent class and use $this.
 		$blobs = array('text', 'smalltext', 'mediumtext', 'largetext');
@@ -615,7 +615,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 
 		foreach ($keys as $key)
 		{
-			if ($key instanceof SimpleXMLElement)
+			if ($key instanceof \SimpleXMLElement)
 			{
 				$kName = (string) $key['Index'];
 			}
@@ -650,7 +650,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 
 		foreach ($sequences as $seq)
 		{
-			if ($seq instanceof SimpleXMLElement)
+			if ($seq instanceof \SimpleXMLElement)
 			{
 				$sName = (string) $seq['Name'];
 			}
@@ -703,13 +703,13 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 		$prefix = $this->db->getPrefix();
 		$tables = $this->db->getTableList();
 
-		if ($this->from instanceof SimpleXMLElement)
+		if ($this->from instanceof \SimpleXMLElement)
 		{
 			$xml = $this->from;
 		}
 		else
 		{
-			$xml = new SimpleXMLElement($this->from);
+			$xml = new \SimpleXMLElement($this->from);
 		}
 
 		// Get all the table definitions.
@@ -756,7 +756,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 				{
 					$this->db->execute();
 				}
-				catch (RuntimeException $e)
+				catch (\RuntimeException $e)
 				{
 					$this->addLog('Fail: ' . $this->db->getQuery());
 					throw $e;

--- a/libraries/joomla/database/iterator.php
+++ b/libraries/joomla/database/iterator.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Database
  * @since       12.1
  */
-abstract class JDatabaseIterator implements Countable, Iterator
+abstract class JDatabaseIterator implements \Countable, \Iterator
 {
 	/**
 	 * The database cursor.
@@ -79,7 +79,7 @@ abstract class JDatabaseIterator implements Countable, Iterator
 	{
 		if (!class_exists($class))
 		{
-			throw new InvalidArgumentException(sprintf('new %s(*%s*, cursor)', get_class($this), gettype($class)));
+			throw new \InvalidArgumentException(sprintf('new %s(*%s*, cursor)', get_class($this), gettype($class)));
 		}
 
 		$this->cursor = $cursor;

--- a/libraries/joomla/database/iterator/pdo.php
+++ b/libraries/joomla/database/iterator/pdo.php
@@ -28,7 +28,7 @@ class JDatabaseIteratorPdo extends JDatabaseIterator
 	 */
 	public function count()
 	{
-		if (!empty($this->cursor) && $this->cursor instanceof PDOStatement)
+		if (!empty($this->cursor) && $this->cursor instanceof \PDOStatement)
 		{
 			return $this->cursor->rowCount();
 		}
@@ -47,7 +47,7 @@ class JDatabaseIteratorPdo extends JDatabaseIterator
 	 */
 	protected function fetchObject()
 	{
-		if (!empty($this->cursor) && $this->cursor instanceof PDOStatement)
+		if (!empty($this->cursor) && $this->cursor instanceof \PDOStatement)
 		{
 			return $this->cursor->fetchObject($this->class);
 		}
@@ -66,7 +66,7 @@ class JDatabaseIteratorPdo extends JDatabaseIterator
 	 */
 	protected function freeResult()
 	{
-		if (!empty($this->cursor) && $this->cursor instanceof PDOStatement)
+		if (!empty($this->cursor) && $this->cursor instanceof \PDOStatement)
 		{
 			$this->cursor->closeCursor();
 		}

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -742,7 +742,7 @@ abstract class JDatabaseQuery
 	{
 		if (!($this->db instanceof JDatabaseDriver))
 		{
-			throw new RuntimeException('JLIB_DATABASE_ERROR_INVALID_DB_OBJECT');
+			throw new \RuntimeException('JLIB_DATABASE_ERROR_INVALID_DB_OBJECT');
 		}
 
 		return $this->db->getDateFormat();
@@ -810,7 +810,7 @@ abstract class JDatabaseQuery
 	{
 		if (!($this->db instanceof JDatabaseDriver))
 		{
-			throw new RuntimeException('JLIB_DATABASE_ERROR_INVALID_DB_OBJECT');
+			throw new \RuntimeException('JLIB_DATABASE_ERROR_INVALID_DB_OBJECT');
 		}
 
 		return $this->db->escape($text, $extra);
@@ -873,7 +873,7 @@ abstract class JDatabaseQuery
 			{
 				if (is_null($subQueryAlias))
 				{
-					throw new RuntimeException('JLIB_DATABASE_ERROR_NULL_SUBQUERY_ALIAS');
+					throw new \RuntimeException('JLIB_DATABASE_ERROR_NULL_SUBQUERY_ALIAS');
 				}
 
 				$tables = '( ' . (string) $tables . ' ) AS ' . $this->quoteName($subQueryAlias);
@@ -1171,7 +1171,7 @@ abstract class JDatabaseQuery
 	{
 		if (!($this->db instanceof JDatabaseDriver))
 		{
-			throw new RuntimeException('JLIB_DATABASE_ERROR_INVALID_DB_OBJECT');
+			throw new \RuntimeException('JLIB_DATABASE_ERROR_INVALID_DB_OBJECT');
 		}
 
 		$result = $this->db->getNullDate($quoted);
@@ -1254,7 +1254,7 @@ abstract class JDatabaseQuery
 	{
 		if (!($this->db instanceof JDatabaseDriver))
 		{
-			throw new RuntimeException('JLIB_DATABASE_ERROR_INVALID_DB_OBJECT');
+			throw new \RuntimeException('JLIB_DATABASE_ERROR_INVALID_DB_OBJECT');
 		}
 
 		return $this->db->quote(($escape ? $this->db->escape($text) : $text));
@@ -1287,7 +1287,7 @@ abstract class JDatabaseQuery
 	{
 		if (!($this->db instanceof JDatabaseDriver))
 		{
-			throw new RuntimeException('JLIB_DATABASE_ERROR_INVALID_DB_OBJECT');
+			throw new \RuntimeException('JLIB_DATABASE_ERROR_INVALID_DB_OBJECT');
 		}
 
 		return $this->db->quoteName($name, $as);

--- a/libraries/joomla/database/query/oracle.php
+++ b/libraries/joomla/database/query/oracle.php
@@ -52,7 +52,7 @@ class JDatabaseQueryOracle extends JDatabaseQueryPdo implements JDatabaseQueryPr
 	 *
 	 * @since   12.1
 	 */
-	public function bind($key = null, &$value = null, $dataType = PDO::PARAM_STR, $length = 0, $driverOptions = array())
+	public function bind($key = null, &$value = null, $dataType = \PDO::PARAM_STR, $length = 0, $driverOptions = array())
 	{
 		// Case 1: Empty Key (reset $bounded array)
 		if (empty($key))

--- a/libraries/joomla/database/query/preparable.php
+++ b/libraries/joomla/database/query/preparable.php
@@ -37,7 +37,7 @@ interface JDatabaseQueryPreparable
 	 *
 	 * @since   12.1
 	 */
-	public function bind($key = null, &$value = null, $dataType = PDO::PARAM_STR, $length = 0, $driverOptions = array());
+	public function bind($key = null, &$value = null, $dataType = \PDO::PARAM_STR, $length = 0, $driverOptions = array());
 
 	/**
 	 * Retrieves the bound parameters array when key is null and returns it by reference. If a key is provided then that item is

--- a/libraries/joomla/database/query/sqlite.php
+++ b/libraries/joomla/database/query/sqlite.php
@@ -52,7 +52,7 @@ class JDatabaseQuerySqlite extends JDatabaseQueryPdo implements JDatabaseQueryPr
 	 *
 	 * @since   12.1
 	 */
-	public function bind($key = null, &$value = null, $dataType = PDO::PARAM_STR, $length = 0, $driverOptions = array())
+	public function bind($key = null, &$value = null, $dataType = \PDO::PARAM_STR, $length = 0, $driverOptions = array())
 	{
 		// Case 1: Empty Key (reset $bounded array)
 		if (empty($key))

--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -30,7 +30,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Date
  * @since       11.1
  */
-class JDate extends DateTime
+class JDate extends \DateTime
 {
 	const DAY_ABBR = "\x021\x03";
 	const DAY_NAME = "\x022\x03";
@@ -88,7 +88,7 @@ class JDate extends DateTime
 		}
 
 		// If the time zone object is not set, attempt to build it.
-		if (!($tz instanceof DateTimeZone))
+		if (!($tz instanceof \DateTimeZone))
 		{
 			if ($tz === null)
 			{
@@ -213,7 +213,7 @@ class JDate extends DateTime
 	 */
 	public static function getInstance($date = 'now', $tz = null)
 	{
-		return new JDate($date, $tz);
+		return new static($date, $tz);
 	}
 
 	/**

--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -83,8 +83,8 @@ class JDate extends DateTime
 		// Create the base GMT and server time zone objects.
 		if (empty(self::$gmt) || empty(self::$stz))
 		{
-			self::$gmt = new DateTimeZone('GMT');
-			self::$stz = new DateTimeZone(@date_default_timezone_get());
+			self::$gmt = new \DateTimeZone('GMT');
+			self::$stz = new \DateTimeZone(@date_default_timezone_get());
 		}
 
 		// If the time zone object is not set, attempt to build it.
@@ -96,7 +96,7 @@ class JDate extends DateTime
 			}
 			elseif (is_string($tz))
 			{
-				$tz = new DateTimeZone($tz);
+				$tz = new \DateTimeZone($tz);
 			}
 		}
 
@@ -411,7 +411,7 @@ class JDate extends DateTime
 	 */
 	public function toISO8601($local = false)
 	{
-		return $this->format(DateTime::RFC3339, $local, false);
+		return $this->format(\DateTime::RFC3339, $local, false);
 	}
 
 	/**
@@ -447,7 +447,7 @@ class JDate extends DateTime
 	 */
 	public function toRFC822($local = false)
 	{
-		return $this->format(DateTime::RFC2822, $local, false);
+		return $this->format(\DateTime::RFC2822, $local, false);
 	}
 
 	/**

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -289,7 +289,7 @@ class JDocument
 				}
 				else
 				{
-					throw new RuntimeException('Invalid JDocument Class', 500);
+					throw new \RuntimeException('Invalid JDocument Class', 500);
 				}
 			}
 
@@ -917,7 +917,7 @@ class JDocument
 			}
 			else
 			{
-				throw new RuntimeException('Unable to load renderer class', 500);
+				throw new \RuntimeException('Unable to load renderer class', 500);
 			}
 		}
 

--- a/libraries/joomla/document/error/error.php
+++ b/libraries/joomla/document/error/error.php
@@ -55,7 +55,7 @@ class JDocumentError extends JDocument
 	 */
 	public function setError($error)
 	{
-		if ($error instanceof Exception)
+		if ($error instanceof \Exception)
 		{
 			$this->_error = & $error;
 

--- a/libraries/joomla/document/feed/feed.php
+++ b/libraries/joomla/document/feed/feed.php
@@ -201,7 +201,7 @@ class JDocumentFeed extends JDocument
 
 		if (!is_a($renderer, 'JDocumentRenderer'))
 		{
-			throw new Exception(JText::_('JGLOBAL_RESOURCE_NOT_FOUND'), 404);
+			throw new \Exception(JText::_('JGLOBAL_RESOURCE_NOT_FOUND'), 404);
 		}
 		$this->setMimeEncoding($renderer->getContentType());
 

--- a/libraries/joomla/document/feed/renderer/atom.php
+++ b/libraries/joomla/document/feed/renderer/atom.php
@@ -48,7 +48,7 @@ class JDocumentRendererAtom extends JDocumentRenderer
 		$app = JFactory::getApplication();
 
 		// Gets and sets timezone offset from site configuration
-		$tz = new DateTimeZone($app->getCfg('offset'));
+		$tz = new \DateTimeZone($app->getCfg('offset'));
 		$now = JFactory::getDate();
 		$now->setTimeZone($tz);
 

--- a/libraries/joomla/document/feed/renderer/rss.php
+++ b/libraries/joomla/document/feed/renderer/rss.php
@@ -44,7 +44,7 @@ class JDocumentRendererRSS extends JDocumentRenderer
 		$app = JFactory::getApplication();
 
 		// Gets and sets timezone offset from site configuration
-		$tz = new DateTimeZone($app->getCfg('offset'));
+		$tz = new \DateTimeZone($app->getCfg('offset'));
 		$now = JFactory::getDate();
 		$now->setTimeZone($tz);
 

--- a/libraries/joomla/document/html/renderer/module.php
+++ b/libraries/joomla/document/html/renderer/module.php
@@ -93,7 +93,7 @@ class JDocumentRendererModule extends JDocumentRenderer
 		{
 
 			// Default to itemid creating method and workarounds on
-			$cacheparams = new stdClass;
+			$cacheparams = new \stdClass;
 			$cacheparams->cachemode = $cachemode;
 			$cacheparams->class = 'JModuleHelper';
 			$cacheparams->method = 'renderModule';

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -170,13 +170,13 @@ class JBrowser
 	 *
 	 * @since  11.1
 	 */
-	static public function getInstance($userAgent = null, $accept = null)
+	public static function getInstance($userAgent = null, $accept = null)
 	{
 		$signature = serialize(array($userAgent, $accept));
 
 		if (empty(self::$instances[$signature]))
 		{
-			self::$instances[$signature] = new JBrowser($userAgent, $accept);
+			self::$instances[$signature] = new static($userAgent, $accept);
 		}
 
 		return self::$instances[$signature];

--- a/libraries/joomla/event/dispatcher.php
+++ b/libraries/joomla/event/dispatcher.php
@@ -112,7 +112,7 @@ class JEventDispatcher extends JObject
 		}
 		else
 		{
-			throw new InvalidArgumentException('Invalid event handler.');
+			throw new \InvalidArgumentException('Invalid event handler.');
 		}
 	}
 

--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -98,7 +98,7 @@ abstract class JFactory
 		{
 			if (!$id)
 			{
-				throw new Exception('Application Instantiation Error', 500);
+				throw new \Exception('Application Instantiation Error', 500);
 			}
 
 			self::$application = JApplication::getInstance($id, $config, $prefix);
@@ -349,7 +349,7 @@ abstract class JFactory
 	{
 		if (!class_exists('JSimplepieFactory'))
 		{
-			throw new BadMethodCallException('JSimplepieFactory not found');
+			throw new \BadMethodCallException('JSimplepieFactory not found');
 		}
 
 		JLog::add(__METHOD__ . ' is deprecated.   Use JSimplepieFactory::getFeedParser() instead.', JLog::WARNING, 'deprecated');
@@ -430,7 +430,7 @@ abstract class JFactory
 
 		if (!class_exists('JEditor'))
 		{
-			throw new BadMethodCallException('JEditor not found');
+			throw new \BadMethodCallException('JEditor not found');
 		}
 
 		JLog::add(__METHOD__ . ' is deprecated. Use JEditor directly.', JLog::WARNING, 'deprecated');
@@ -504,7 +504,7 @@ abstract class JFactory
 			}
 		}
 
-		$key = $time . '-' . ($tzOffset instanceof DateTimeZone ? $tzOffset->getName() : (string) $tzOffset);
+		$key = $time . '-' . ($tzOffset instanceof \DateTimeZone ? $tzOffset->getName() : (string) $tzOffset);
 
 		if (!isset(self::$dates[$classname][$key]))
 		{
@@ -611,7 +611,7 @@ abstract class JFactory
 		{
 			$db = JDatabaseDriver::getInstance($options);
 		}
-		catch (RuntimeException $e)
+		catch (\RuntimeException $e)
 		{
 			if (!headers_sent())
 			{

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -52,17 +52,17 @@ abstract class JFolder
 
 		if (!self::exists($src))
 		{
-			throw new RuntimeException('Source folder not found', -1);
+			throw new \RuntimeException('Source folder not found', -1);
 		}
 		if (self::exists($dest) && !$force)
 		{
-			throw new RuntimeException('Destination folder not found', -1);
+			throw new \RuntimeException('Destination folder not found', -1);
 		}
 
 		// Make sure the destination exists
 		if (!self::create($dest))
 		{
-			throw new RuntimeException('Cannot create destination folder', -1);
+			throw new \RuntimeException('Cannot create destination folder', -1);
 		}
 
 		// If we're using ftp and don't have streams enabled
@@ -73,7 +73,7 @@ abstract class JFolder
 
 			if (!($dh = @opendir($src)))
 			{
-				throw new RuntimeException('Cannot open source folder', -1);
+				throw new \RuntimeException('Cannot open source folder', -1);
 			}
 			// Walk through the directory copying files and recursing into folders.
 			while (($file = readdir($dh)) !== false)
@@ -101,7 +101,7 @@ abstract class JFolder
 
 						if (!$ftp->store($sfid, $dfid))
 						{
-							throw new RuntimeException('Copy file failed', -1);
+							throw new \RuntimeException('Copy file failed', -1);
 						}
 						break;
 				}
@@ -140,14 +140,14 @@ abstract class JFolder
 
 							if (!$stream->copy($sfid, $dfid))
 							{
-								throw new RuntimeException('Cannot copy file: ' . $stream->getError(), -1);
+								throw new \RuntimeException('Cannot copy file: ' . $stream->getError(), -1);
 							}
 						}
 						else
 						{
 							if (!@copy($sfid, $dfid))
 							{
-								throw new RuntimeException('Copy file failed', -1);
+								throw new \RuntimeException('Copy file failed', -1);
 							}
 						}
 						break;

--- a/libraries/joomla/filesystem/helper.php
+++ b/libraries/joomla/filesystem/helper.php
@@ -264,7 +264,7 @@ class JFilesystemHelper
 
 		if (!$streams)
 		{
-			$files = new DirectoryIterator(__DIR__ . '/streams');
+			$files = new \DirectoryIterator(__DIR__ . '/streams');
 
 			foreach ($files as $file)
 			{

--- a/libraries/joomla/filesystem/patcher.php
+++ b/libraries/joomla/filesystem/patcher.php
@@ -162,7 +162,7 @@ class JFilesystemPatcher
 				// If no modifications were found, throw an exception
 				if (!$done)
 				{
-					throw new RuntimeException('Invalid Diff');
+					throw new \RuntimeException('Invalid Diff');
 				}
 			}
 		}
@@ -298,13 +298,13 @@ class JFilesystemPatcher
 
 			if ($line === false)
 			{
-				throw new RuntimeException('Unexpected EOF');
+				throw new \RuntimeException('Unexpected EOF');
 			}
 
 			// Search the destination file
 			if (!preg_match(self::DST_FILE, $line, $m))
 			{
-				throw new RuntimeException('Invalid Diff file');
+				throw new \RuntimeException('Invalid Diff file');
 			}
 
 			// Set the destination file
@@ -313,7 +313,7 @@ class JFilesystemPatcher
 			// Advance to the next line
 			if (next($lines) === false)
 			{
-				throw new RuntimeException('Unexpected EOF');
+				throw new \RuntimeException('Unexpected EOF');
 			}
 			return true;
 		}
@@ -364,7 +364,7 @@ class JFilesystemPatcher
 
 			if (next($lines) === false)
 			{
-				throw new RuntimeException('Unexpected EOF');
+				throw new \RuntimeException('Unexpected EOF');
 			}
 
 			return true;
@@ -417,7 +417,7 @@ class JFilesystemPatcher
 			{
 				if ($src_left == 0)
 				{
-					throw new RuntimeException(JText::sprintf('JLIB_FILESYSTEM_PATCHER_REMOVE_LINE', key($lines)));
+					throw new \RuntimeException(JText::sprintf('JLIB_FILESYSTEM_PATCHER_REMOVE_LINE', key($lines)));
 				}
 				$source[] = substr($line, 1);
 				$src_left--;
@@ -426,7 +426,7 @@ class JFilesystemPatcher
 			{
 				if ($dst_left == 0)
 				{
-					throw new RuntimeException(JText::sprintf('JLIB_FILESYSTEM_PATCHER_ADD_LINE', key($lines)));
+					throw new \RuntimeException(JText::sprintf('JLIB_FILESYSTEM_PATCHER_ADD_LINE', key($lines)));
 				}
 				$destin[] = substr($line, 1);
 				$dst_left--;
@@ -449,7 +449,7 @@ class JFilesystemPatcher
 
 					if (!isset($src_lines))
 					{
-						throw new RuntimeException(JText::sprintf('JLIB_FILESYSTEM_PATCHER_UNEXISING_SOURCE', $src));
+						throw new \RuntimeException(JText::sprintf('JLIB_FILESYSTEM_PATCHER_UNEXISING_SOURCE', $src));
 					}
 				}
 				if ($dst_size > 0)
@@ -463,7 +463,7 @@ class JFilesystemPatcher
 						{
 							if ($src_lines[$l] != $source[$l - $src_line])
 							{
-								throw new RuntimeException(JText::sprintf('JLIB_FILESYSTEM_PATCHER_FAILED_VERIFY', $src, $l));
+								throw new \RuntimeException(JText::sprintf('JLIB_FILESYSTEM_PATCHER_FAILED_VERIFY', $src, $l));
 							}
 						}
 						array_splice($dst_lines, $dst_line, count($source), $destin);
@@ -484,7 +484,7 @@ class JFilesystemPatcher
 			$line = next($lines);
 		}
 		while ($line !== false);
-		throw new RuntimeException('Unexpected EOF');
+		throw new \RuntimeException('Unexpected EOF');
 	}
 
 	/**

--- a/libraries/joomla/filesystem/path.php
+++ b/libraries/joomla/filesystem/path.php
@@ -167,7 +167,7 @@ class JPath
 		if (strpos($path, '..') !== false)
 		{
 			// Don't translate
-			throw new Exception('JPath::check Use of relative paths not permitted', 20);
+			throw new \Exception('JPath::check Use of relative paths not permitted', 20);
 		}
 
 		$path = self::clean($path);
@@ -175,7 +175,7 @@ class JPath
 		if ((JPATH_ROOT != '') && strpos($path, self::clean(JPATH_ROOT)) !== 0)
 		{
 			// Don't translate
-			throw new Exception('JPath::check Snooping out of bounds @ ' . $path, 20);
+			throw new \Exception('JPath::check Snooping out of bounds @ ' . $path, 20);
 		}
 
 		return $path;
@@ -268,7 +268,7 @@ class JPath
 	public static function find($paths, $file)
 	{
 		// Force to array
-		if (!is_array($paths) && !($paths instanceof Iterator))
+		if (!is_array($paths) && !($paths instanceof \Iterator))
 		{
 			settype($paths, 'array');
 		}

--- a/libraries/joomla/github/account.php
+++ b/libraries/joomla/github/account.php
@@ -46,7 +46,7 @@ class JGithubAccount extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -74,7 +74,7 @@ class JGithubAccount extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -122,7 +122,7 @@ class JGithubAccount extends JGithubObject
 		// Only allowed to send data for one scope parameter
 		if ($scopesCount >= 2)
 		{
-			throw new RuntimeException('You can only send one scope key in this request.');
+			throw new \RuntimeException('You can only send one scope key in this request.');
 		}
 
 		// Build the request path.
@@ -144,7 +144,7 @@ class JGithubAccount extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -173,7 +173,7 @@ class JGithubAccount extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -200,7 +200,7 @@ class JGithubAccount extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -226,7 +226,7 @@ class JGithubAccount extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);

--- a/libraries/joomla/github/commits.php
+++ b/libraries/joomla/github/commits.php
@@ -51,7 +51,7 @@ class JGithubCommits extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -95,7 +95,7 @@ class JGithubCommits extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -125,7 +125,7 @@ class JGithubCommits extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -162,7 +162,7 @@ class JGithubCommits extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -194,7 +194,7 @@ class JGithubCommits extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -224,7 +224,7 @@ class JGithubCommits extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -256,7 +256,7 @@ class JGithubCommits extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -287,7 +287,7 @@ class JGithubCommits extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -318,7 +318,7 @@ class JGithubCommits extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -349,7 +349,7 @@ class JGithubCommits extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);

--- a/libraries/joomla/github/forks.php
+++ b/libraries/joomla/github/forks.php
@@ -54,7 +54,7 @@ class JGithubForks extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -86,7 +86,7 @@ class JGithubForks extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);

--- a/libraries/joomla/github/gists.php
+++ b/libraries/joomla/github/gists.php
@@ -51,7 +51,7 @@ class JGithubGists extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -87,7 +87,7 @@ class JGithubGists extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -115,7 +115,7 @@ class JGithubGists extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 	}
 
@@ -141,7 +141,7 @@ class JGithubGists extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 	}
 
@@ -194,7 +194,7 @@ class JGithubGists extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -230,7 +230,7 @@ class JGithubGists extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -259,7 +259,7 @@ class JGithubGists extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -287,7 +287,7 @@ class JGithubGists extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -315,7 +315,7 @@ class JGithubGists extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -345,7 +345,7 @@ class JGithubGists extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -375,7 +375,7 @@ class JGithubGists extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -405,7 +405,7 @@ class JGithubGists extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -434,7 +434,7 @@ class JGithubGists extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -463,7 +463,7 @@ class JGithubGists extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -499,7 +499,7 @@ class JGithubGists extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 	}
 
@@ -525,7 +525,7 @@ class JGithubGists extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 	}
 
@@ -551,7 +551,7 @@ class JGithubGists extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 	}
 
@@ -580,7 +580,7 @@ class JGithubGists extends JGithubObject
 			// Verify that the each file exists.
 			elseif (!file_exists($file))
 			{
-				throw new InvalidArgumentException('The file ' . $file . ' does not exist.');
+				throw new \InvalidArgumentException('The file ' . $file . ' does not exist.');
 			}
 			else
 			{

--- a/libraries/joomla/github/hooks.php
+++ b/libraries/joomla/github/hooks.php
@@ -54,7 +54,7 @@ class JGithubHooks extends JGithubObject
 		{
 			if (!in_array($event, $this->events))
 			{
-				throw new RuntimeException('Your events array contains an unauthorized event.');
+				throw new \RuntimeException('Your events array contains an unauthorized event.');
 			}
 		}
 
@@ -70,7 +70,7 @@ class JGithubHooks extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -101,7 +101,7 @@ class JGithubHooks extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -134,7 +134,7 @@ class JGithubHooks extends JGithubObject
 		{
 			if (!in_array($event, $this->events))
 			{
-				throw new RuntimeException('Your events array contains an unauthorized event.');
+				throw new \RuntimeException('Your events array contains an unauthorized event.');
 			}
 		}
 
@@ -142,7 +142,7 @@ class JGithubHooks extends JGithubObject
 		{
 			if (!in_array($event, $this->events))
 			{
-				throw new RuntimeException('Your active_events array contains an unauthorized event.');
+				throw new \RuntimeException('Your active_events array contains an unauthorized event.');
 			}
 		}
 
@@ -150,7 +150,7 @@ class JGithubHooks extends JGithubObject
 		{
 			if (!in_array($event, $this->events))
 			{
-				throw new RuntimeException('Your remove_events array contains an unauthorized event.');
+				throw new \RuntimeException('Your remove_events array contains an unauthorized event.');
 			}
 		}
 		// Build the request path.
@@ -174,7 +174,7 @@ class JGithubHooks extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -205,7 +205,7 @@ class JGithubHooks extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -237,7 +237,7 @@ class JGithubHooks extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -268,7 +268,7 @@ class JGithubHooks extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);

--- a/libraries/joomla/github/issues.php
+++ b/libraries/joomla/github/issues.php
@@ -63,7 +63,7 @@ class JGithubIssues extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -101,7 +101,7 @@ class JGithubIssues extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -140,7 +140,7 @@ class JGithubIssues extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -170,7 +170,7 @@ class JGithubIssues extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 	}
 
@@ -198,7 +198,7 @@ class JGithubIssues extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 	}
 
@@ -280,7 +280,7 @@ class JGithubIssues extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -318,7 +318,7 @@ class JGithubIssues extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -358,7 +358,7 @@ class JGithubIssues extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -388,7 +388,7 @@ class JGithubIssues extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -418,7 +418,7 @@ class JGithubIssues extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -450,7 +450,7 @@ class JGithubIssues extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -480,7 +480,7 @@ class JGithubIssues extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -509,7 +509,7 @@ class JGithubIssues extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -546,7 +546,7 @@ class JGithubIssues extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -628,7 +628,7 @@ class JGithubIssues extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);

--- a/libraries/joomla/github/milestones.php
+++ b/libraries/joomla/github/milestones.php
@@ -50,7 +50,7 @@ class JGithubMilestones extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -80,7 +80,7 @@ class JGithubMilestones extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -135,7 +135,7 @@ class JGithubMilestones extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -194,7 +194,7 @@ class JGithubMilestones extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -224,7 +224,7 @@ class JGithubMilestones extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 	}
 }

--- a/libraries/joomla/github/pulls.php
+++ b/libraries/joomla/github/pulls.php
@@ -58,7 +58,7 @@ class JGithubPulls extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -102,7 +102,7 @@ class JGithubPulls extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -142,7 +142,7 @@ class JGithubPulls extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -186,7 +186,7 @@ class JGithubPulls extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -216,7 +216,7 @@ class JGithubPulls extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 	}
 
@@ -240,7 +240,7 @@ class JGithubPulls extends JGithubObject
 		$path = '/repos/' . $user . '/' . $repo . '/pulls/' . (int) $pullId;
 
 		// Craete the data object.
-		$data = new stdClass;
+		$data = new \stdClass;
 
 		// If a title is set add it to the data object.
 		if (isset($title))
@@ -271,7 +271,7 @@ class JGithubPulls extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -309,7 +309,7 @@ class JGithubPulls extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -339,7 +339,7 @@ class JGithubPulls extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -369,7 +369,7 @@ class JGithubPulls extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -401,7 +401,7 @@ class JGithubPulls extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -433,7 +433,7 @@ class JGithubPulls extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -465,7 +465,7 @@ class JGithubPulls extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -503,7 +503,7 @@ class JGithubPulls extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -541,7 +541,7 @@ class JGithubPulls extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 	}
 
@@ -577,7 +577,7 @@ class JGithubPulls extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);

--- a/libraries/joomla/github/refs.php
+++ b/libraries/joomla/github/refs.php
@@ -51,7 +51,7 @@ class JGithubRefs extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -76,7 +76,7 @@ class JGithubRefs extends JGithubObject
 		$path = '/repos/' . $user . '/' . $repo . '/git/refs/' . $ref;
 
 		// Craete the data object.
-		$data = new stdClass;
+		$data = new \stdClass;
 
 		// If a title is set add it to the data object.
 		if ($force)
@@ -97,7 +97,7 @@ class JGithubRefs extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -127,7 +127,7 @@ class JGithubRefs extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -159,7 +159,7 @@ class JGithubRefs extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);

--- a/libraries/joomla/github/statuses.php
+++ b/libraries/joomla/github/statuses.php
@@ -39,7 +39,7 @@ class JGithubStatuses extends JGithubObject
 
 		if (!in_array($state, array('pending', 'success', 'error', 'failure')))
 		{
-			throw new InvalidArgumentException('State must be one of pending, success, error or failure.');
+			throw new \InvalidArgumentException('State must be one of pending, success, error or failure.');
 		}
 
 		// Build the request data.
@@ -65,7 +65,7 @@ class JGithubStatuses extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);
@@ -95,7 +95,7 @@ class JGithubStatuses extends JGithubObject
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
-			throw new DomainException($error->message, $response->code);
+			throw new \DomainException($error->message, $response->code);
 		}
 
 		return json_decode($response->body);

--- a/libraries/joomla/google/data.php
+++ b/libraries/joomla/google/data.php
@@ -82,11 +82,11 @@ abstract class JGoogleData
 	{
 		try
 		{
-			return new SimpleXMLElement($data, LIBXML_NOWARNING | LIBXML_NOERROR);
+			return new \SimpleXMLElement($data, LIBXML_NOWARNING | LIBXML_NOERROR);
 		}
-		catch (Exception $e)
+		catch (\Exception $e)
 		{
-			throw new UnexpectedValueException("Unexpected data received from Google: `$data`.");
+			throw new \UnexpectedValueException("Unexpected data received from Google: `$data`.");
 		}
 	}
 
@@ -131,7 +131,7 @@ abstract class JGoogleData
 		}
 		else
 		{
-			throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+			throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 		}
 	}
 

--- a/libraries/joomla/google/data/adsense.php
+++ b/libraries/joomla/google/data/adsense.php
@@ -59,7 +59,7 @@ class JGoogleDataAdsense extends JGoogleData
 			}
 			else
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
 		}
 		else
@@ -148,7 +148,7 @@ class JGoogleDataAdsense extends JGoogleData
 			}
 			else
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
 		}
 		else
@@ -213,7 +213,7 @@ class JGoogleDataAdsense extends JGoogleData
 			}
 			else
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
 		}
 		else
@@ -333,12 +333,12 @@ class JGoogleDataAdsense extends JGoogleData
 		{
 			if (is_int($start))
 			{
-				$startobj = new DateTime;
+				$startobj = new \DateTime;
 				$startobj->setTimestamp($start);
 			}
 			elseif (is_string($start))
 			{
-				$startobj = new DateTime($start);
+				$startobj = new \DateTime($start);
 			}
 			elseif (is_a($start, 'DateTime'))
 			{
@@ -346,21 +346,21 @@ class JGoogleDataAdsense extends JGoogleData
 			}
 			else
 			{
-				throw new InvalidArgumentException('Invalid start time.');
+				throw new \InvalidArgumentException('Invalid start time.');
 			}
 
 			if (!$end)
 			{
-				$endobj = new DateTime;
+				$endobj = new \DateTime;
 			}
 			elseif (is_int($end))
 			{
-				$endobj = new DateTime;
+				$endobj = new \DateTime;
 				$endobj->setTimestamp($end);
 			}
 			elseif (is_string($end))
 			{
-				$endobj = new DateTime($end);
+				$endobj = new \DateTime($end);
 			}
 			elseif (is_a($end, 'DateTime'))
 			{
@@ -368,7 +368,7 @@ class JGoogleDataAdsense extends JGoogleData
 			}
 			else
 			{
-				throw new InvalidArgumentException('Invalid end time.');
+				throw new \InvalidArgumentException('Invalid end time.');
 			}
 
 			$options['startDate'] = $startobj->format('Y-m-d');
@@ -399,7 +399,7 @@ class JGoogleDataAdsense extends JGoogleData
 				}
 				else
 				{
-					throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+					throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 				}
 
 				$i++;

--- a/libraries/joomla/google/data/calendar.php
+++ b/libraries/joomla/google/data/calendar.php
@@ -54,7 +54,7 @@ class JGoogleDataCalendar extends JGoogleData
 
 			if ($jdata->body != '')
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
 			return true;
 		}
@@ -86,7 +86,7 @@ class JGoogleDataCalendar extends JGoogleData
 			}
 			else
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
 		}
 		else
@@ -120,7 +120,7 @@ class JGoogleDataCalendar extends JGoogleData
 			}
 			else
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
 		}
 		else
@@ -180,7 +180,7 @@ class JGoogleDataCalendar extends JGoogleData
 			}
 			else
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
 		}
 		else
@@ -207,7 +207,7 @@ class JGoogleDataCalendar extends JGoogleData
 
 			if ($data->body != '')
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$data->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$data->body}`.");
 			}
 			return true;
 		}
@@ -235,7 +235,7 @@ class JGoogleDataCalendar extends JGoogleData
 
 			if ($data->body != '')
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$data->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$data->body}`.");
 			}
 			return true;
 		}
@@ -270,7 +270,7 @@ class JGoogleDataCalendar extends JGoogleData
 			}
 			else
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
 		}
 		else
@@ -304,7 +304,7 @@ class JGoogleDataCalendar extends JGoogleData
 			}
 			else
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
 		}
 		else
@@ -333,7 +333,7 @@ class JGoogleDataCalendar extends JGoogleData
 
 			if ($data->body != '')
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$data->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$data->body}`.");
 			}
 			return true;
 		}
@@ -369,7 +369,7 @@ class JGoogleDataCalendar extends JGoogleData
 			}
 			else
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
 		}
 		else
@@ -401,16 +401,16 @@ class JGoogleDataCalendar extends JGoogleData
 		{
 			if (!$start)
 			{
-				$startobj = new DateTime;
+				$startobj = new \DateTime;
 			}
 			elseif (is_int($start))
 			{
-				$startobj = new DateTime;
+				$startobj = new \DateTime;
 				$startobj->setTimestamp($start);
 			}
 			elseif (is_string($start))
 			{
-				$startobj = new DateTime($start);
+				$startobj = new \DateTime($start);
 			}
 			elseif (is_a($start, 'DateTime'))
 			{
@@ -418,7 +418,7 @@ class JGoogleDataCalendar extends JGoogleData
 			}
 			else
 			{
-				throw new InvalidArgumentException('Invalid event start time.');
+				throw new \InvalidArgumentException('Invalid event start time.');
 			}
 
 			if (!$end)
@@ -427,12 +427,12 @@ class JGoogleDataCalendar extends JGoogleData
 			}
 			elseif (is_int($end))
 			{
-				$endobj = new DateTime;
+				$endobj = new \DateTime;
 				$endobj->setTimestamp($end);
 			}
 			elseif (is_string($end))
 			{
-				$endobj = new DateTime($end);
+				$endobj = new \DateTime($end);
 			}
 			elseif (is_a($end, 'DateTime'))
 			{
@@ -440,7 +440,7 @@ class JGoogleDataCalendar extends JGoogleData
 			}
 			else
 			{
-				throw new InvalidArgumentException('Invalid event end time.');
+				throw new \InvalidArgumentException('Invalid event end time.');
 			}
 
 			if ($allday)
@@ -450,8 +450,8 @@ class JGoogleDataCalendar extends JGoogleData
 			}
 			else
 			{
-				$options['start'] = array('dateTime' => $startobj->format(DateTime::RFC3339));
-				$options['end'] = array('dateTime' => $endobj->format(DateTime::RFC3339));
+				$options['start'] = array('dateTime' => $startobj->format(\DateTime::RFC3339));
+				$options['end'] = array('dateTime' => $endobj->format(\DateTime::RFC3339));
 			}
 
 			if ($timezone === true)
@@ -479,7 +479,7 @@ class JGoogleDataCalendar extends JGoogleData
 			}
 			else
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
 		}
 		else
@@ -573,7 +573,7 @@ class JGoogleDataCalendar extends JGoogleData
 			}
 			else
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
 		}
 		else
@@ -609,7 +609,7 @@ class JGoogleDataCalendar extends JGoogleData
 			}
 			else
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
 		}
 		else

--- a/libraries/joomla/google/data/picasa.php
+++ b/libraries/joomla/google/data/picasa.php
@@ -66,7 +66,7 @@ class JGoogleDataPicasa extends JGoogleData
 			}
 			else
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
 		}
 		else
@@ -96,7 +96,7 @@ class JGoogleDataPicasa extends JGoogleData
 		{
 			$time = $time ? $time : time();
 			$title = $title != '' ? $title : date('F j, Y');
-			$xml = new SimpleXMLElement('<entry></entry>');
+			$xml = new \SimpleXMLElement('<entry></entry>');
 			$xml->addAttribute('xmlns', 'http://www.w3.org/2005/Atom');
 			$xml->addChild('title', $title);
 			$xml->addChild('summary', $summary);

--- a/libraries/joomla/google/data/picasa/album.php
+++ b/libraries/joomla/google/data/picasa/album.php
@@ -33,7 +33,7 @@ class JGoogleDataPicasaAlbum extends JGoogleData
 	 *
 	 * @since   12.3
 	 */
-	public function __construct(SimpleXMLElement $xml, JRegistry $options = null, JGoogleAuth $auth = null)
+	public function __construct(\SimpleXMLElement $xml, JRegistry $options = null, JGoogleAuth $auth = null)
 	{
 		$this->xml = $xml;
 
@@ -71,18 +71,18 @@ class JGoogleDataPicasaAlbum extends JGoogleData
 			{
 				$jdata = $this->query($url, null, array('GData-Version' => 2, 'If-Match' => $match), 'delete');
 			}
-			catch (Exception $e)
+			catch (\Exception $e)
 			{
 				if (strpos($e->getMessage(), 'Error code 412 received requesting data: Mismatch: etags') === 0)
 				{
-					throw new RuntimeException("Etag match failed: `$match`.");
+					throw new \RuntimeException("Etag match failed: `$match`.");
 				}
 				throw $e;
 			}
 
 			if ($jdata->body != '')
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
 			$this->xml = null;
 
@@ -287,7 +287,7 @@ class JGoogleDataPicasaAlbum extends JGoogleData
 			{
 				if (strpos($e->getMessage(), 'Error code 412 received requesting data: Mismatch: etags') === 0)
 				{
-					throw new RuntimeException("Etag match failed: `$match`.");
+					throw new \RuntimeException("Etag match failed: `$match`.");
 				}
 				throw $e;
 			}
@@ -354,7 +354,7 @@ class JGoogleDataPicasaAlbum extends JGoogleData
 			}
 			else
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
 		}
 		else
@@ -383,14 +383,14 @@ class JGoogleDataPicasaAlbum extends JGoogleData
 
 			if (!($type = $this->getMIME($file)))
 			{
-				throw new RuntimeException("Inappropriate file type.");
+				throw new \RuntimeException("Inappropriate file type.");
 			}
 			if (!($data = JFile::read($file)))
 			{
-				throw new RuntimeException("Cannot access file: `$file`");
+				throw new \RuntimeException("Cannot access file: `$file`");
 			}
 
-			$xml = new SimpleXMLElement('<entry></entry>');
+			$xml = new \SimpleXMLElement('<entry></entry>');
 			$xml->addAttribute('xmlns', 'http://www.w3.org/2005/Atom');
 			$xml->addChild('title', $title);
 			$xml->addChild('summary', $summary);

--- a/libraries/joomla/google/data/picasa/photo.php
+++ b/libraries/joomla/google/data/picasa/photo.php
@@ -33,7 +33,7 @@ class JGoogleDataPicasaPhoto extends JGoogleData
 	 *
 	 * @since   12.3
 	 */
-	public function __construct(SimpleXMLElement $xml, JRegistry $options = null, JGoogleAuth $auth = null)
+	public function __construct(\SimpleXMLElement $xml, JRegistry $options = null, JGoogleAuth $auth = null)
 	{
 		$this->xml = $xml;
 
@@ -71,18 +71,18 @@ class JGoogleDataPicasaPhoto extends JGoogleData
 			{
 				$jdata = $this->query($url, null, array('GData-Version' => 2, 'If-Match' => $match), 'delete');
 			}
-			catch (Exception $e)
+			catch (\Exception $e)
 			{
 				if (strpos($e->getMessage(), 'Error code 412 received requesting data: Mismatch: etags') === 0)
 				{
-					throw new RuntimeException("Etag match failed: `$match`.");
+					throw new \RuntimeException("Etag match failed: `$match`.");
 				}
 				throw $e;
 			}
 
 			if ($jdata->body != '')
 			{
-				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
+				throw new \UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
 			$this->xml = null;
 
@@ -324,11 +324,11 @@ class JGoogleDataPicasaPhoto extends JGoogleData
 				$headers = array('GData-Version' => 2, 'Content-type' => 'application/atom+xml', 'If-Match' => $match);
 				$jdata = $this->query($url, $this->xml->asXML(), $headers, 'put');
 			}
-			catch (Exception $e)
+			catch (\Exception $e)
 			{
 				if (strpos($e->getMessage(), 'Error code 412 received requesting data: Mismatch: etags') === 0)
 				{
-					throw new RuntimeException("Etag match failed: `$match`.");
+					throw new \RuntimeException("Etag match failed: `$match`.");
 				}
 				throw $e;
 			}

--- a/libraries/joomla/google/embed/analytics.php
+++ b/libraries/joomla/google/embed/analytics.php
@@ -262,7 +262,7 @@ class JGoogleEmbedAnalytics extends JGoogleEmbed
 
 		if (!$this->getOption('code'))
 		{
-			throw new UnexpectedValueException('A Google Analytics tracking code is required.');
+			throw new \UnexpectedValueException('A Google Analytics tracking code is required.');
 		}
 
 		$code = $this->getOption('code');
@@ -293,7 +293,7 @@ class JGoogleEmbedAnalytics extends JGoogleEmbed
 	{
 		if (!$this->getOption('code'))
 		{
-			throw new UnexpectedValueException('A Google Analytics tracking code is required.');
+			throw new \UnexpectedValueException('A Google Analytics tracking code is required.');
 		}
 
 		$prefix = $this->isSecure() ? 'https://ssl' : 'http://www';

--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -393,7 +393,7 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 
 		if ($index >= count($markers) || $index < 0)
 		{
-			throw new OutOfBoundsException('Marker index out of bounds.');
+			throw new \OutOfBoundsException('Marker index out of bounds.');
 		}
 
 		$marker = $markers[$index];
@@ -551,7 +551,7 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 	{
 		if (!$this->getOption('key'))
 		{
-			throw new UnexpectedValueException('A Google Maps API key is required.');
+			throw new \UnexpectedValueException('A Google Maps API key is required.');
 		}
 
 		$zoom = $this->getZoom();
@@ -679,14 +679,14 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 
 		if ($response->code < 200 || $response->code >= 300)
 		{
-			throw new RuntimeException('Error code ' . $response->code . ' received geocoding address: ' . $response->body . '.');
+			throw new \RuntimeException('Error code ' . $response->code . ' received geocoding address: ' . $response->body . '.');
 		}
 
 		$data = json_decode($response->body, true);
 
 		if (!$data)
 		{
-			throw new RuntimeException('Invalid json received geocoding address: ' . $response->body . '.');
+			throw new \RuntimeException('Invalid json received geocoding address: ' . $response->body . '.');
 		}
 		if ($data['status'] != 'OK')
 		{

--- a/libraries/joomla/grid/grid.php
+++ b/libraries/joomla/grid/grid.php
@@ -285,7 +285,7 @@ class JGrid
 	{
 		if ($replace || !isset($this->rows[$this->activeRow][$name]))
 		{
-			$cell = new stdClass;
+			$cell = new \stdClass;
 			$cell->options = $option;
 			$cell->content = $content;
 			$this->rows[$this->activeRow][$name] = $cell;

--- a/libraries/joomla/html/content.php
+++ b/libraries/joomla/html/content.php
@@ -35,7 +35,7 @@ abstract class JHtmlContent
 		{
 			$params = new JObject;
 		}
-		$article = new stdClass;
+		$article = new \stdClass;
 		$article->text = $text;
 		JPluginHelper::importPlugin('content');
 		$dispatcher = JEventDispatcher::getInstance();

--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -117,12 +117,12 @@ abstract class JHtml
 
 				if (!class_exists($className))
 				{
-					throw new InvalidArgumentException(sprintf('%s not found.', $className), 500);
+					throw new \InvalidArgumentException(sprintf('%s not found.', $className), 500);
 				}
 			}
 			else
 			{
-				throw new InvalidArgumentException(sprintf('%s %s not found.', $prefix, $file), 500);
+				throw new \InvalidArgumentException(sprintf('%s %s not found.', $prefix, $file), 500);
 			}
 		}
 
@@ -140,7 +140,7 @@ abstract class JHtml
 		}
 		else
 		{
-			throw new InvalidArgumentException(sprintf('%s::%s not found.', $className, $func), 500);
+			throw new \InvalidArgumentException(sprintf('%s::%s not found.', $className, $func), 500);
 		}
 	}
 
@@ -222,7 +222,7 @@ abstract class JHtml
 	{
 		if (!is_callable($function))
 		{
-			throw new InvalidArgumentException('Function not supported', 500);
+			throw new \InvalidArgumentException('Function not supported', 500);
 		}
 
 		// PHP 5.3 workaround
@@ -746,7 +746,7 @@ abstract class JHtml
 			$date = JFactory::getDate($input, 'UTC');
 
 			// Set the correct time zone based on the server configuration.
-			$date->setTimeZone(new DateTimeZone($config->get('offset')));
+			$date->setTimeZone(new \DateTimeZone($config->get('offset')));
 		}
 		// No date conversion.
 		elseif ($tz === null)
@@ -760,7 +760,7 @@ abstract class JHtml
 			$date = JFactory::getDate($input, 'UTC');
 
 			// Set the correct time zone based on the server configuration.
-			$date->setTimeZone(new DateTimeZone($tz));
+			$date->setTimeZone(new \DateTimeZone($tz));
 		}
 
 		// If no format is given use the default locale based format.

--- a/libraries/joomla/html/jgrid.php
+++ b/libraries/joomla/html/jgrid.php
@@ -161,7 +161,7 @@ abstract class JHtmlJGrid
 			$nullDate = JFactory::getDBO()->getNullDate();
 			$nowDate = JFactory::getDate()->toUnix();
 
-			$tz = new DateTimeZone(JFactory::getUser()->getParam('timezone', JFactory::getConfig()->get('offset')));
+			$tz = new \DateTimeZone(JFactory::getUser()->getParam('timezone', JFactory::getConfig()->get('offset')));
 
 			$publish_up = ($publish_up != $nullDate) ? JFactory::getDate($publish_up, 'UTC')->setTimeZone($tz) : false;
 			$publish_down = ($publish_down != $nullDate) ? JFactory::getDate($publish_down, 'UTC')->setTimeZone($tz) : false;

--- a/libraries/joomla/html/list.php
+++ b/libraries/joomla/html/list.php
@@ -45,7 +45,7 @@ abstract class JHtmlList
 				. ".options[selectedIndex].value} else {document.imagelib.src='media/system/images/blank.png'}\"";
 		}
 
-		$imageFiles = new DirectoryIterator(JPATH_SITE . '/' . $directory);
+		$imageFiles = new \DirectoryIterator(JPATH_SITE . '/' . $directory);
 		$images = array(JHtml::_('select.option', '', JText::_('JOPTION_SELECT_IMAGE')));
 
 		foreach ($imageFiles as $file)

--- a/libraries/joomla/html/select.php
+++ b/libraries/joomla/html/select.php
@@ -345,13 +345,13 @@ abstract class JHtmlSelect
 		switch ($state)
 		{
 			case 'open':
-				$obj = new stdClass;
+				$obj = new \stdClass;
 				$obj->$optKey = '<OPTGROUP>';
 				$obj->$optText = $text;
 				$state = 'close';
 				break;
 			case 'close':
-				$obj = new stdClass;
+				$obj = new \stdClass;
 				$obj->$optKey = '</OPTGROUP>';
 				$obj->$optText = $text;
 				$state = 'open';

--- a/libraries/joomla/http/factory.php
+++ b/libraries/joomla/http/factory.php
@@ -85,7 +85,7 @@ class JHttpFactory
 	public static function getHttpTransports()
 	{
 		$names = array();
-		$iterator = new DirectoryIterator(__DIR__ . '/transport');
+		$iterator = new \DirectoryIterator(__DIR__ . '/transport');
 
 		foreach ($iterator as $file)
 		{

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -158,7 +158,7 @@ class JHttpTransportCurl implements JHttpTransport
 				$message = 'No HTTP response received';
 			}
 
-			throw new RuntimeException($message);
+			throw new \RuntimeException($message);
 		}
 
 		// Get the request information.
@@ -216,7 +216,7 @@ class JHttpTransportCurl implements JHttpTransport
 		// No valid response code was detected.
 		else
 		{
-			throw new UnexpectedValueException('No HTTP response code found.');
+			throw new \UnexpectedValueException('No HTTP response code found.');
 		}
 
 		// Add the response headers to the response object.

--- a/libraries/joomla/http/transport/socket.php
+++ b/libraries/joomla/http/transport/socket.php
@@ -42,7 +42,7 @@ class JHttpTransportSocket implements JHttpTransport
 	{
 		if (!self::isSupported())
 		{
-			throw new RuntimeException('Cannot use a socket transport when fsockopen() is not available.');
+			throw new \RuntimeException('Cannot use a socket transport when fsockopen() is not available.');
 		}
 
 		$this->options = $options;
@@ -75,12 +75,12 @@ class JHttpTransportSocket implements JHttpTransport
 
 			if ($meta['timed_out'])
 			{
-				throw new RuntimeException('Server connection timed out.');
+				throw new \RuntimeException('Server connection timed out.');
 			}
 		}
 		else
 		{
-			throw new RuntimeException('Not connected to server.');
+			throw new \RuntimeException('Not connected to server.');
 		}
 
 		// Get the request path from the URI object.
@@ -162,7 +162,7 @@ class JHttpTransportSocket implements JHttpTransport
 
 		if (empty($content))
 		{
-			throw new UnexpectedValueException('No content in response.');
+			throw new \UnexpectedValueException('No content in response.');
 		}
 
 		// Split the response into headers and body.
@@ -186,7 +186,7 @@ class JHttpTransportSocket implements JHttpTransport
 		// No valid response code was detected.
 		else
 		{
-			throw new UnexpectedValueException('No HTTP response code found.');
+			throw new \UnexpectedValueException('No HTTP response code found.');
 		}
 
 		// Add the response headers to the response object.
@@ -243,7 +243,7 @@ class JHttpTransportSocket implements JHttpTransport
 			{
 				if (!fclose($this->connections[$key]))
 				{
-					throw new RuntimeException('Cannot close connection');
+					throw new \RuntimeException('Cannot close connection');
 				}
 			}
 
@@ -279,7 +279,7 @@ class JHttpTransportSocket implements JHttpTransport
 			// Restore error tracking to give control to the exception handler
 			ini_set('track_errors', $track_errors);
 
-			throw new RuntimeException($php_errormsg);
+			throw new \RuntimeException($php_errormsg);
 		}
 		// Restore error tracking to what it was before.
 		ini_set('track_errors', $track_errors);

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -37,13 +37,13 @@ class JHttpTransportStream implements JHttpTransport
 		// Verify that fopen() is available.
 		if (!self::isSupported())
 		{
-			throw new RuntimeException('Cannot use a stream transport when fopen() is not available.');
+			throw new \RuntimeException('Cannot use a stream transport when fopen() is not available.');
 		}
 
 		// Verify that URLs can be used with fopen();
 		if (!ini_get('allow_url_fopen'))
 		{
-			throw new RuntimeException('Cannot use a stream transport when "allow_url_fopen" is disabled.');
+			throw new \RuntimeException('Cannot use a stream transport when "allow_url_fopen" is disabled.');
 		}
 
 		$this->options = $options;
@@ -144,7 +144,7 @@ class JHttpTransportStream implements JHttpTransport
 			// Restore error tracking to give control to the exception handler
 			ini_set('track_errors', $track_errors);
 
-			throw new RuntimeException($php_errormsg);
+			throw new \RuntimeException($php_errormsg);
 		}
 
 		// Restore error tracking to what it was before.
@@ -207,7 +207,7 @@ class JHttpTransportStream implements JHttpTransport
 		// No valid response code was detected.
 		else
 		{
-			throw new UnexpectedValueException('No HTTP response code found.');
+			throw new \UnexpectedValueException('No HTTP response code found.');
 		}
 
 		// Add the response headers to the response object.

--- a/libraries/joomla/image/filter.php
+++ b/libraries/joomla/image/filter.php
@@ -48,7 +48,7 @@ abstract class JImageFilter
 		if (!is_resource($handle) || (get_resource_type($handle) != 'gd'))
 		{
 			JLog::add('The image handle is invalid for the image filter.', JLog::ERROR);
-			throw new InvalidArgumentException('The image handle is invalid for the image filter.');
+			throw new \InvalidArgumentException('The image handle is invalid for the image filter.');
 		}
 
 		$this->handle = $handle;

--- a/libraries/joomla/image/filter/brightness.php
+++ b/libraries/joomla/image/filter/brightness.php
@@ -33,7 +33,7 @@ class JImageFilterBrightness extends JImageFilter
 		// Validate that the brightness value exists and is an integer.
 		if (!isset($options[IMG_FILTER_BRIGHTNESS]) || !is_int($options[IMG_FILTER_BRIGHTNESS]))
 		{
-			throw new InvalidArgumentException('No valid brightness value was given.  Expected integer.');
+			throw new \InvalidArgumentException('No valid brightness value was given.  Expected integer.');
 		}
 
 		// Perform the brightness filter.

--- a/libraries/joomla/image/filter/contrast.php
+++ b/libraries/joomla/image/filter/contrast.php
@@ -33,7 +33,7 @@ class JImageFilterContrast extends JImageFilter
 		// Validate that the contrast value exists and is an integer.
 		if (!isset($options[IMG_FILTER_CONTRAST]) || !is_int($options[IMG_FILTER_CONTRAST]))
 		{
-			throw new InvalidArgumentException('No valid contrast value was given.  Expected integer.');
+			throw new \InvalidArgumentException('No valid contrast value was given.  Expected integer.');
 		}
 
 		// Perform the contrast filter.

--- a/libraries/joomla/image/filter/smooth.php
+++ b/libraries/joomla/image/filter/smooth.php
@@ -33,7 +33,7 @@ class JImageFilterSmooth extends JImageFilter
 		// Validate that the smoothing value exists and is an integer.
 		if (!isset($options[IMG_FILTER_SMOOTH]) || !is_int($options[IMG_FILTER_SMOOTH]))
 		{
-			throw new InvalidArgumentException('No valid smoothing value was given.  Expected integer.');
+			throw new \InvalidArgumentException('No valid smoothing value was given.  Expected integer.');
 		}
 
 		// Perform the smoothing filter.

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -75,7 +75,7 @@ class JImage
 		{
 			// @codeCoverageIgnoreStart
 			JLog::add('The GD extension for PHP is not available.', JLog::ERROR);
-			throw new RuntimeException('The GD extension for PHP is not available.');
+			throw new \RuntimeException('The GD extension for PHP is not available.');
 
 			// @codeCoverageIgnoreEnd
 		}
@@ -119,7 +119,7 @@ class JImage
 		// Make sure the file exists.
 		if (!file_exists($path))
 		{
-			throw new InvalidArgumentException('The image file does not exist.');
+			throw new \InvalidArgumentException('The image file does not exist.');
 		}
 
 		// Get the image file information.
@@ -128,7 +128,7 @@ class JImage
 		if (!$info)
 		{
 			// @codeCoverageIgnoreStart
-			throw new RuntimeException('Unable to get properties for the image.');
+			throw new \RuntimeException('Unable to get properties for the image.');
 
 			// @codeCoverageIgnoreEnd
 		}
@@ -166,7 +166,7 @@ class JImage
 		// Make sure the resource handle is valid.
 		if (!$this->isLoaded())
 		{
-			throw new LogicException('No valid image was loaded.');
+			throw new \LogicException('No valid image was loaded.');
 		}
 
 		// Accept a single thumbsize string as parameter
@@ -187,7 +187,7 @@ class JImage
 
 				if (count($size) != 2)
 				{
-					throw new InvalidArgumentException('Invalid thumb size received: ' . $thumbSize);
+					throw new \InvalidArgumentException('Invalid thumb size received: ' . $thumbSize);
 				}
 				$thumbWidth 	= $size[0];
 				$thumbHeight	= $size[1];
@@ -230,7 +230,7 @@ class JImage
 		// Make sure the resource handle is valid.
 		if (!$this->isLoaded())
 		{
-			throw new LogicException('No valid image was loaded.');
+			throw new \LogicException('No valid image was loaded.');
 		}
 
 		// No thumbFolder set -> we will create a thumbs folder in the current image folder
@@ -242,7 +242,7 @@ class JImage
 		// Check destination
 		if (!is_dir($thumbsFolder) && (!is_dir(dirname($thumbsFolder)) || !@mkdir($thumbsFolder)))
 		{
-			throw new InvalidArgumentException('Folder does not exist and cannot be created: ' . $thumbsFolder);
+			throw new \InvalidArgumentException('Folder does not exist and cannot be created: ' . $thumbsFolder);
 		}
 
 		// Process thumbs
@@ -298,7 +298,7 @@ class JImage
 		// Make sure the resource handle is valid.
 		if (!$this->isLoaded())
 		{
-			throw new LogicException('No valid image was loaded.');
+			throw new \LogicException('No valid image was loaded.');
 		}
 
 		// Sanitize width.
@@ -384,7 +384,7 @@ class JImage
 		// Make sure the resource handle is valid.
 		if (!$this->isLoaded())
 		{
-			throw new LogicException('No valid image was loaded.');
+			throw new \LogicException('No valid image was loaded.');
 		}
 
 		// Get the image filter instance.
@@ -409,7 +409,7 @@ class JImage
 		// Make sure the resource handle is valid.
 		if (!$this->isLoaded())
 		{
-			throw new LogicException('No valid image was loaded.');
+			throw new \LogicException('No valid image was loaded.');
 		}
 
 		return imagesy($this->handle);
@@ -428,7 +428,7 @@ class JImage
 		// Make sure the resource handle is valid.
 		if (!$this->isLoaded())
 		{
-			throw new LogicException('No valid image was loaded.');
+			throw new \LogicException('No valid image was loaded.');
 		}
 
 		return imagesx($this->handle);
@@ -477,7 +477,7 @@ class JImage
 		// Make sure the resource handle is valid.
 		if (!$this->isLoaded())
 		{
-			throw new LogicException('No valid image was loaded.');
+			throw new \LogicException('No valid image was loaded.');
 		}
 
 		return (imagecolortransparent($this->handle) >= 0);
@@ -499,7 +499,7 @@ class JImage
 		// Make sure the file exists.
 		if (!file_exists($path))
 		{
-			throw new InvalidArgumentException('The image file does not exist.');
+			throw new \InvalidArgumentException('The image file does not exist.');
 		}
 
 		// Get the image properties.
@@ -514,7 +514,7 @@ class JImage
 				{
 					// @codeCoverageIgnoreStart
 					JLog::add('Attempting to load an image of unsupported type GIF.', JLog::ERROR);
-					throw new RuntimeException('Attempting to load an image of unsupported type GIF.');
+					throw new \RuntimeException('Attempting to load an image of unsupported type GIF.');
 
 					// @codeCoverageIgnoreEnd
 				}
@@ -525,7 +525,7 @@ class JImage
 				if (!is_resource($handle))
 				{
 					// @codeCoverageIgnoreStart
-					throw new RuntimeException('Unable to process GIF image.');
+					throw new \RuntimeException('Unable to process GIF image.');
 
 					// @codeCoverageIgnoreEnd
 				}
@@ -538,7 +538,7 @@ class JImage
 				{
 					// @codeCoverageIgnoreStart
 					JLog::add('Attempting to load an image of unsupported type JPG.', JLog::ERROR);
-					throw new RuntimeException('Attempting to load an image of unsupported type JPG.');
+					throw new \RuntimeException('Attempting to load an image of unsupported type JPG.');
 
 					// @codeCoverageIgnoreEnd
 				}
@@ -549,7 +549,7 @@ class JImage
 				if (!is_resource($handle))
 				{
 					// @codeCoverageIgnoreStart
-					throw new RuntimeException('Unable to process JPG image.');
+					throw new \RuntimeException('Unable to process JPG image.');
 
 					// @codeCoverageIgnoreEnd
 				}
@@ -562,7 +562,7 @@ class JImage
 				{
 					// @codeCoverageIgnoreStart
 					JLog::add('Attempting to load an image of unsupported type PNG.', JLog::ERROR);
-					throw new RuntimeException('Attempting to load an image of unsupported type PNG.');
+					throw new \RuntimeException('Attempting to load an image of unsupported type PNG.');
 
 					// @codeCoverageIgnoreEnd
 				}
@@ -573,7 +573,7 @@ class JImage
 				if (!is_resource($handle))
 				{
 					// @codeCoverageIgnoreStart
-					throw new RuntimeException('Unable to process PNG image.');
+					throw new \RuntimeException('Unable to process PNG image.');
 
 					// @codeCoverageIgnoreEnd
 				}
@@ -582,7 +582,7 @@ class JImage
 
 			default:
 				JLog::add('Attempting to load an image of unsupported type: ' . $properties->mime, JLog::ERROR);
-				throw new InvalidArgumentException('Attempting to load an image of unsupported type: ' . $properties->mime);
+				throw new \InvalidArgumentException('Attempting to load an image of unsupported type: ' . $properties->mime);
 				break;
 		}
 
@@ -609,7 +609,7 @@ class JImage
 		// Make sure the resource handle is valid.
 		if (!$this->isLoaded())
 		{
-			throw new LogicException('No valid image was loaded.');
+			throw new \LogicException('No valid image was loaded.');
 		}
 
 		// Sanitize width.
@@ -682,7 +682,7 @@ class JImage
 		// Make sure the resource handle is valid.
 		if (!$this->isLoaded())
 		{
-			throw new LogicException('No valid image was loaded.');
+			throw new \LogicException('No valid image was loaded.');
 		}
 
 		// Sanitize input
@@ -738,7 +738,7 @@ class JImage
 		// Make sure the resource handle is valid.
 		if (!$this->isLoaded())
 		{
-			throw new LogicException('No valid image was loaded.');
+			throw new \LogicException('No valid image was loaded.');
 		}
 
 		switch ($type)
@@ -778,7 +778,7 @@ class JImage
 		if (!class_exists($className))
 		{
 			JLog::add('The ' . ucfirst($type) . ' image filter is not available.', JLog::ERROR);
-			throw new RuntimeException('The ' . ucfirst($type) . ' image filter is not available.');
+			throw new \RuntimeException('The ' . ucfirst($type) . ' image filter is not available.');
 		}
 
 		// Instantiate the filter object.
@@ -789,7 +789,7 @@ class JImage
 		{
 			// @codeCoverageIgnoreStart
 			JLog::add('The ' . ucfirst($type) . ' image filter is not valid.', JLog::ERROR);
-			throw new RuntimeException('The ' . ucfirst($type) . ' image filter is not valid.');
+			throw new \RuntimeException('The ' . ucfirst($type) . ' image filter is not valid.');
 
 			// @codeCoverageIgnoreEnd
 		}
@@ -812,7 +812,7 @@ class JImage
 	protected function prepareDimensions($width, $height, $scaleMethod)
 	{
 		// Instantiate variables.
-		$dimensions = new stdClass;
+		$dimensions = new \stdClass;
 
 		switch ($scaleMethod)
 		{
@@ -827,7 +827,7 @@ class JImage
 				// Both $height or $width cannot be zero
 				if ($width == 0 || $height == 0)
 				{
-					throw new InvalidArgumentException(' Width or height cannot be zero with this scale method ');
+					throw new \InvalidArgumentException(' Width or height cannot be zero with this scale method ');
 				}
 
 				// If both $width and $height are not equals to zero
@@ -851,7 +851,7 @@ class JImage
 				break;
 
 			default:
-				throw new InvalidArgumentException('Invalid scale method.');
+				throw new \InvalidArgumentException('Invalid scale method.');
 				break;
 		}
 

--- a/libraries/joomla/input/input.php
+++ b/libraries/joomla/input/input.php
@@ -37,7 +37,7 @@ defined('JPATH_PLATFORM') or die;
  * @method      string   getPath()      getPath($name, $default = null)
  * @method      string   getUsername()  getUsername($name, $default = null)
  */
-class JInput implements Serializable, Countable
+class JInput implements \Serializable, \Countable
 {
 	/**
 	 * Options array for the JInput instance.

--- a/libraries/joomla/keychain/keychain.php
+++ b/libraries/joomla/keychain/keychain.php
@@ -49,14 +49,14 @@ class JKeychain extends JRegistry
 
 		if (!$privateKey)
 		{
-			throw new RuntimeException("Failed to load private key.");
+			throw new \RuntimeException("Failed to load private key.");
 		}
 
 		$crypted = '';
 
 		if (!openssl_private_encrypt($passphrase, $crypted, $privateKey))
 		{
-			throw new RuntimeException("Failed to encrypt data using private key.");
+			throw new \RuntimeException("Failed to encrypt data using private key.");
 		}
 
 		return file_put_contents($passphraseFile, $crypted);
@@ -117,7 +117,7 @@ class JKeychain extends JRegistry
 	{
 		if (!file_exists($keychainFile))
 		{
-			throw new RuntimeException('Attempting to load non-existent keychain file');
+			throw new \RuntimeException('Attempting to load non-existent keychain file');
 		}
 		$passphrase = $this->getPassphraseFromFile($passphraseFile, $publicKeyFile);
 
@@ -125,7 +125,7 @@ class JKeychain extends JRegistry
 
 		if ($cleartext === false)
 		{
-			throw new RuntimeException("Failed to decrypt keychain file");
+			throw new \RuntimeException("Failed to decrypt keychain file");
 		}
 
 		return $this->loadObject(json_decode($cleartext));
@@ -152,7 +152,7 @@ class JKeychain extends JRegistry
 
 		if ($encrypted === false)
 		{
-			throw new RuntimeException('Unable to encrypt keychain');
+			throw new \RuntimeException('Unable to encrypt keychain');
 		}
 
 		return file_put_contents($keychainFile, $encrypted);
@@ -173,25 +173,26 @@ class JKeychain extends JRegistry
 	{
 		if (!file_exists($publicKeyFile))
 		{
-			throw new RuntimeException('Missing public key file');
+			throw new \RuntimeException('Missing public key file');
 		}
 		$publicKey = openssl_get_publickey(file_get_contents($publicKeyFile));
 
 		if (!$publicKey)
 		{
-			throw new RuntimeException("Failed to load public key.");
+			throw new \RuntimeException("Failed to load public key.");
 		}
 
 		if (!file_exists($passphraseFile))
 		{
-			throw new RuntimeException('Missing passphrase file');
+			throw new \RuntimeException('Missing passphrase file');
 		}
 		$passphrase = '';
 
 		if (!openssl_public_decrypt(file_get_contents($passphraseFile), $passphrase, $publicKey))
 		{
-			throw new RuntimeException('Failed to decrypt passphrase file');
+			throw new \RuntimeException('Failed to decrypt passphrase file');
 		}
+
 		return $passphrase;
 	}
 }

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -1253,7 +1253,7 @@ class JLanguage
 	{
 		$languages = array();
 
-		$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));
+		$iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir));
 
 		foreach ($iterator as $file)
 		{
@@ -1298,7 +1298,7 @@ class JLanguage
 	{
 		if (!is_readable($path))
 		{
-			throw new RuntimeException('File not found or not readable');
+			throw new \RuntimeException('File not found or not readable');
 		}
 
 		// Try to load the file

--- a/libraries/joomla/language/stemmer.php
+++ b/libraries/joomla/language/stemmer.php
@@ -57,7 +57,7 @@ abstract class JLanguageStemmer
 		if (!class_exists($class))
 		{
 			// Throw invalid adapter exception.
-			throw new RuntimeException(JText::sprintf('JLIB_STEMMER_INVALID_STEMMER', $adapter));
+			throw new \RuntimeException(JText::sprintf('JLIB_STEMMER_INVALID_STEMMER', $adapter));
 		}
 
 		self::$instances[$adapter] = new $class;

--- a/libraries/joomla/log/log.php
+++ b/libraries/joomla/log/log.php
@@ -256,7 +256,7 @@ class JLog
 				}
 				else
 				{
-					throw new RuntimeException('Unable to create a JLogLogger instance: ' . $class);
+					throw new \RuntimeException('Unable to create a JLogLogger instance: ' . $class);
 				}
 			}
 

--- a/libraries/joomla/log/logger/formattedtext.php
+++ b/libraries/joomla/log/logger/formattedtext.php
@@ -168,7 +168,7 @@ class JLogLoggerFormattedtext extends JLogLogger
 		// Write the new entry to the file.
 		if (!fwrite($this->file, $line . "\n"))
 		{
-			throw new RuntimeException('Cannot write to log file.');
+			throw new \RuntimeException('Cannot write to log file.');
 		}
 	}
 
@@ -238,7 +238,7 @@ class JLogLoggerFormattedtext extends JLogLogger
 		{
 			if (!fwrite($this->file, $head))
 			{
-				throw new RuntimeException('Cannot fput file for log');
+				throw new \RuntimeException('Cannot fput file for log');
 			}
 		}
 	}

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -18,7 +18,7 @@ jimport('phpmailer.phpmailer');
  * @subpackage  Mail
  * @since       11.1
  */
-class JMail extends PHPMailer
+class JMail extends \PHPMailer
 {
 	/**
 	 * @var    array  JMail instances container.
@@ -82,7 +82,7 @@ class JMail extends PHPMailer
 			}
 			else
 			{
-				throw new RuntimeException(sprintf('%s::Send mail not enabled.'), get_class($this));
+				throw new \RuntimeException(sprintf('%s::Send mail not enabled.'), get_class($this));
 			}
 		}
 
@@ -96,7 +96,7 @@ class JMail extends PHPMailer
 			}
 			else
 			{
-				throw new RuntimeException(sprintf('%s::Send failed: "%s".'), get_class($this), $this->ErrorInfo);
+				throw new \RuntimeException(sprintf('%s::Send failed: "%s".'), get_class($this), $this->ErrorInfo);
 			}
 		}
 
@@ -137,7 +137,7 @@ class JMail extends PHPMailer
 		else
 		{
 			// If it's neither we throw an exception
-			throw new UnexpectedValueException(sprintf('Invalid email Sender: %s, JMail::setSender(%s)', $from));
+			throw new \UnexpectedValueException(sprintf('Invalid email Sender: %s, JMail::setSender(%s)', $from));
 		}
 
 		return $this;
@@ -201,7 +201,7 @@ class JMail extends PHPMailer
 
 				if ($combined === false)
 				{
-					throw new InvalidArgumentException("The number of elements for each array isn't equal.");
+					throw new \InvalidArgumentException("The number of elements for each array isn't equal.");
 				}
 
 				foreach ($combined as $recipientEmail => $recipientName)
@@ -312,7 +312,7 @@ class JMail extends PHPMailer
 			{
 				if (!empty($name) && count($attachment) != count($name))
 				{
-					throw new InvalidArgumentException("The number of attachments must be equal with the number of name");
+					throw new \InvalidArgumentException("The number of attachments must be equal with the number of name");
 				}
 
 				foreach ($attachment as $key => $file)

--- a/libraries/joomla/oauth2/client.php
+++ b/libraries/joomla/oauth2/client.php
@@ -97,7 +97,7 @@ class JOAuth2Client
 			}
 			else
 			{
-				throw new RuntimeException('Error code ' . $response->code . ' received requesting access token: ' . $response->body . '.');
+				throw new \RuntimeException('Error code ' . $response->code . ' received requesting access token: ' . $response->body . '.');
 			}
 		}
 
@@ -144,7 +144,7 @@ class JOAuth2Client
 	{
 		if (!$this->getOption('authurl') || !$this->getOption('clientid'))
 		{
-			throw new InvalidArgumentException('Authorization URL and client_id are required');
+			throw new \InvalidArgumentException('Authorization URL and client_id are required');
 		}
 
 		$url = $this->getOption('authurl');
@@ -246,12 +246,12 @@ class JOAuth2Client
 			$response = $this->http->$method($url, $data, $headers, $timeout);
 			break;
 			default:
-			throw new InvalidArgumentException('Unknown HTTP request method: ' . $method . '.');
+			throw new \InvalidArgumentException('Unknown HTTP request method: ' . $method . '.');
 		}
 
 		if ($response->code < 200 || $response->code >= 400)
 		{
-			throw new RuntimeException('Error code ' . $response->code . ' received requesting data: ' . $response->body . '.');
+			throw new \RuntimeException('Error code ' . $response->code . ' received requesting data: ' . $response->body . '.');
 		}
 		return $response;
 	}
@@ -333,7 +333,7 @@ class JOAuth2Client
 	{
 		if (!$this->getOption('userefresh'))
 		{
-			throw new RuntimeException('Refresh token is not supported for this OAuth instance.');
+			throw new \RuntimeException('Refresh token is not supported for this OAuth instance.');
 		}
 
 		if (!$token)
@@ -342,7 +342,7 @@ class JOAuth2Client
 
 			if (!array_key_exists('refresh_token', $token))
 			{
-				throw new RuntimeException('No refresh token is available.');
+				throw new \RuntimeException('No refresh token is available.');
 			}
 			$token = $token['refresh_token'];
 		}
@@ -370,7 +370,7 @@ class JOAuth2Client
 		}
 		else
 		{
-			throw new Exception('Error code ' . $response->code . ' received refreshing token: ' . $response->body . '.');
+			throw new \Exception('Error code ' . $response->code . ' received refreshing token: ' . $response->body . '.');
 		}
 	}
 }

--- a/libraries/joomla/object/object.php
+++ b/libraries/joomla/object/object.php
@@ -145,7 +145,7 @@ class JObject
 		}
 
 		// Check if only the string is requested
-		if ($error instanceof Exception && $toString)
+		if ($error instanceof \Exception && $toString)
 		{
 			return (string) $error;
 		}

--- a/libraries/joomla/pagination/pagination.php
+++ b/libraries/joomla/pagination/pagination.php
@@ -662,7 +662,7 @@ class JPagination
 	 */
 	protected function _buildDataObject()
 	{
-		$data = new stdClass;
+		$data = new \stdClass;
 
 		// Build the additional URL parameters string.
 		$params = '';
@@ -782,10 +782,12 @@ class JPagination
 			$prop[1] = ucfirst($prop[1]);
 			$property = implode($prop);
 		}
+
 		if (isset($this->$property))
 		{
 			return $this->$property;
 		}
+
 		return $default;
 	}
 }

--- a/libraries/joomla/registry/format.php
+++ b/libraries/joomla/registry/format.php
@@ -56,7 +56,7 @@ abstract class JRegistryFormat
 				}
 				else
 				{
-					throw new InvalidArgumentException('Unable to load format class.', 500);
+					throw new \InvalidArgumentException('Unable to load format class.', 500);
 				}
 			}
 

--- a/libraries/joomla/registry/format/ini.php
+++ b/libraries/joomla/registry/format/ini.php
@@ -89,10 +89,10 @@ class JRegistryFormatINI extends JRegistryFormat
 		// If no lines present just return the object.
 		if (empty($data))
 		{
-			return new stdClass;
+			return new \stdClass;
 		}
 
-		$obj = new stdClass;
+		$obj = new \stdClass;
 		$section = false;
 		$lines = explode("\n", $data);
 
@@ -116,7 +116,7 @@ class JRegistryFormatINI extends JRegistryFormat
 				if (($line[0] == '[') && ($line[$length - 1] == ']'))
 				{
 					$section = substr($line, 1, $length - 2);
-					$obj->$section = new stdClass;
+					$obj->$section = new \stdClass;
 					continue;
 				}
 			}

--- a/libraries/joomla/registry/format/xml.php
+++ b/libraries/joomla/registry/format/xml.php
@@ -56,7 +56,7 @@ class JRegistryFormatXML extends JRegistryFormat
 	 */
 	public function stringToObject($data, array $options = array())
 	{
-		$obj = new stdClass;
+		$obj = new \stdClass;
 
 		// Parse the XML string.
 		$xml = simplexml_load_string($data);
@@ -109,7 +109,7 @@ class JRegistryFormatXML extends JRegistryFormat
 				}
 				break;
 			default:
-				$value = new stdClass;
+				$value = new \stdClass;
 
 				foreach ($node->children() as $child)
 				{
@@ -132,7 +132,7 @@ class JRegistryFormatXML extends JRegistryFormat
 	 *
 	 * @since   11.1
 	 */
-	protected function getXmlChildren(SimpleXMLElement $node, $var, $nodeName)
+	protected function getXmlChildren(\SimpleXMLElement $node, $var, $nodeName)
 	{
 		// Iterate over the object members.
 		foreach ((array) $var as $k => $v)

--- a/libraries/joomla/registry/registry.php
+++ b/libraries/joomla/registry/registry.php
@@ -346,7 +346,7 @@ class JRegistry implements JsonSerializable
 			{
 				if (!isset($node->$nodes[$i]) && ($i != $n))
 				{
-					$node->$nodes[$i] = new stdClass;
+					$node->$nodes[$i] = new \stdClass;
 				}
 				$node = $node->$nodes[$i];
 			}
@@ -426,7 +426,7 @@ class JRegistry implements JsonSerializable
 		{
 			if ((is_array($v) && JArrayHelper::isAssociative($v)) || is_object($v))
 			{
-				$parent->$k = new stdClass;
+				$parent->$k = new \stdClass;
 				$this->bindData($parent->$k, $v);
 			}
 			else

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -21,7 +21,7 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Session
  * @since       11.1
  */
-class JSession implements IteratorAggregate
+class JSession implements \IteratorAggregate
 {
 	/**
 	 * Internal state.
@@ -296,7 +296,7 @@ class JSession implements IteratorAggregate
 	 */
 	public function getIterator()
 	{
-		return new ArrayIterator($_SESSION);
+		return new \ArrayIterator($_SESSION);
 	}
 
 	/**
@@ -382,7 +382,7 @@ class JSession implements IteratorAggregate
 		$connectors = array();
 
 		// Get an iterator and loop trough the driver classes.
-		$iterator = new DirectoryIterator(__DIR__ . '/storage');
+		$iterator = new \DirectoryIterator(__DIR__ . '/storage');
 
 		foreach ($iterator as $file)
 		{

--- a/libraries/joomla/session/storage/apc.php
+++ b/libraries/joomla/session/storage/apc.php
@@ -31,7 +31,7 @@ class JSessionStorageApc extends JSessionStorage
 	{
 		if (!self::isSupported())
 		{
-			throw new RuntimeException('APC Extension is not available', 404);
+			throw new \RuntimeException('APC Extension is not available', 404);
 		}
 
 		parent::__construct($options);

--- a/libraries/joomla/session/storage/database.php
+++ b/libraries/joomla/session/storage/database.php
@@ -45,7 +45,7 @@ class JSessionStorageDatabase extends JSessionStorage
 
 			return (string) $db->loadResult();
 		}
-		catch (Exception $e)
+		catch (\Exception $e)
 		{
 			return false;
 		}
@@ -87,7 +87,7 @@ class JSessionStorageDatabase extends JSessionStorage
 			*/
 			return true;
 		}
-		catch (Exception $e)
+		catch (\Exception $e)
 		{
 			return false;
 		}
@@ -118,7 +118,7 @@ class JSessionStorageDatabase extends JSessionStorage
 
 			return (boolean) $db->execute();
 		}
-		catch (Exception $e)
+		catch (\Exception $e)
 		{
 			return false;
 		}
@@ -152,7 +152,7 @@ class JSessionStorageDatabase extends JSessionStorage
 
 			return (boolean) $db->execute();
 		}
-		catch (Exception $e)
+		catch (\Exception $e)
 		{
 			return false;
 		}

--- a/libraries/joomla/session/storage/memcache.php
+++ b/libraries/joomla/session/storage/memcache.php
@@ -30,7 +30,7 @@ class JSessionStorageMemcache extends JSessionStorage
 	{
 		if (!self::isSupported())
 		{
-			throw new RuntimeException('Memcache Extension is not available', 404);
+			throw new \RuntimeException('Memcache Extension is not available', 404);
 		}
 
 		parent::__construct($options);

--- a/libraries/joomla/session/storage/memcached.php
+++ b/libraries/joomla/session/storage/memcached.php
@@ -30,7 +30,7 @@ class JSessionStorageMemcached extends JSessionStorage
 	{
 		if (!self::isSupported())
 		{
-			throw new RuntimeException('Memcached Extension is not available', 404);
+			throw new \RuntimeException('Memcached Extension is not available', 404);
 		}
 
 		parent::__construct($options);

--- a/libraries/joomla/session/storage/wincache.php
+++ b/libraries/joomla/session/storage/wincache.php
@@ -30,7 +30,7 @@ class JSessionStorageWincache extends JSessionStorage
 	{
 		if (!self::isSupported())
 		{
-			throw new RuntimeException('Wincache Extension is not available', 404);
+			throw new \RuntimeException('Wincache Extension is not available', 404);
 		}
 
 		parent::__construct($options);

--- a/libraries/joomla/session/storage/xcache.php
+++ b/libraries/joomla/session/storage/xcache.php
@@ -30,7 +30,7 @@ class JSessionStorageXcache extends JSessionStorage
 	{
 		if (!self::isSupported())
 		{
-			throw new RuntimeException('XCache Extension is not available', 404);
+			throw new \RuntimeException('XCache Extension is not available', 404);
 		}
 
 		parent::__construct($options);

--- a/libraries/joomla/string/inflector.php
+++ b/libraries/joomla/string/inflector.php
@@ -137,7 +137,7 @@ class JStringInflector
 		elseif (!is_array($data))
 		{
 			// Do not translate.
-			throw new InvalidArgumentException('Invalid inflector rule data.');
+			throw new \InvalidArgumentException('Invalid inflector rule data.');
 		}
 
 		foreach ($data as $rule)

--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -217,7 +217,7 @@ class JTableNested extends JTable
 		// Make sure the location is valid.
 		if (($position != 'before') && ($position != 'after') && ($position != 'first-child') && ($position != 'last-child'))
 		{
-			throw new InvalidArgumentException(sprintf('%s::setLocation(%d, *%s*)', get_class($this), $referenceId, $position));
+			throw new \InvalidArgumentException(sprintf('%s::setLocation(%d, *%s*)', get_class($this), $referenceId, $position));
 		}
 
 		// Set the location properties.
@@ -331,7 +331,7 @@ class JTableNested extends JTable
 		// Cannot move the node to be a child of itself.
 		if (in_array($referenceId, $children))
 		{
-			$e = new UnexpectedValueException(
+			$e = new \UnexpectedValueException(
 				sprintf('%s::moveByReference(%d, %s, %d) parenting to child.', get_class($this), $referenceId, $position, $pk)
 			);
 			$this->setError($e);
@@ -664,7 +664,7 @@ class JTableNested extends JTable
 			// Check that the parent_id field is valid.
 			if ($this->parent_id == 0)
 			{
-				throw new UnexpectedValueException(sprintf('Invalid `parent_id` [%d] in %s', $this->parent_id, get_class($this)));
+				throw new \UnexpectedValueException(sprintf('Invalid `parent_id` [%d] in %s', $this->parent_id, get_class($this)));
 			}
 
 			$query = $this->_db->getQuery(true);
@@ -674,10 +674,10 @@ class JTableNested extends JTable
 
 			if (!$this->_db->setQuery($query)->loadResult())
 			{
-				throw new UnexpectedValueException(sprintf('Invalid `parent_id` [%d] in %s', $this->parent_id, get_class($this)));
+				throw new \UnexpectedValueException(sprintf('Invalid `parent_id` [%d] in %s', $this->parent_id, get_class($this)));
 			}
 		}
-		catch (UnexpectedValueException $e)
+		catch (\UnexpectedValueException $e)
 		{
 			// Validation error - record it and return false.
 			$this->setError($e);
@@ -685,7 +685,7 @@ class JTableNested extends JTable
 			return false;
 		}
 		// @codeCoverageIgnoreStart
-		catch (Exception $e)
+		catch (\Exception $e)
 		{
 			// Database error - rethrow.
 			throw $e;
@@ -801,7 +801,7 @@ class JTableNested extends JTable
 			else
 			{
 				// Negative parent ids are invalid
-				$e = new UnexpectedValueException(sprintf('%s::store() used a negative _location_id', get_class($this)));
+				$e = new \UnexpectedValueException(sprintf('%s::store() used a negative _location_id', get_class($this)));
 				$this->setError($e);
 
 				return false;
@@ -893,7 +893,7 @@ class JTableNested extends JTable
 			// Nothing to set publishing state on, return false.
 			else
 			{
-				$e = new UnexpectedValueException(sprintf('%s::publish(%s, %d, %d) empty.', get_class($this), $pks, $state, $userId));
+				$e = new \UnexpectedValueException(sprintf('%s::publish(%s, %d, %d) empty.', get_class($this), $pks, $state, $userId));
 				$this->setError($e);
 
 				return false;
@@ -928,7 +928,7 @@ class JTableNested extends JTable
 				if ($this->_db->loadResult())
 				{
 					// TODO Convert to a conflict exception when available.
-					$e = new RuntimeException(sprintf('%s::publish(%s, %d, %d) checked-out conflict.', get_class($this), $pks, $state, $userId));
+					$e = new \RuntimeException(sprintf('%s::publish(%s, %d, %d) checked-out conflict.', get_class($this), $pks, $state, $userId));
 					$this->setError($e);
 
 					return false;
@@ -950,7 +950,7 @@ class JTableNested extends JTable
 
 				if (!empty($rows))
 				{
-					$e = new UnexpectedValueException(
+					$e = new \UnexpectedValueException(
 						sprintf('%s::publish(%s, %d, %d) ancestors have lower state.', get_class($this), $pks, $state, $userId)
 					);
 					$this->setError($e);
@@ -1208,7 +1208,7 @@ class JTableNested extends JTable
 			}
 		}
 
-		$e = new UnexpectedValueException(sprintf('%s::getRootId', get_class($this)));
+		$e = new \UnexpectedValueException(sprintf('%s::getRootId', get_class($this)));
 		$this->setError($e);
 
 		return false;
@@ -1407,7 +1407,7 @@ class JTableNested extends JTable
 				return false;
 			}
 		}
-		catch (Exception $e)
+		catch (\Exception $e)
 		{
 			$this->_unlock();
 			throw $e;
@@ -1459,7 +1459,7 @@ class JTableNested extends JTable
 		// Check for no $row returned
 		if (empty($row))
 		{
-			$e = new UnexpectedValueException(sprintf('%s::_getNode(%d, %s) failed.', get_class($this), $id, $key));
+			$e = new \UnexpectedValueException(sprintf('%s::_getNode(%d, %s) failed.', get_class($this), $id, $key));
 			$this->setError($e);
 
 			return false;
@@ -1503,7 +1503,7 @@ class JTableNested extends JTable
 		}
 
 		$k = $this->_tbl_key;
-		$data = new stdClass;
+		$data = new \stdClass;
 
 		// Run the calculations and build the data object by reference position.
 		switch ($position)
@@ -1630,7 +1630,7 @@ class JTableNested extends JTable
 			}
 			// @codeCoverageIgnoreEnd
 		}
-		catch (Exception $e)
+		catch (\Exception $e)
 		{
 			// Unlock the tables and rethrow.
 			$this->_unlock();

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -186,7 +186,7 @@ abstract class JTable extends JObject
 
 			if (empty($fields))
 			{
-				throw new UnexpectedValueException(sprintf('No columns found for %s table', $name));
+				throw new \UnexpectedValueException(sprintf('No columns found for %s table', $name));
 			}
 			$cache = $fields;
 		}
@@ -540,7 +540,7 @@ abstract class JTable extends JObject
 		// If the source value is not an array or object return false.
 		if (!is_object($src) && !is_array($src))
 		{
-			throw new InvalidArgumentException(sprintf('%s::bind(*%s*)', get_class($this), gettype($src)));
+			throw new \InvalidArgumentException(sprintf('%s::bind(*%s*)', get_class($this), gettype($src)));
 		}
 
 		// If the source value is an object, get its accessible properties.
@@ -615,13 +615,13 @@ abstract class JTable extends JObject
 			{
 				if ($keyCount > 1)
 				{
-					throw new InvalidArgumentException('Table has multiple primary keys specified, only one primary key value provided.');
+					throw new \InvalidArgumentException('Table has multiple primary keys specified, only one primary key value provided.');
 				}
 				$keys = array($this->getKeyName() => $keys);
 			}
 			else
 			{
-				throw new RuntimeException('No table keys defined.');
+				throw new \RuntimeException('No table keys defined.');
 			}
 		}
 
@@ -641,7 +641,7 @@ abstract class JTable extends JObject
 			// Check that $field is in the table.
 			if (!in_array($field, $fields))
 			{
-				throw new UnexpectedValueException(sprintf('Missing field in database: %s &#160; %s.', get_class($this), $field));
+				throw new \UnexpectedValueException(sprintf('Missing field in database: %s &#160; %s.', get_class($this), $field));
 			}
 			// Add the search tuple to the query.
 			$query->where($this->_db->quoteName($field) . ' = ' . $this->_db->quote($value));
@@ -882,7 +882,7 @@ abstract class JTable extends JObject
 
 			if ($pk[$key] === null)
 			{
-				throw new UnexpectedValueException('Null primary key not allowed.');
+				throw new \UnexpectedValueException('Null primary key not allowed.');
 			}
 			$this->$key = $pk[$key];
 		}
@@ -970,7 +970,7 @@ abstract class JTable extends JObject
 
 			if ($pk[$key] === null)
 			{
-				throw new UnexpectedValueException('Null primary key not allowed.');
+				throw new \UnexpectedValueException('Null primary key not allowed.');
 			}
 		}
 
@@ -1032,7 +1032,7 @@ abstract class JTable extends JObject
 
 			if ($pk[$key] === null)
 			{
-				throw new UnexpectedValueException('Null primary key not allowed.');
+				throw new \UnexpectedValueException('Null primary key not allowed.');
 			}
 		}
 
@@ -1133,7 +1133,7 @@ abstract class JTable extends JObject
 
 			if ($pk[$key] === null)
 			{
-				throw new UnexpectedValueException('Null primary key not allowed.');
+				throw new \UnexpectedValueException('Null primary key not allowed.');
 			}
 		}
 
@@ -1204,7 +1204,7 @@ abstract class JTable extends JObject
 		// If there is no ordering field set an error and return false.
 		if (!property_exists($this, 'ordering'))
 		{
-			throw new UnexpectedValueException(sprintf('%s does not support ordering.', get_class($this)));
+			throw new \UnexpectedValueException(sprintf('%s does not support ordering.', get_class($this)));
 		}
 
 		// Get the largest ordering value for a given where clause.
@@ -1264,7 +1264,7 @@ abstract class JTable extends JObject
 		// If there is no ordering field set an error and return false.
 		if (!property_exists($this, 'ordering'))
 		{
-			throw new UnexpectedValueException(sprintf('%s does not support ordering.', get_class($this)));
+			throw new \UnexpectedValueException(sprintf('%s does not support ordering.', get_class($this)));
 		}
 
 		$k = $this->_tbl_key;
@@ -1327,7 +1327,7 @@ abstract class JTable extends JObject
 		// If there is no ordering field set an error and return false.
 		if (!property_exists($this, 'ordering'))
 		{
-			throw new UnexpectedValueException(sprintf('%s does not support ordering.', get_class($this)));
+			throw new \UnexpectedValueException(sprintf('%s does not support ordering.', get_class($this)));
 		}
 
 		// If the change is none, do nothing.

--- a/libraries/joomla/table/usergroup.php
+++ b/libraries/joomla/table/usergroup.php
@@ -156,15 +156,15 @@ class JTableUsergroup extends JTable
 		}
 		if ($this->id == 0)
 		{
-			throw new UnexpectedValueException('Global Category not found');
+			throw new \UnexpectedValueException('Global Category not found');
 		}
 		if ($this->parent_id == 0)
 		{
-			throw new UnexpectedValueException('Root categories cannot be deleted.');
+			throw new \UnexpectedValueException('Root categories cannot be deleted.');
 		}
 		if ($this->lft == 0 || $this->rgt == 0)
 		{
-			throw new UnexpectedValueException('Left-Right data inconsistency. Cannot delete usergroup.');
+			throw new \UnexpectedValueException('Left-Right data inconsistency. Cannot delete usergroup.');
 		}
 
 		$db = $this->_db;
@@ -180,7 +180,7 @@ class JTableUsergroup extends JTable
 
 		if (empty($ids))
 		{
-			throw new UnexpectedValueException('Left-Right data inconsistency. Cannot delete usergroup.');
+			throw new \UnexpectedValueException('Left-Right data inconsistency. Cannot delete usergroup.');
 		}
 
 		// Delete the category dependencies

--- a/libraries/joomla/uri/uri.php
+++ b/libraries/joomla/uri/uri.php
@@ -197,7 +197,7 @@ class JUri
 				$theURI = $uri;
 			}
 
-			self::$instances[$uri] = new JURI($theURI);
+			self::$instances[$uri] = new static($theURI);
 		}
 		return self::$instances[$uri];
 	}

--- a/libraries/joomla/user/authentication.php
+++ b/libraries/joomla/user/authentication.php
@@ -120,7 +120,7 @@ class JAuthentication extends JObject
 	{
 		if (empty(self::$instance))
 		{
-			self::$instance = new JAuthentication;
+			self::$instance = new static;
 		}
 
 		return self::$instance;
@@ -171,7 +171,7 @@ class JAuthentication extends JObject
 		}
 		else
 		{
-			if (!($observer instanceof JAuthentication))
+			if (!($observer instanceof self))
 			{
 				return;
 			}

--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -52,7 +52,7 @@ abstract class JUserHelper
 			// If the group does not exist, return an exception.
 			if (!$title)
 			{
-				throw new RuntimeException('Access Usergroup Invalid');
+				throw new \RuntimeException('Access Usergroup Invalid');
 			}
 
 			// Add the group data to the user object.

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -257,13 +257,13 @@ class JUser extends JObject
 		// Note: don't cache this user because it'll have a new ID on save!
 		if ($id === 0)
 		{
-			return new JUser;
+			return new static;
 		}
 
 		// Check if the user ID is already cached.
 		if (empty(self::$instances[$id]))
 		{
-			$user = new JUser($id);
+			$user = new static($id);
 			self::$instances[$id] = $user;
 		}
 

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -686,7 +686,7 @@ class JUser extends JObject
 					{
 						if (JAccess::checkGroup($groupId, 'core.admin'))
 						{
-							throw new RuntimeException('User not Super Administrator');
+							throw new \RuntimeException('User not Super Administrator');
 						}
 					}
 				}
@@ -695,7 +695,7 @@ class JUser extends JObject
 					// I am not a Super Admin, and this one is, so fail.
 					if (JAccess::check($this->id, 'core.admin'))
 					{
-						throw new RuntimeException('User not Super Administrator');
+						throw new \RuntimeException('User not Super Administrator');
 					}
 
 					if ($this->groups != null)
@@ -705,7 +705,7 @@ class JUser extends JObject
 						{
 							if (JAccess::checkGroup($groupId, 'core.admin'))
 							{
-								throw new RuntimeException('User not Super Administrator');
+								throw new \RuntimeException('User not Super Administrator');
 							}
 						}
 					}
@@ -743,7 +743,7 @@ class JUser extends JObject
 			// Fire the onUserAfterSave event
 			$dispatcher->trigger('onUserAfterSave', array($this->getProperties(), $isNew, $result, $this->getError()));
 		}
-		catch (Exception $e)
+		catch (\Exception $e)
 		{
 			$this->setError($e->getMessage());
 

--- a/libraries/joomla/view/html.php
+++ b/libraries/joomla/view/html.php
@@ -44,7 +44,7 @@ abstract class JViewHtml extends JViewBase
 	 *
 	 * @since   12.1
 	 */
-	public function __construct(JModel $model, SplPriorityQueue $paths = null)
+	public function __construct(JModel $model, \SplPriorityQueue $paths = null)
 	{
 		parent::__construct($model);
 
@@ -140,7 +140,7 @@ abstract class JViewHtml extends JViewBase
 		// Check if the layout path was found.
 		if (!$path)
 		{
-			throw new RuntimeException('Layout Path Not Found');
+			throw new \RuntimeException('Layout Path Not Found');
 		}
 
 		// Start an output buffer.
@@ -180,7 +180,7 @@ abstract class JViewHtml extends JViewBase
 	 *
 	 * @since   12.1
 	 */
-	public function setPaths(SplPriorityQueue $paths)
+	public function setPaths(\SplPriorityQueue $paths)
 	{
 		$this->paths = $paths;
 
@@ -196,6 +196,6 @@ abstract class JViewHtml extends JViewBase
 	 */
 	protected function loadPaths()
 	{
-		return new SplPriorityQueue;
+		return new \SplPriorityQueue;
 	}
 }

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -70,14 +70,14 @@ abstract class JLoader
 		{
 			if ($recurse)
 			{
-				$iterator = new RecursiveIteratorIterator(
-					new RecursiveDirectoryIterator($parentPath),
-					RecursiveIteratorIterator::SELF_FIRST
+				$iterator = new \RecursiveIteratorIterator(
+					new \RecursiveDirectoryIterator($parentPath),
+					\RecursiveIteratorIterator::SELF_FIRST
 				);
 			}
 			else
 			{
-				$iterator = new DirectoryIterator($parentPath);
+				$iterator = new \DirectoryIterator($parentPath);
 			}
 
 			foreach ($iterator as $file)
@@ -99,7 +99,7 @@ abstract class JLoader
 				}
 			}
 		}
-		catch (UnexpectedValueException $e)
+		catch (\UnexpectedValueException $e)
 		{
 			// Exception will be thrown if the path is not a directory. Ignore it.
 		}
@@ -430,7 +430,7 @@ abstract class JLoader
 		// Verify the library path exists.
 		if (!file_exists($path))
 		{
-			throw new RuntimeException('Library path ' . $path . ' cannot be found.', 500);
+			throw new \RuntimeException('Library path ' . $path . ' cannot be found.', 500);
 		}
 
 		// If the prefix is not yet registered or we have an explicit reset flag then set set the path.
@@ -463,7 +463,7 @@ abstract class JLoader
 		// Verify the library path exists.
 		if (!file_exists($path))
 		{
-			throw new RuntimeException('Library path ' . $path . ' cannot be found.', 500);
+			throw new \RuntimeException('Library path ' . $path . ' cannot be found.', 500);
 		}
 
 		// If the namespace is not yet registered or we have an explicit reset flag then set the path.

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -505,7 +505,7 @@ abstract class JLoader
 		if ($enableClasses)
 		{
 			// Register the class map based autoloader.
-			spl_autoload_register(array('JLoader', 'load'));
+			spl_autoload_register(array(__CLASS__, 'load'));
 		}
 
 		if ($enablePrefixes)
@@ -514,7 +514,7 @@ abstract class JLoader
 			self::registerPrefix('J', JPATH_PLATFORM . '/joomla');
 
 			// Register the prefix autoloader.
-			spl_autoload_register(array('JLoader', '_autoload'));
+			spl_autoload_register(array(__CLASS__, '_autoload'));
 		}
 
 		if ($enableNamespaces)
@@ -523,22 +523,22 @@ abstract class JLoader
 			{
 				// Register the lower case namespace loader.
 				case self::LOWER_CASE:
-					spl_autoload_register(array('JLoader', 'loadByNamespaceLowerCase'));
+					spl_autoload_register(array(__CLASS__, 'loadByNamespaceLowerCase'));
 					break;
 
 				// Register the natural case namespace loader.
 				case self::NATURAL_CASE:
-					spl_autoload_register(array('JLoader', 'loadByNamespaceNaturalCase'));
+					spl_autoload_register(array(__CLASS__, 'loadByNamespaceNaturalCase'));
 					break;
 
 				// Register the mixed case namespace loader.
 				case self::MIXED_CASE:
-					spl_autoload_register(array('JLoader', 'loadByNamespaceMixedCase'));
+					spl_autoload_register(array(__CLASS__, 'loadByNamespaceMixedCase'));
 					break;
 
 				// Default to the lower case namespace loader.
 				default:
-					spl_autoload_register(array('JLoader', 'loadByNamespaceLowerCase'));
+					spl_autoload_register(array(__CLASS__, 'loadByNamespaceLowerCase'));
 					break;
 			}
 		}


### PR DESCRIPTION
This PR adds in the root namespace backslash on calls to internal PHP and SPL classes. This will facilitate the platform moving to native PHP namespaces, whenever that may be.

More info can be found here: http://www.php.net/manual/en/language.namespaces.faq.php#language.namespaces.faq.globalclass

Also, I've replaced some explicit calls to class names with `__CLASS__` in callables. For example, in `JLoader` when calling `spl_autoload_register()`. Also, where creating a new instance of the containing class, I've changed `new JClassName` to `new static`. I've not completed all instances of these yet.

This PR does not break B/C at all, as the whole codebase is already operating in the root/global namespace. But this will need to be done when we do move to namespaces, so I thought I could help that along.

No unit tests were harmed in the making of this pull request.
