### PR TITLE
Consolidating duplicate code checks into isSupported() method

### DIFF
--- a/libraries/joomla/image/filter.php
+++ b/libraries/joomla/image/filter.php
@@ -34,6 +34,16 @@ abstract class JImageFilter
 	 */
 	public function __construct($handle)
 	{
+		// Verify that image filter support for PHP is available.
+		if (!function_exists('imagefilter'))
+		{
+			// @codeCoverageIgnoreStart
+			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR);
+			throw new RuntimeException('The imagefilter function for PHP is not available.');
+
+			// @codeCoverageIgnoreEnd
+		}
+
 		// Make sure the file handle is valid.
 		if (!is_resource($handle) || (get_resource_type($handle) != 'gd'))
 		{

--- a/libraries/joomla/image/filter/brightness.php
+++ b/libraries/joomla/image/filter/brightness.php
@@ -27,20 +27,9 @@ class JImageFilterBrightness extends JImageFilter
 	 *
 	 * @since   11.3
 	 * @throws  InvalidArgumentException
-	 * @throws  RuntimeException
 	 */
 	public function execute(array $options = array())
 	{
-		// Verify that image filter support for PHP is available.
-		if (!function_exists('imagefilter'))
-		{
-			// @codeCoverageIgnoreStart
-			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR);
-			throw new RuntimeException('The imagefilter function for PHP is not available.');
-
-			// @codeCoverageIgnoreEnd
-		}
-
 		// Validate that the brightness value exists and is an integer.
 		if (!isset($options[IMG_FILTER_BRIGHTNESS]) || !is_int($options[IMG_FILTER_BRIGHTNESS]))
 		{

--- a/libraries/joomla/image/filter/contrast.php
+++ b/libraries/joomla/image/filter/contrast.php
@@ -27,20 +27,9 @@ class JImageFilterContrast extends JImageFilter
 	 *
 	 * @since   11.3
 	 * @throws  InvalidArgumentException
-	 * @throws  RuntimeException
 	 */
 	public function execute(array $options = array())
 	{
-		// Verify that image filter support for PHP is available.
-		if (!function_exists('imagefilter'))
-		{
-			// @codeCoverageIgnoreStart
-			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR);
-			throw new RuntimeException('The imagefilter function for PHP is not available.');
-
-			// @codeCoverageIgnoreEnd
-		}
-
 		// Validate that the contrast value exists and is an integer.
 		if (!isset($options[IMG_FILTER_CONTRAST]) || !is_int($options[IMG_FILTER_CONTRAST]))
 		{

--- a/libraries/joomla/image/filter/edgedetect.php
+++ b/libraries/joomla/image/filter/edgedetect.php
@@ -26,20 +26,9 @@ class JImageFilterEdgedetect extends JImageFilter
 	 * @return  void
 	 *
 	 * @since   11.3
-	 * @throws  RuntimeException
 	 */
 	public function execute(array $options = array())
 	{
-		// Verify that image filter support for PHP is available.
-		if (!function_exists('imagefilter'))
-		{
-			// @codeCoverageIgnoreStart
-			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR);
-			throw new RuntimeException('The imagefilter function for PHP is not available.');
-
-			// @codeCoverageIgnoreEnd
-		}
-
 		// Perform the edge detection filter.
 		imagefilter($this->handle, IMG_FILTER_EDGEDETECT);
 	}

--- a/libraries/joomla/image/filter/emboss.php
+++ b/libraries/joomla/image/filter/emboss.php
@@ -26,17 +26,9 @@ class JImageFilterEmboss extends JImageFilter
 	 * @return  void
 	 *
 	 * @since   11.3
-	 * @throws  RuntimeException
 	 */
 	public function execute(array $options = array())
 	{
-		// Verify that image filter support for PHP is available.
-		if (!function_exists('imagefilter'))
-		{
-			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR);
-			throw new RuntimeException('The imagefilter function for PHP is not available.');
-		}
-
 		// Perform the emboss filter.
 		imagefilter($this->handle, IMG_FILTER_EMBOSS);
 	}

--- a/libraries/joomla/image/filter/grayscale.php
+++ b/libraries/joomla/image/filter/grayscale.php
@@ -26,18 +26,9 @@ class JImageFilterGrayscale extends JImageFilter
 	 * @return  void
 	 *
 	 * @since   11.3
-	 * @throws  InvalidArgumentException
-	 * @throws  RuntimeException
 	 */
 	public function execute(array $options = array())
 	{
-		// Verify that image filter support for PHP is available.
-		if (!function_exists('imagefilter'))
-		{
-			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR);
-			throw new RuntimeException('The imagefilter function for PHP is not available.');
-		}
-
 		// Perform the grayscale filter.
 		imagefilter($this->handle, IMG_FILTER_GRAYSCALE);
 	}

--- a/libraries/joomla/image/filter/negate.php
+++ b/libraries/joomla/image/filter/negate.php
@@ -26,17 +26,9 @@ class JImageFilterNegate extends JImageFilter
 	 * @return  void
 	 *
 	 * @since   11.3
-	 * @throws  RuntimeException
 	 */
 	public function execute(array $options = array())
 	{
-		// Verify that image filter support for PHP is available.
-		if (!function_exists('imagefilter'))
-		{
-			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR);
-			throw new RuntimeException('The imagefilter function for PHP is not available.');
-		}
-
 		// Perform the negative filter.
 		imagefilter($this->handle, IMG_FILTER_NEGATE);
 	}

--- a/libraries/joomla/image/filter/sketchy.php
+++ b/libraries/joomla/image/filter/sketchy.php
@@ -26,17 +26,9 @@ class JImageFilterSketchy extends JImageFilter
 	 * @return  void
 	 *
 	 * @since   11.3
-	 * @throws  RuntimeException
 	 */
 	public function execute(array $options = array())
 	{
-		// Verify that image filter support for PHP is available.
-		if (!function_exists('imagefilter'))
-		{
-			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR);
-			throw new RuntimeException('The imagefilter function for PHP is not available.');
-		}
-
 		// Perform the sketchy filter.
 		imagefilter($this->handle, IMG_FILTER_MEAN_REMOVAL);
 	}

--- a/libraries/joomla/image/filter/smooth.php
+++ b/libraries/joomla/image/filter/smooth.php
@@ -27,17 +27,9 @@ class JImageFilterSmooth extends JImageFilter
 	 *
 	 * @since   11.3
 	 * @throws  InvalidArgumentException
-	 * @throws  RuntimeException
 	 */
 	public function execute(array $options = array())
 	{
-		// Verify that image filter support for PHP is available.
-		if (!function_exists('imagefilter'))
-		{
-			JLog::add('The imagefilter function for PHP is not available.', JLog::ERROR);
-			throw new RuntimeException('The imagefilter function for PHP is not available.');
-		}
-
 		// Validate that the smoothing value exists and is an integer.
 		if (!isset($options[IMG_FILTER_SMOOTH]) || !is_int($options[IMG_FILTER_SMOOTH]))
 		{

--- a/tests/suites/unit/joomla/image/JImageFilterTest.php
+++ b/tests/suites/unit/joomla/image/JImageFilterTest.php
@@ -73,7 +73,7 @@ class JImageFilterTest extends TestCase
 	 */
 	public function testConstructor()
 	{
-		// Create a image handle of the correct size.
+		// Create an image handle of the correct size.
 		$imageHandle = imagecreatetruecolor(100, 100);
 
 		$filter = new JImageFilterBrightness($imageHandle);


### PR DESCRIPTION
8 lines of code were duplicated across every `JImageFilter*` class in the execute method to determine whether or not the `imagefilter` function existed. Seemed a little ridiculous to me, so I consolidated the check into it's own `isSupported()` method, and call that instead.
