### PR TITLE
Proposal: Add ability to auto-discover custom libraries

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -495,12 +495,14 @@ abstract class JLoader
 	 * @param   boolean  $enableNamespaces  True to enable PHP namespace based class autoloading.
 	 * @param   boolean  $enablePrefixes    True to enable prefix based class loading (needed to auto load the Joomla core).
 	 * @param   boolean  $enableClasses     True to enable class map based class loading (needed to auto load the Joomla core).
+	 * @param   boolean  $discoverLibs      True to enable auto-discovery for custom libs in the /libraries directory.
 	 *
 	 * @return  void
 	 *
 	 * @since   12.3
 	 */
-	public static function setup($caseStrategy = self::LOWER_CASE, $enableNamespaces = false, $enablePrefixes = true, $enableClasses = true)
+	public static function setup($caseStrategy = self::LOWER_CASE, $enableNamespaces = false, $enablePrefixes = true, $enableClasses = true,
+		$discoverLibs = true)
 	{
 		if ($enableClasses)
 		{
@@ -540,6 +542,28 @@ abstract class JLoader
 				default:
 					spl_autoload_register(array('JLoader', 'loadByNamespaceLowerCase'));
 					break;
+			}
+		}
+
+		if ($discoverLibs)
+		{
+			$iterator = new DirectoryIterator(JPATH_PLATFORM);
+
+			foreach ($iterator as $fileinfo)
+			{
+				// If we find a folder, see if there is a setup.php file.
+				if ($fileinfo->getType() === 'dir')
+				{
+					$it = new DirectoryIterator($fileinfo->getPathname());
+
+					foreach ($it as $finfo)
+					{
+						if ($finfo->getFilename() === 'setup.php')
+						{
+							include $finfo->getPathname();
+						}
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
See discussion here: https://groups.google.com/forum/?fromgroups=#!topic/joomla-dev-platform/cl_73WKCkgk

See this gist: https://gist.github.com/4208509

I propose adding the ability to auto-discover custom libraries found in the /libraries directory. Libraries can be auto-discovered by including a `setup.php` file in the root of the library folder. If you wanted to add the SwiftMailer library, you could place a `swift` folder containing the library in your /libraries folder. The `/libraries/swift` folder would contain a `setup.php` file in it which, when found, would be included and executed.

We could also set a standard as to the basic structure of the `setup.php` file, but that's beyond the scope of this PR.
