### PR TITLE
Deprecate application loading in JFactory::getApplication()

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -17,7 +17,7 @@ defined('JPATH_PLATFORM') or die;
 abstract class JFactory
 {
 	/**
-	 * @var    JApplication
+	 * @var    JApplicationBase
 	 * @since  11.1
 	 */
 	public static $application = null;
@@ -80,15 +80,15 @@ abstract class JFactory
 	/**
 	 * Get a application object.
 	 *
-	 * Returns the global {@link JApplication} object, only creating it if it doesn't already exist.
+	 * Returns the global {@link JApplicationBase} object, only creating it if it doesn't already exist.
 	 *
 	 * @param   mixed   $id      A client identifier or name.
 	 * @param   array   $config  An optional associative array of configuration settings.
 	 * @param   string  $prefix  Application prefix
 	 *
-	 * @return  JApplication object
+	 * @return  JApplicationBase object
 	 *
-	 * @see     JApplication
+	 * @see     JApplicationBase
 	 * @since   11.1
 	 * @throws  Exception
 	 */
@@ -96,12 +96,32 @@ abstract class JFactory
 	{
 		if (!self::$application)
 		{
+			/*
+			 * @deprecated  13.3 - JFactory::getApplication() will no longer attempt to retrieve an instance of JApplication if self::$application is not set.
+			 *                     Instead, an Exception will be thrown if the object is not set.
+			 */
+			JLog::add(
+				sprintf(
+					'Using %s to instantiate applications is deprecated.  JApplicationBase classes should register directly to JFactory::$application.',
+					__METHOD__
+				),
+				JLog::WARNING,
+				'deprecated'
+			);
+
 			if (!$id)
 			{
 				throw new Exception('Application Instantiation Error', 500);
 			}
 
-			self::$application = JApplication::getInstance($id, $config, $prefix);
+			if (class_exists('JApplication'))
+			{
+				self::$application = JApplication::getInstance($id, $config, $prefix);
+			}
+			else
+			{
+				throw new Exception('JApplication not loaded, unable to load JApplication instance', 500);
+			}
 		}
 
 		return self::$application;


### PR DESCRIPTION
JFactory::getApplication() is heavily tied in to working with the legacy JApplication class, making it nearly impossible to properly refactor the method to work with the newer JApplicationBase classes.  Since JFactory::getApplication() is heavily used to retrieve the application object, instead of deprecating and removing the method completely, instead I propose to deprecate its code to handle instantiating an application instance, in this case, JApplication.  In 13.3 when JApplication is removed from the legacy tree, the method will be converted to throwing an Exception if the application object in JFactory is not set by applications.  This allows this heavily used API to continue to be used to globally retrieve the application object.

As well, I've added a check to ensure that JApplication is present if getApplication() is actually loading an instance.  Since it is in the legacy tree, there is the chance it is not present.  An Exception is thrown in this instance.
