### PR TITLE
Use 'load_language' property as a flag to load the language files 

### DIFF
--- a/libraries/joomla/plugin/plugin.php
+++ b/libraries/joomla/plugin/plugin.php
@@ -48,7 +48,7 @@ abstract class JPlugin extends JEvent
 	 * @var    boolean
 	 * @since  12.3
 	 */
-	protected $load_language = false;
+	protected $loadLanguage = false;
 
 	/**
 	 * Constructor
@@ -89,7 +89,7 @@ abstract class JPlugin extends JEvent
 		}
 
 		// Load the language files if needed.
-		if ($this->load_language)
+		if ($this->loadLanguage)
 		{
 			$this->loadLanguage();
 		}

--- a/libraries/joomla/plugin/plugin.php
+++ b/libraries/joomla/plugin/plugin.php
@@ -48,7 +48,7 @@ abstract class JPlugin extends JEvent
 	 * @var    boolean
 	 * @since  12.3
 	 */
-	protected $loadLanguage = false;
+	protected $autoloadLanguage = false;
 
 	/**
 	 * Constructor
@@ -89,7 +89,7 @@ abstract class JPlugin extends JEvent
 		}
 
 		// Load the language files if needed.
-		if ($this->loadLanguage)
+		if ($this->autoloadLanguage)
 		{
 			$this->loadLanguage();
 		}

--- a/libraries/joomla/plugin/plugin.php
+++ b/libraries/joomla/plugin/plugin.php
@@ -43,6 +43,14 @@ abstract class JPlugin extends JEvent
 	protected $_type = null;
 
 	/**
+	 * Affects constructor behavior. If true, language files will be loaded automatically.
+	 *
+	 * @var    boolean
+	 * @since  12.3
+	 */
+	protected $load_language = false;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   object  &$subject  The object to observe
@@ -78,6 +86,12 @@ abstract class JPlugin extends JEvent
 		if (isset($config['type']))
 		{
 			$this->_type = $config['type'];
+		}
+
+		// Load the language files if needed.
+		if ($this->load_language)
+		{
+			$this->loadLanguage();
 		}
 
 		parent::__construct($subject);


### PR DESCRIPTION
So that the constructor doesn't need to be overridden for this purpose.

It seems that almost all plugins override the constructor just to load language files. Now you will be able to simply set a property to true and they will be loaded automatically. 
