### PR TITLE
Fix and expand JDatabaseQuery tests.

### DIFF
--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -1258,7 +1258,7 @@ abstract class JDatabaseQuery
 			throw new RuntimeException('JLIB_DATABASE_ERROR_INVALID_DB_OBJECT');
 		}
 
-		return $this->db->quote(($escape ? $this->db->escape($text) : $text));
+		return $this->db->quote($text, $escape);
 	}
 
 	/**

--- a/tests/suites/unit/joomla/database/database/JDatabasePostgresqlQueryTest.php
+++ b/tests/suites/unit/joomla/database/database/JDatabasePostgresqlQueryTest.php
@@ -33,7 +33,7 @@ class JDatabasePostgresqlQueryTest extends TestCase
 	{
 		return array(
 			// Quoted, expected
-			array(true, "'1970-01-01 00:00:00'"),
+			array(true, "'_1970-01-01 00:00:00_'"),
 			array(false, "1970-01-01 00:00:00"),
 		);
 	}


### PR DESCRIPTION
Fixed mocking of the quote method in TestMockDatabaseDriver to allow for
an array of strings to be quoted.
Fixed a bug in JDatabaseQuery->quote that escaped strings before sending
them to the JDatabaseDriver->quote method ($escape argument was not
being honoured).
Added the escape method to TestMockDatabaseDriver.
Added covers to and improved code coverage of the JDatabaseQuery class.
