### PR TITLE
Update libraries/joomla/html/html.php

### DIFF
--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -283,7 +283,7 @@ abstract class JHtml
 	 *
 	 * @param   string   $folder          folder name to search into (images, css, js, ...)
 	 * @param   string   $file            path to file
-	 * @param   boolean  $relative        path to file is relative to /media folder
+	 * @param   boolean  $relative        path to file is relative to /media folder  (and searches in template)
 	 * @param   boolean  $detect_browser  detect browser to include specific browser files
 	 * @param   boolean  $detect_debug    detect debug to include compressed files if debug is on
 	 *
@@ -526,40 +526,31 @@ abstract class JHtml
 	/**
 	 * Write a <img></img> element
 	 *
-	 * @param   string   $file       The relative or absolute URL to use for the src attribute
-	 * @param   string   $alt        The alt text.
-	 * @param   string   $attribs    The target attribute to use
-	 * @param   array    $relative   An associative array of attributes to add
-	 * @param   boolean  $path_only  If set to true, it tries to find an override for the file in the template
+	 * @param   string	$file		The relative or absolute URL to use for the src attribute
+	 * @param   string	$alt		The alt text.
+	 * @param   mixed	$attribs	String or associative array of attribute(s) to use
+	 * @param   boolean	$relative	path to file is relative to /media folder (and searches in template)
+	 * @param   mixed	$path_rel	Return html tag without (-1) or with file computing(false). Return computed path only (true) 
 	 *
 	 * @return  string
 	 *
 	 * @since   11.1
 	 */
-	public static function image($file, $alt, $attribs = null, $relative = false, $path_only = false)
+	public static function image($file, $alt, $attribs = null, $relative = false, $path_rel = false)
 	{
-		if (is_array($attribs))
-		{
-			$attribs = JArrayHelper::toString($attribs);
+		if ($path_rel!==-1) {
+			$includes = self::includeRelativeFiles('images', $file, $relative, false, false);
+			$file = count($includes) ? $includes[0] : null;
 		}
-
-		$includes = self::includeRelativeFiles('images', $file, $relative, false, false);
-
 		// If only path is required
-		if ($path_only)
-		{
-			if (count($includes))
-			{
-				return $includes[0];
-			}
-			else
-			{
-				return null;
-			}
+		if ($path_rel) {
+			return $file;
 		}
 		else
 		{
-			return '<img src="' . (count($includes) ? $includes[0] : '') . '" alt="' . $alt . '" ' . $attribs . ' />';
+			return	'<img src="' . $file . '" alt="' . $alt . '" ' .
+				(is_array($attribs)?JArrayHelper::toString($attribs):$attribs) .
+				' />';
 		}
 	}
 

--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -526,11 +526,11 @@ abstract class JHtml
 	/**
 	 * Write a <img></img> element
 	 *
-	 * @param   string	$file		The relative or absolute URL to use for the src attribute
-	 * @param   string	$alt		The alt text.
-	 * @param   mixed	$attribs	String or associative array of attribute(s) to use
-	 * @param   boolean	$relative	path to file is relative to /media folder (and searches in template)
-	 * @param   mixed	$path_rel	Return html tag without (-1) or with file computing(false). Return computed path only (true) 
+	 * @param   string   $file     The relative or absolute URL to use for the src attribute
+	 * @param   string   $alt      The alt text.
+	 * @param   mixed    $attribs  String or associative array of attribute(s) to use
+	 * @param   boolean  $relative Path to file is relative to /media folder (and searches in template)
+	 * @param   mixed    $path_rel Return html tag without (-1) or with file computing(false). Return computed path only (true) 
 	 *
 	 * @return  string
 	 *
@@ -538,12 +538,14 @@ abstract class JHtml
 	 */
 	public static function image($file, $alt, $attribs = null, $relative = false, $path_rel = false)
 	{
-		if ($path_rel!==-1) {
+		if ($path_rel !== -1)
+		{
 			$includes = self::includeRelativeFiles('images', $file, $relative, false, false);
 			$file = count($includes) ? $includes[0] : null;
 		}
 		// If only path is required
-		if ($path_rel) {
+		if ($path_rel)
+		{
 			return $file;
 		}
 		else

--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -551,7 +551,7 @@ abstract class JHtml
 		else
 		{
 			return	'<img src="' . $file . '" alt="' . $alt . '" ' .
-				(is_array($attribs)?JArrayHelper::toString($attribs):$attribs) .
+				(is_array($attribs) ? JArrayHelper::toString($attribs) : $attribs) .
 				' />';
 		}
 	}

--- a/libraries/joomla/html/html.php
+++ b/libraries/joomla/html/html.php
@@ -526,11 +526,11 @@ abstract class JHtml
 	/**
 	 * Write a <img></img> element
 	 *
-	 * @param   string   $file     The relative or absolute URL to use for the src attribute
-	 * @param   string   $alt      The alt text.
-	 * @param   mixed    $attribs  String or associative array of attribute(s) to use
-	 * @param   boolean  $relative Path to file is relative to /media folder (and searches in template)
-	 * @param   mixed    $path_rel Return html tag without (-1) or with file computing(false). Return computed path only (true) 
+	 * @param   string   $file      The relative or absolute URL to use for the src attribute
+	 * @param   string   $alt       The alt text.
+	 * @param   mixed    $attribs   String or associative array of attribute(s) to use
+	 * @param   boolean  $relative  Path to file is relative to /media folder (and searches in template)
+	 * @param   mixed    $path_rel  Return html tag without (-1) or with file computing(false). Return computed path only (true) 
 	 *
 	 * @return  string
 	 *


### PR DESCRIPTION
Did several things here:
- Fixed the wrong statements about the function's parameter's in the comments
- Uses ternary operator for pathonly return (wee bit less and better(?) code)
- Allow faster result if you just want the tag without looking for possible alternatives 
  -> by re-using path_only since it does not make sense asking only the path without computing
- We don't want to check the attribs if path_only is required, hence putting it in the bottom if; and made ternary operation of it
- reuse $file, 2 (potential) reasons: 1. wee bit less of code (why not?) 2. You can use this function as check for $file and changing the variable itself to the right path (if it was right or not). That way the user of the function will have a variable less (why not?)
