### PR TITLE
Added JDataMapper class

### DIFF
--- a/libraries/joomla/data/mapper.php
+++ b/libraries/joomla/data/mapper.php
@@ -57,6 +57,7 @@ abstract class JDataMapper
 			else
 			{
 				$objects->rewind();
+
 				return $objects->current();
 			}
 		}
@@ -108,12 +109,14 @@ abstract class JDataMapper
 			if ($limit > 0 && count($objects) > $limit)
 			{
 				$count = 1;
+
 				foreach ($objects as $k => $v)
 				{
 					if ($count > $limit)
 					{
 						unset($objects[$k]);
 					}
+
 					$count += 1;
 				}
 			}
@@ -127,8 +130,8 @@ abstract class JDataMapper
 	/**
 	 * Finds a single object based on arbitrary criteria.
 	 *
-	 * @param   mixed    $where  The criteria by which to search the data source.
-	 * @param   mixed    $sort   The sorting to apply to the search.
+	 * @param   mixed  $where  The criteria by which to search the data source.
+	 * @param   mixed  $sort   The sorting to apply to the search.
 	 *
 	 * @return  JData  An object matching the search criteria, or null if none found.
 	 *
@@ -177,6 +180,7 @@ abstract class JDataMapper
 			else
 			{
 				$objects->rewind();
+
 				return $objects->current();
 			}
 		}

--- a/libraries/joomla/data/mapper.php
+++ b/libraries/joomla/data/mapper.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Mapper
+ *
+ * @copyright   Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Data source mapper class.
+ *
+ * This class is used to provide a layer between data objects and their datasource.
+ *
+ * An <em>initialise</em> method may be implemented to perform custom setup.
+ *
+ * @package     Joomla.Platform
+ * @subpackage  Mapper
+ * @since       12.3
+ */
+abstract class JDataMapper
+{
+	/**
+	 * The class constructor.
+	 *
+	 * @since   12.3
+	 */
+	public function __construct()
+	{
+		// Do the customisable initialisation.
+		$this->initialise();
+	}
+
+	/**
+	 * Creates a new object or list of objects in the data store.
+	 *
+	 * @param   JDataDumpable  $input  An object or an array of objects for the mapper to create in the data store.
+	 *
+	 * @return  mixed  The JData or JDataSet object that was created.
+	 *
+	 * @since   12.3
+	 * @throws  UnexpectedValueException if doCreate does not return an array.
+	 */
+	public function create(JDataDumpable $input)
+	{
+		$dump = $input->dump();
+		$objects = $this->doCreate(is_array($dump) ? $dump : array($dump));
+
+		if ($objects instanceof JDataSet)
+		{
+			if (is_array($dump))
+			{
+				return $objects;
+			}
+			else
+			{
+				$objects->rewind();
+				return $objects->current();
+			}
+		}
+
+		throw new UnexpectedValueException(sprintf('%s::update()->doUpdate() returned %s', get_class($this), gettype($input)));
+	}
+
+	/**
+	 * Deletes an object or a list of objects from the data store.
+	 *
+	 * @param   mixed  $input  An object identifier or an array of object identifier.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.3
+	 * @throws  UnexpectedValueException if doDelete returned something other than an object or an array.
+	 */
+	public function delete($input)
+	{
+		if (!is_array($input))
+		{
+			$input = array($input);
+		}
+
+		$this->doDelete($input);
+	}
+
+	/**
+	 * Finds a list of objects based on arbitrary criteria.
+	 *
+	 * @param   mixed    $where   The criteria by which to search the data source.
+	 * @param   mixed    $sort    The sorting to apply to the search.
+	 * @param   integer  $offset  The pagination offset for the result set.
+	 * @param   integer  $limit   The number of results to return (zero for all).
+	 *
+	 * @return  JDataSet  An array of objects matching the search criteria and pagination settings.
+	 *
+	 * @since   12.3
+	 * @throws  UnexpectedValueException if JDataMapper->doFind does not return a JDataSet.
+	 */
+	public function find($where = null, $sort = null, $offset = 0, $limit = 0)
+	{
+		// Find the appropriate results based on the critera.
+		$objects = $this->doFind($where, $sort, $offset, $limit);
+
+		if ($objects instanceof JDataSet)
+		{
+			// The doFind method should honour the limit, but let's check just in case.
+			if ($limit > 0 && count($objects) > $limit)
+			{
+				$count = 1;
+				foreach ($objects as $k => $v)
+				{
+					if ($count > $limit)
+					{
+						unset($objects[$k]);
+					}
+					$count += 1;
+				}
+			}
+
+			return $objects;
+		}
+
+		throw new UnexpectedValueException(sprintf('%s->doFind cannot return a %s', __METHOD__, gettype($objects)));
+	}
+
+	/**
+	 * Finds a single object based on arbitrary criteria.
+	 *
+	 * @param   mixed    $where  The criteria by which to search the data source.
+	 * @param   mixed    $sort   The sorting to apply to the search.
+	 *
+	 * @return  JData  An object matching the search criteria, or null if none found.
+	 *
+	 * @since   12.3
+	 * @throws  UnexpectedValueException if JDataMapper->doFind (via JDataMapper->find) does not return a JDataSet.
+	 */
+	public function findOne($where = null, $sort = null)
+	{
+		// Find the appropriate results based on the critera.
+		$objects = $this->find($where, $sort, 0, 1);
+
+		// Check the results (empty doesn't work on JDataSet).
+		if (count($objects) == 0)
+		{
+			// Should we throw an exception?
+			return null;
+		}
+
+		// Load the object from the first element of the array (emulates array_shift on an ArrayAccess object).
+		$objects->rewind();
+
+		return $objects->current();
+	}
+
+	/**
+	 * Updates an object or a list of objects in the data store.
+	 *
+	 * @param   mixed  $input  An object or a list of objects to update.
+	 *
+	 * @return  mixed  The object or object list updated.
+	 *
+	 * @since   12.3
+	 * @throws  UnexpectedValueException if doUpdate returned something unexpected.
+	 */
+	public function update(JDataDumpable $input)
+	{
+		$dump = $input->dump();
+		$objects = $this->doUpdate(is_array($dump) ? $dump : array($dump));
+
+		if ($objects instanceof JDataSet)
+		{
+			if (is_array($dump))
+			{
+				return $objects;
+			}
+			else
+			{
+				$objects->rewind();
+				return $objects->current();
+			}
+		}
+
+		throw new UnexpectedValueException(sprintf('%s::update()->doUpdate() returned %s', get_class($this), gettype($objects)));
+	}
+
+	/**
+	 * Customisable method to create an object or list of objects in the data store.
+	 *
+	 * @param   mixed  $input  An array of dumped objects.
+	 *
+	 * @return  array  The array JData objects that were created, keyed on the unique identifier.
+	 *
+	 * @since   12.3
+	 * @throws  RuntimeException if there was a problem with the data source.
+	 */
+	abstract protected function doCreate(array $input);
+
+	/**
+	 * Customisable method to delete a list of objects from the data store.
+	 *
+	 * @param   mixed  $input  An array of unique object identifiers.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.3
+	 * @throws  RuntimeException
+	 */
+	abstract protected function doDelete(array $input);
+
+	/**
+	 * Customisable method to find the primary identifiers for a list of objects from the data store based on an
+	 * associative array of key/value pair criteria.
+	 *
+	 * @param   mixed    $where   The criteria by which to search the data source.
+	 * @param   mixed    $sort    The sorting to apply to the search.
+	 * @param   integer  $offset  The pagination offset for the result set.
+	 * @param   integer  $limit   The number of results to return (zero for all).
+	 *
+	 * @return  JDataSet  The set of data that matches the criteria.
+	 *
+	 * @since   12.3
+	 * @throws  RuntimeException
+	 */
+	abstract protected function doFind($where = null, $sort = null, $offset = 0, $limit = 0);
+
+	/**
+	 * Customisable method to update an object or list of objects in the data store.
+	 *
+	 * @param   mixed  $input  An array of dumped objects.
+	 *
+	 * @return  array  The array of JData objects that were updated, keyed on the unique identifier.
+	 *
+	 * @since   12.3
+	 * @throws  RuntimeException
+	 */
+	abstract protected function doUpdate(array $input);
+
+	/**
+	 * Customisable initialise method for extended classes to use.
+	 *
+	 * This method is called last in the JDataMapper constructor.
+	 *
+	 * @return  void
+	 *
+	 * @codeCoverageIgnore
+	 * @since   12.3
+	 */
+	protected function initialise()
+	{
+	}
+}

--- a/tests/suites/unit/joomla/data/mapperTest.php
+++ b/tests/suites/unit/joomla/data/mapperTest.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Data
+ *
+ * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+JLoader::register('Landsat', __DIR__ . '/stubs/landsat.php');
+JLoader::register('Landsat6', __DIR__ . '/stubs/landsat6.php');
+
+/**
+ * Tests for the JContentHelperTest class.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Data
+ * @since       12.3
+ */
+class JDataMapperTest extends TestCase
+{
+	/**
+	 * @var    JDataMapper
+	 * @since  12.3
+	 */
+	protected $_instance;
+
+	/**
+	 * Tests the __construct method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JDataMapper::__construct
+	 * @since   12.3
+	 */
+	public function test__construct()
+	{
+		$initData = TestReflection::getValue($this->_instance, 'data');
+		$this->assertEquals(5, count($initData), 'Check initialise was called.');
+	}
+
+	/**
+	 * Tests the create method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JDataMapper::create
+	 * @since   12.3
+	 */
+	public function testCreate()
+	{
+		$input = new JData(array('fail' => false));
+
+		$this->assertThat(
+			$this->_instance->create($input),
+			$this->equalTo($input),
+			'Checks the return value.'
+		);
+	}
+
+	/**
+	 * Tests the create method for an expected exception.
+	 *
+	 * @return  void
+	 *
+	 * @covers            JDataMapper::create
+	 * @since             12.3
+	 * @expectedException UnexpectedValueException
+	 */
+	public function testCreate_exception1()
+	{
+		$instance = new Landsat6;
+		$instance->create(new JData);
+	}
+
+	/**
+	 * Tests the delete method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JDataMapper::delete
+	 * @since   12.3
+	 */
+	public function testDelete()
+	{
+		$this->_instance->delete(1);
+
+		$this->assertEquals(array(1), $this->_instance->deleted);
+	}
+
+	/**
+	 * Tests the find method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JDataMapper::find
+	 * @since   12.3
+	 */
+	public function testFind()
+	{
+		$this->assertEquals(3, count($this->_instance->find(null)), 'Check find all.');
+		$this->assertEquals(2, count($this->_instance->find(null, null, 0, 2)), 'Check find with a limit.');
+	}
+
+	/**
+	 * Tests the find method for an expected exception.
+	 *
+	 * @return  void
+	 *
+	 * @covers             JDataMapper::find
+	 * @since              12.3
+	 * @expectedException  UnexpectedValueException
+	 */
+	public function testFind_exception()
+	{
+		$instance = new Landsat6;
+		$instance->find(null);
+	}
+
+	/**
+	 * Tests the findOne method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JDataMapper::findOne
+	 * @since   12.3
+	 */
+	public function testFindOne()
+	{
+		$findOne = $this->_instance->findOne(null);
+		$this->assertInstanceOf('JData', $findOne);
+		$this->assertEquals('Landsat 1', $findOne->name);
+		$this->assertNull($this->_instance->findOne(6), 'Check findOne where no results are returned.');
+	}
+
+	/**
+	 * Tests the Update method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JDataMapper::update
+	 * @since   12.3
+	 */
+	public function testUpdate()
+	{
+		$input = new JData(array('id' => 1, 'name' => 'Landsat 1A'));
+
+		$updated = $this->_instance->update($input);
+		$this->assertInstanceOf('JData', $updated, 'Checks the return value is a JData.');
+		$this->assertTrue($updated->updated);
+
+		$input = new JDataSet(
+			array(
+				new JData(array('id' => 1, 'updated' => false)),
+				new JData(array('id' => 2, 'updated' => false))
+			)
+		);
+
+		$updated = $this->_instance->update($input);
+		$this->assertInstanceOf('JDataSet', $updated, 'Checks the return value is a JDataSet.');
+		$this->assertCount(2, $updated);
+	}
+
+	/**
+	 * Tests the update method for an expected exception.
+	 *
+	 * @return  void
+	 *
+	 * @covers            JDataMapper::update
+	 * @since             12.3
+	 * @expectedException UnexpectedValueException
+	 */
+	public function testUpdate_exception1()
+	{
+		$instance = new Landsat6;
+		$instance->update(new JData);
+	}
+
+	/**
+	 * Setup the tests.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.4
+	 */
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->_instance = new Landsat;
+	}
+}

--- a/tests/suites/unit/joomla/data/stubs/landsat.php
+++ b/tests/suites/unit/joomla/data/stubs/landsat.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Data
+ *
+ * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Derived mapper class for testing purposes (cannot test DataMapper directly because it is abstract).
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Data
+ * @since       12.3
+ */
+class Landsat extends JDataMapper
+{
+	/**
+	 * Place holder for doDelete testing.
+	 *
+	 * @var    mixed
+	 * @since  12.3
+	 */
+	public $deleted;
+
+	/**
+	 * Dummy data for the mapper to use.
+	 *
+	 * @var    array
+	 * @since  12.3
+	 */
+	protected $data = array();
+
+	/**
+	 * Customisable method to create an object or list of objects in the data store.
+	 *
+	 * @param   mixed  $input  An object or list of objects.
+	 *
+	 * @return  mixed  The JData or JDataSet created.
+	 *
+	 * @since   12.3
+	 */
+	protected function doCreate(array $input)
+	{
+		// Create $input.
+		$result = new JDataSet;
+
+		foreach ($input as $k => $object)
+		{
+			$result[$k] = new JData($object);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Customisable method to delete an object or list of objects from the data store.
+	 *
+	 * @param   mixed  $input  An object, a list of objects, an object id or a list of object id's.
+	 *
+	 * @return  mixed  The object or object list deleted.
+	 *
+	 * @since   12.3
+	 */
+	protected function doDelete(array $input)
+	{
+		$this->deleted = $input;
+	}
+
+	/**
+	 * Customisable method to find the primary identifiers for a list of objects from the data store based on an
+	 * associative array of key/value pair criteria.
+	 *
+	 * @param   mixed    $where   The criteria by which to search the data source.
+	 * @param   mixed    $sort    The sorting to apply to the search.
+	 * @param   integer  $offset  The pagination offset for the result set.
+	 * @param   integer  $limit   The number of results to return (zero for all).
+	 *
+	 * @return  JDataSet  An array of objects matching the search criteria and pagination settings.
+	 *
+	 * @since   12.3
+	 */
+	protected function doFind($where = null, $sort = null, $offset = 0, $limit = 0)
+	{
+		if ($where == 6)
+		{
+			return new JDataSet;
+		}
+		else
+		{
+			$found = new JDataSet;
+			$found[1] = $this->data[1];
+			$found[2] = $this->data[2];
+			$found[3] = $this->data[3];
+
+			return $found;
+		}
+	}
+
+	/**
+	 * Customisable method to update an object or list of objects in the data store.
+	 *
+	 * @param   mixed  $input  An object or list of objects.
+	 *
+	 * @return  mixed  The modified JData object or JDataSet.
+	 *
+	 * @since   12.3
+	 */
+	protected function doUpdate(array $input)
+	{
+		// Update $input.
+		$result = new JDataSet;
+
+		foreach ($input as $k => $object)
+		{
+			$object->updated = true;
+			$result[$k] = new JData($object);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Method to inialise the object.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.3
+	 */
+	protected function initialise()
+	{
+		$this->data = array(
+			'1' => new JData(array('id' => 1, 'name' => 'Landsat 1', 'launch' => '1972-07-23')),
+			'2' => new JData(array('id' => 2, 'name' => 'Landsat 2', 'launch' => '1975-01-22')),
+			'3' => new JData(array('id' => 3, 'name' => 'Landsat 3', 'launch' => '1978-03-05')),
+			'4' => new JData(array('id' => 4, 'name' => 'Landsat 4', 'launch' => '1982-07-16')),
+			'5' => new JData(array('id' => 5, 'name' => 'Landsat 5', 'launch' => '1984-03-01')),
+		);
+	}
+}

--- a/tests/suites/unit/joomla/data/stubs/landsat6.php
+++ b/tests/suites/unit/joomla/data/stubs/landsat6.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Data
+ *
+ * @copyright   Copyright (C) 2005 - 2011 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Landsat 6 was launched on 5 October 1993 but failed to make orbit.
+ * This class is used to test some exception handling.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Data
+ * @since       12.3
+ */
+class Landsat6 extends JDataMapper
+{
+	/**
+	 * Customisable method to create an object or list of objects in the data store.
+	 *
+	 * @param   mixed  $input  An object or list of objects.
+	 *
+	 * @return  mixed  The object or object list created.
+	 *
+	 * @since   12.3
+	 */
+	protected function doCreate(array $input)
+	{
+		return false;
+	}
+
+	/**
+	 * Customisable method to delete an object or list of objects from the data store.
+	 *
+	 * @param   mixed  $input  An object, a list of objects, an object id or a list of object id's.
+	 *
+	 * @return  mixed  The object or object list deleted.
+	 *
+	 * @since   12.3
+	 */
+	protected function doDelete(array $input)
+	{
+		return false;
+	}
+
+	/**
+	 * Customisable method to find the primary identifiers for a list of objects from the data store based on an
+	 * associative array of key/value pair criteria.
+	 *
+	 * @param   mixed    $where   The criteria by which to search the data source.
+	 * @param   mixed    $sort    The sorting to apply to the search.
+	 * @param   integer  $offset  The pagination offset for the result set.
+	 * @param   integer  $limit   The number of results to return (zero for all).
+	 *
+	 * @return  JDataSet  An array of objects matching the search criteria and pagination settings.
+	 *
+	 * @since   12.3
+	 */
+	protected function doFind($where = null, $sort = null, $offset = 0, $limit = 0)
+	{
+		return false;
+	}
+
+	/**
+	 * Customisable method to update an object or list of objects in the data store.
+	 *
+	 * @param   mixed  $input  An object or list of objects.
+	 *
+	 * @return  mixed  The modified object or list of objects.
+	 *
+	 * @since   12.3
+	 * @throws  RuntimeException
+	 */
+	protected function doUpdate(array $input)
+	{
+		return false;
+	}
+}


### PR DESCRIPTION
This pull request adds a new class to the Data package called `JDataMapper`. The idea is that this sits in between data objects, like JData or even JDataSet, and the data source (which could be a database, could be a caching layer, etc).

The documentation for the class can be found here:

https://github.com/eBaySF/joomla-platform/blob/data-package/docs/manual/en-US/chapters/packages/data.md#jdatamapper

For those familiar with eBay's UCM implementation, the mapper will replace the JDatabaseObject class and the mapper is obviously pivotal in moving forward with UCM (at least for the architecture that eBay has been using).  You can see hints of UCM fundamentals in the JDatabaseTableMapper example in the documentation where it is filtering out unknown table columns in doCreate and doUpdate.
