### PR TITLE
fixing tested for windows system

### DIFF
--- a/tests/suites/unit/joomla/application/JApplicationWebTest.php
+++ b/tests/suites/unit/joomla/application/JApplicationWebTest.php
@@ -471,6 +471,14 @@ class JApplicationWebTest extends TestCase
 	 */
 	public function testCompressWithNoAcceptEncodings()
 	{
+		$string = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+					eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+					veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+					consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+					dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+					sunt in culpa qui officia deserunt mollit anim id est laborum.';
+
+		//replace \r\n -> \n to ensure same length on all platforms
 		// Fill the header body with a value.
 		TestReflection::setValue(
 			$this->class,
@@ -478,12 +486,7 @@ class JApplicationWebTest extends TestCase
 			(object) array(
 				'cachable' => null,
 				'headers' => null,
-				'body' => array('Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-					eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-					veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-					consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
-					dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-					sunt in culpa qui officia deserunt mollit anim id est laborum.'),
+				'body' => array(str_replace("\r\n","\n",$string)),
 			)
 		);
 
@@ -522,6 +525,14 @@ class JApplicationWebTest extends TestCase
 	 */
 	public function testCompressWithHeadersSent()
 	{
+		$string = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+					eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+					veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+					consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+					dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+					sunt in culpa qui officia deserunt mollit anim id est laborum.';
+
+		//replace \r\n -> \n to ensure same length on all platforms
 		// Fill the header body with a value.
 		TestReflection::setValue(
 			$this->class,
@@ -529,12 +540,7 @@ class JApplicationWebTest extends TestCase
 			(object) array(
 				'cachable' => null,
 				'headers' => null,
-				'body' => array('Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-					eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-					veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-					consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
-					dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-					sunt in culpa qui officia deserunt mollit anim id est laborum.'),
+				'body' => array(str_replace("\r\n","\n",$string)),
 			)
 		);
 
@@ -579,6 +585,14 @@ class JApplicationWebTest extends TestCase
 	 */
 	public function testCompressWithUnsupportedEncodings()
 	{
+		$string = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+					eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+					veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+					consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+					dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+					sunt in culpa qui officia deserunt mollit anim id est laborum.';
+
+		//replace \r\n -> \n to ensure same length on all platforms
 		// Fill the header body with a value.
 		TestReflection::setValue(
 			$this->class,
@@ -586,12 +600,7 @@ class JApplicationWebTest extends TestCase
 			(object) array(
 				'cachable' => null,
 				'headers' => null,
-				'body' => array('Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-					eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-					veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-					consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
-					dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-					sunt in culpa qui officia deserunt mollit anim id est laborum.'),
+				'body' => array(str_replace("\r\n","\n",$string)),
 			)
 		);
 

--- a/tests/suites/unit/joomla/application/JApplicationWebTest.php
+++ b/tests/suites/unit/joomla/application/JApplicationWebTest.php
@@ -478,7 +478,7 @@ class JApplicationWebTest extends TestCase
 					dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
 					sunt in culpa qui officia deserunt mollit anim id est laborum.';
 
-		//replace \r\n -> \n to ensure same length on all platforms
+		// Replace \r\n -> \n to ensure same length on all platforms
 		// Fill the header body with a value.
 		TestReflection::setValue(
 			$this->class,
@@ -532,7 +532,7 @@ class JApplicationWebTest extends TestCase
 					dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
 					sunt in culpa qui officia deserunt mollit anim id est laborum.';
 
-		//replace \r\n -> \n to ensure same length on all platforms
+		// Replace \r\n -> \n to ensure same length on all platforms
 		// Fill the header body with a value.
 		TestReflection::setValue(
 			$this->class,
@@ -592,7 +592,7 @@ class JApplicationWebTest extends TestCase
 					dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
 					sunt in culpa qui officia deserunt mollit anim id est laborum.';
 
-		//replace \r\n -> \n to ensure same length on all platforms
+		// Replace \r\n -> \n to ensure same length on all platforms
 		// Fill the header body with a value.
 		TestReflection::setValue(
 			$this->class,

--- a/tests/suites/unit/joomla/database/database/JDatabaseExporterMySqlTest.php
+++ b/tests/suites/unit/joomla/database/database/JDatabaseExporterMySqlTest.php
@@ -213,10 +213,7 @@ class JDatabaseExporterMySqlTest extends PHPUnit_Framework_TestCase
 			->from('jos_test')
 			->withStructure(true);
 
-		$this->assertThat(
-			(string) $instance,
-			$this->equalTo(
-				'<?xml version="1.0"?>
+		$expecting = '<?xml version="1.0"?>
 <mysqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <database name="">
   <table_structure name="#__test">
@@ -225,11 +222,15 @@ class JDatabaseExporterMySqlTest extends PHPUnit_Framework_TestCase
    <key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" Null="" Index_type="BTREE" Comment="" />
   </table_structure>
  </database>
-</mysqldump>'
+</mysqldump>';
+
+		$this->assertThat(
+			preg_replace('/\v/', '', (string) $instance),
+			$this->equalTo(
+				preg_replace('/\v/', '', $expecting)
 			),
 			'__toString has not returned the expected result.'
 		);
-
 	}
 
 	/**
@@ -275,10 +276,7 @@ class JDatabaseExporterMySqlTest extends PHPUnit_Framework_TestCase
 			->from('jos_test')
 			->withStructure(true);
 
-		$this->assertThat(
-			$instance->buildXml(),
-			$this->equalTo(
-				'<?xml version="1.0"?>
+		$expecting = '<?xml version="1.0"?>
 <mysqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <database name="">
   <table_structure name="#__test">
@@ -287,7 +285,12 @@ class JDatabaseExporterMySqlTest extends PHPUnit_Framework_TestCase
    <key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" Null="" Index_type="BTREE" Comment="" />
   </table_structure>
  </database>
-</mysqldump>'
+</mysqldump>';
+		//replace used to prevent platform conflicts
+		$this->assertThat(
+			preg_replace('/\v/', '', $instance->buildXml()),
+			$this->equalTo(
+				preg_replace('/\v/', '', $expecting)
 			),
 			'buildXml has not returned the expected result.'
 		);

--- a/tests/suites/unit/joomla/database/database/JDatabaseExporterMySqlTest.php
+++ b/tests/suites/unit/joomla/database/database/JDatabaseExporterMySqlTest.php
@@ -286,7 +286,7 @@ class JDatabaseExporterMySqlTest extends PHPUnit_Framework_TestCase
   </table_structure>
  </database>
 </mysqldump>';
-		//replace used to prevent platform conflicts
+		// Replace used to prevent platform conflicts
 		$this->assertThat(
 			preg_replace('/\v/', '', $instance->buildXml()),
 			$this->equalTo(

--- a/tests/suites/unit/joomla/database/database/JDatabaseExporterPostgresqlTest.php
+++ b/tests/suites/unit/joomla/database/database/JDatabaseExporterPostgresqlTest.php
@@ -275,15 +275,12 @@ class JDatabaseExporterPostgresqlTest extends PHPUnit_Framework_TestCase
 			$start_val = '1';
 		}
 
-		$this->assertThat(
-			(string) $instance,
-			$this->equalTo(
-'<?xml version="1.0"?>
+		$expecting = '<?xml version="1.0"?>
 <postgresqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <database name="">
   <table_structure name="#__test">
    <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
-	$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />
+			$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />
    <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />
    <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />
    <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />
@@ -291,11 +288,15 @@ class JDatabaseExporterPostgresqlTest extends PHPUnit_Framework_TestCase
    <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)" />
   </table_structure>
  </database>
-</postgresqldump>'
+</postgresqldump>';
+		//replace used to prevent platform conflicts
+		$this->assertThat(
+			preg_replace('/\v/', '', (string) $instance),
+			$this->equalTo(
+				preg_replace('/\v/', '', $expecting)
 			),
 			'__toString has not returned the expected result.'
 		);
-
 	}
 
 	/**
@@ -349,15 +350,12 @@ class JDatabaseExporterPostgresqlTest extends PHPUnit_Framework_TestCase
 			$start_val = '1';
 		}
 
-		$this->assertThat(
-			$instance->buildXml(),
-			$this->equalTo(
-'<?xml version="1.0"?>
+		$expecting = '<?xml version="1.0"?>
 <postgresqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <database name="">
   <table_structure name="#__test">
    <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
-	$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />
+			$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />
    <field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />
    <field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />
    <field Field="start_date" Type="timestamp without time zone" Null="NO" Default="NULL" Comments="" />
@@ -365,7 +363,12 @@ class JDatabaseExporterPostgresqlTest extends PHPUnit_Framework_TestCase
    <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)" />
   </table_structure>
  </database>
-</postgresqldump>'
+</postgresqldump>';
+		//replace used to prevent platform conflicts
+		$this->assertThat(
+			preg_replace('/\v/', '', $instance->buildXml()),
+			$this->equalTo(
+				preg_replace('/\v/', '', $expecting)
 			),
 			'buildXml has not returned the expected result.'
 		);

--- a/tests/suites/unit/joomla/database/database/JDatabaseExporterPostgresqlTest.php
+++ b/tests/suites/unit/joomla/database/database/JDatabaseExporterPostgresqlTest.php
@@ -289,7 +289,7 @@ class JDatabaseExporterPostgresqlTest extends PHPUnit_Framework_TestCase
   </table_structure>
  </database>
 </postgresqldump>';
-		//replace used to prevent platform conflicts
+		// Replace used to prevent platform conflicts
 		$this->assertThat(
 			preg_replace('/\v/', '', (string) $instance),
 			$this->equalTo(
@@ -364,7 +364,7 @@ class JDatabaseExporterPostgresqlTest extends PHPUnit_Framework_TestCase
   </table_structure>
  </database>
 </postgresqldump>';
-		//replace used to prevent platform conflicts
+		// Replace used to prevent platform conflicts
 		$this->assertThat(
 			preg_replace('/\v/', '', $instance->buildXml()),
 			$this->equalTo(

--- a/tests/suites/unit/joomla/document/opensearch/JDocumentOpensearchTest.php
+++ b/tests/suites/unit/joomla/document/opensearch/JDocumentOpensearchTest.php
@@ -79,7 +79,7 @@ class JDocumentOpensearchTest extends TestCase
 		$this->object->addUrl($item);
 		$this->object->addUrl($item2);
 
-		//replace used to prevent platform conflicts
+		// Replace used to prevent platform conflicts
 		$this->assertThat(
 			preg_replace('/\v/', '', $this->object->render()),
 			$this->equalTo('<?xml version="1.0" encoding="utf-8"?><OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"><ShortName>ShortName</ShortName><Description>Description</Description><InputEncoding>UTF-8</InputEncoding><Url type="application/opensearchdescription+xml" rel="self" template=""/><Url type="text/html" template="http://www.example.com"/><Url type="application/rss+xml" rel="suggestions" template="http://www.example.com?format=feed"/></OpenSearchDescription>')

--- a/tests/suites/unit/joomla/document/opensearch/JDocumentOpensearchTest.php
+++ b/tests/suites/unit/joomla/document/opensearch/JDocumentOpensearchTest.php
@@ -79,11 +79,10 @@ class JDocumentOpensearchTest extends TestCase
 		$this->object->addUrl($item);
 		$this->object->addUrl($item2);
 
+		//replace used to prevent platform conflicts
 		$this->assertThat(
-			$this->object->render(),
-			$this->equalTo('<?xml version="1.0" encoding="utf-8"?>
-<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"><ShortName>ShortName</ShortName><Description>Description</Description><InputEncoding>UTF-8</InputEncoding><Url type="application/opensearchdescription+xml" rel="self" template=""/><Url type="text/html" template="http://www.example.com"/><Url type="application/rss+xml" rel="suggestions" template="http://www.example.com?format=feed"/></OpenSearchDescription>
-')
+			preg_replace('/\v/', '', $this->object->render()),
+			$this->equalTo('<?xml version="1.0" encoding="utf-8"?><OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"><ShortName>ShortName</ShortName><Description>Description</Description><InputEncoding>UTF-8</InputEncoding><Url type="application/opensearchdescription+xml" rel="self" template=""/><Url type="text/html" template="http://www.example.com"/><Url type="application/rss+xml" rel="suggestions" template="http://www.example.com?format=feed"/></OpenSearchDescription>')
 		);
 
 	}

--- a/tests/suites/unit/joomla/filesystem/JFilesystemPatcherTest.php
+++ b/tests/suites/unit/joomla/filesystem/JFilesystemPatcherTest.php
@@ -122,28 +122,28 @@ class JFilesystemPatcherTest extends TestCase
 +Deeper and more profound,
 +The door of all subtleties!
 ';
-
+		// use of realpath to ensure test works for on all platforms
 		return array(
 			array(
 				$udiff,
-				JPATH_TESTS . '/tmp/patcher',
+				realpath(JPATH_TESTS . '/tmp/patcher'),
 				0,
 				array(
 					array(
 						'udiff' => $udiff,
-						'root' => JPATH_TESTS . '/tmp/patcher/',
+						'root' => realpath(JPATH_TESTS . '/tmp/patcher').DIRECTORY_SEPARATOR,
 						'strip' => 0
 					)
 				)
 			),
 			array(
 				$udiff,
-				JPATH_TESTS . '/tmp/patcher/',
+				realpath(JPATH_TESTS . '/tmp/patcher').DIRECTORY_SEPARATOR,
 				0,
 				array(
 					array(
 						'udiff' => $udiff,
-						'root' => JPATH_TESTS . '/tmp/patcher/',
+						'root' => realpath(JPATH_TESTS . '/tmp/patcher').DIRECTORY_SEPARATOR,
 						'strip' => 0
 					)
 				)
@@ -167,7 +167,7 @@ class JFilesystemPatcherTest extends TestCase
 				array(
 					array(
 						'udiff' => $udiff,
-						'root' => '/',
+						'root' => DIRECTORY_SEPARATOR,
 						'strip' => 0
 					)
 				)
@@ -232,14 +232,16 @@ class JFilesystemPatcherTest extends TestCase
 +Deeper and more profound,
 +The door of all subtleties!
 ';
+		// use of realpath to ensure test works for on all platforms
 		file_put_contents(JPATH_TESTS . '/tmp/patcher/lao2tzu.diff', $udiff);
 		$patcher = JFilesystemPatcher::getInstance()->reset();
-		$patcher->addFile(JPATH_TESTS . '/tmp/patcher/lao2tzu.diff', JPATH_TESTS . '/tmp/patcher');
+		$patcher->addFile(JPATH_TESTS . '/tmp/patcher/lao2tzu.diff', realpath(JPATH_TESTS . '/tmp/patcher'));
+
 		$this->assertAttributeEquals(
 			array(
 				array(
 					'udiff' => $udiff,
-					'root' => JPATH_TESTS . '/tmp/patcher/',
+					'root' => realpath(JPATH_TESTS . '/tmp/patcher').DIRECTORY_SEPARATOR,
 					'strip' => 0
 				)
 			),
@@ -947,9 +949,14 @@ But after they are produced,
 			}
 			else
 			{
+				//remove all vertical characters to ensure system independed compare
+				$content = preg_replace('/\v/', '', $content);
+				$data = file_get_contents($path);
+				$data = preg_replace('/\v/', '', $data);
+
 				$this->assertEquals(
 					$content,
-					file_get_contents($path),
+					$data,
 					'Line:' . __LINE__ . ' The patcher did not succeed in patching ' . $path
 				);
 			}

--- a/tests/suites/unit/joomla/filesystem/JFilesystemPatcherTest.php
+++ b/tests/suites/unit/joomla/filesystem/JFilesystemPatcherTest.php
@@ -949,7 +949,7 @@ But after they are produced,
 			}
 			else
 			{
-				//remove all vertical characters to ensure system independed compare
+				// Remove all vertical characters to ensure system independed compare
 				$content = preg_replace('/\v/', '', $content);
 				$data = file_get_contents($path);
 				$data = preg_replace('/\v/', '', $data);

--- a/tests/suites/unit/joomla/filesystem/JFolderTest.php
+++ b/tests/suites/unit/joomla/filesystem/JFolderTest.php
@@ -118,23 +118,29 @@ class JFolderTest extends TestCase
 		file_put_contents(JPath::clean(JPATH_TESTS . '/tmp/test/test/index.html'), 'test');
 		file_put_contents(JPath::clean(JPATH_TESTS . '/tmp/test/test/index.txt'), 'test');
 
-		$expected = array(
-			JPath::clean(JPATH_TESTS . '/tmp/test/index.txt'),
-			JPath::clean(JPATH_TESTS . '/tmp/test/test/index.txt')
-		);
-
+		// use of realpath to ensure test works for on all platforms
+		$result = JFolder::files(JPath::clean(JPATH_TESTS . '/tmp/test'), 'index.*', true, true, array('index.html'));
+		$result[0] = realpath($result[0]);
+		$result[1] = realpath($result[1]);
 		$this->assertEquals(
-			$expected,
-			JFolder::files(JPath::clean(JPATH_TESTS . '/tmp/test'), 'index.*', true, true, array('index.html')),
+			array(
+				JPath::clean(JPATH_TESTS . '/tmp/test/index.txt'),
+				JPath::clean(JPATH_TESTS . '/tmp/test/test/index.txt')
+			),
+			$result,
 			'Line: ' . __LINE__ . ' Should exclude index.html files'
 		);
 
+		// use of realpath to ensure test works for on all platforms
+		$result = JFolder::files(JPath::clean(JPATH_TESTS . '/tmp/test'), 'index.html', true, true);
+		$result[0] = realpath($result[0]);
+		$result[1] = realpath($result[1]);
 		$this->assertEquals(
 			array(
 				JPath::clean(JPATH_TESTS . '/tmp/test/index.html'),
 				JPath::clean(JPATH_TESTS . '/tmp/test/test/index.html')
 			),
-			JFolder::files(JPath::clean(JPATH_TESTS . '/tmp/test'), 'index.html', true, true),
+			$result,
 			'Line: ' . __LINE__ . ' Should include full path of both index.html files'
 		);
 
@@ -147,11 +153,14 @@ class JFolderTest extends TestCase
 			'Line: ' . __LINE__ . ' Should include only file names of both index.html files'
 		);
 
+		// use of realpath to ensure test works for on all platforms
+		$result = JFolder::files(JPath::clean(JPATH_TESTS . '/tmp/test'), 'index.html', false, true);
+		$result[0] = realpath($result[0]);
 		$this->assertEquals(
 			array(
 				JPath::clean(JPATH_TESTS . '/tmp/test/index.html')
 			),
-			JFolder::files(JPath::clean(JPATH_TESTS . '/tmp/test'), 'index.html', false, true),
+			$result,
 			'Line: ' . __LINE__ . ' Non-recursive should only return top folder file full path'
 		);
 
@@ -207,18 +216,32 @@ class JFolderTest extends TestCase
 			JFolder::folders(JPath::clean(JPATH_TESTS . '/tmp/test'), 'bar1', true, true, array('foo1', 'foo2'))
 		);
 
+		// use of realpath to ensure test works for on all platforms
+		$result = JFolder::folders(JPath::clean(JPATH_TESTS . '/tmp/test'), 'bar1', true, true, array('foo1'));
+		$result[0] = realpath($result[0]);
 		$this->assertEquals(
 			array(JPath::clean(JPATH_TESTS . '/tmp/test/foo2/bar1')),
-			JFolder::folders(JPath::clean(JPATH_TESTS . '/tmp/test'), 'bar1', true, true, array('foo1'))
+			$result
 		);
+
+		// use of realpath to ensure test works for on all platforms
+		$result = JFolder::folders(JPath::clean(JPATH_TESTS . '/tmp/test'), 'bar1', true, true);
+		$result[0] = realpath($result[0]);
+		$result[1] = realpath($result[1]);
 		$this->assertEquals(
 			array(
 				JPath::clean(JPATH_TESTS . '/tmp/test/foo1/bar1'),
 				JPath::clean(JPATH_TESTS . '/tmp/test/foo2/bar1'),
 			),
-			JFolder::folders(JPath::clean(JPATH_TESTS . '/tmp/test'), 'bar1', true, true)
+			$result
 		);
 
+		// use of realpath to ensure test works for on all platforms
+		$result = JFolder::folders(JPath::clean(JPATH_TESTS . '/tmp/test'), 'bar', true, true);
+		$result[0] = realpath($result[0]);
+		$result[1] = realpath($result[1]);
+		$result[2] = realpath($result[2]);
+		$result[3] = realpath($result[3]);
 		$this->assertEquals(
 			array(
 				JPath::clean(JPATH_TESTS . '/tmp/test/foo1/bar1'),
@@ -226,8 +249,17 @@ class JFolderTest extends TestCase
 				JPath::clean(JPATH_TESTS . '/tmp/test/foo2/bar1'),
 				JPath::clean(JPATH_TESTS . '/tmp/test/foo2/bar2'),
 			),
-			JFolder::folders(JPath::clean(JPATH_TESTS . '/tmp/test'), 'bar', true, true)
+			$result
 		);
+
+		// use of realpath to ensure test works for on all platforms
+		$result = JFolder::folders(JPath::clean(JPATH_TESTS . '/tmp/test'), '.', true, true);
+		$result[0] = realpath($result[0]);
+		$result[1] = realpath($result[1]);
+		$result[2] = realpath($result[2]);
+		$result[3] = realpath($result[3]);
+		$result[4] = realpath($result[4]);
+		$result[5] = realpath($result[5]);
 
 		$this->assertEquals(
 			array(
@@ -238,7 +270,7 @@ class JFolderTest extends TestCase
 				JPath::clean(JPATH_TESTS . '/tmp/test/foo2/bar1'),
 				JPath::clean(JPATH_TESTS . '/tmp/test/foo2/bar2'),
 			),
-			JFolder::folders(JPath::clean(JPATH_TESTS . '/tmp/test'), '.', true, true)
+			$result
 		);
 
 		$this->assertEquals(
@@ -253,12 +285,17 @@ class JFolderTest extends TestCase
 			JFolder::folders(JPath::clean(JPATH_TESTS . '/tmp/test'), '.', true, false)
 		);
 
+		// use of realpath to ensure test works for on all platforms
+		$result = JFolder::folders(JPath::clean(JPATH_TESTS . '/tmp/test'), '.', false, true);
+		$result[0] = realpath($result[0]);
+		$result[1] = realpath($result[1]);
+
 		$this->assertEquals(
 			array(
 				JPath::clean(JPATH_TESTS . '/tmp/test/foo1'),
 				JPath::clean(JPATH_TESTS . '/tmp/test/foo2'),
 			),
-			JFolder::folders(JPath::clean(JPATH_TESTS . '/tmp/test'), '.', false, true)
+			$result
 		);
 
 		$this->assertEquals(

--- a/tests/suites/unit/joomla/form/JFormTest.php
+++ b/tests/suites/unit/joomla/form/JFormTest.php
@@ -70,7 +70,8 @@ class JFormTest extends TestCase
 		$paths = JForm::addFieldPath();
 
 		// The default path is the class file folder/forms
-		$valid = JPATH_PLATFORM . '/joomla/form/fields';
+		// use of realpath to ensure test works for on all platforms
+		$valid = realpath(JPATH_PLATFORM . '/joomla/form') . '/fields';
 
 		$this->assertThat(
 			in_array($valid, $paths),
@@ -102,7 +103,8 @@ class JFormTest extends TestCase
 		$paths = JForm::addFormPath();
 
 		// The default path is the class file folder/forms
-		$valid = JPATH_PLATFORM . '/joomla/form/forms';
+		// use of realpath to ensure test works for on all platforms
+		$valid = realpath(JPATH_PLATFORM . '/joomla/form') . '/forms';
 
 		$this->assertThat(
 			in_array($valid, $paths),
@@ -134,7 +136,8 @@ class JFormTest extends TestCase
 		$paths = JForm::addRulePath();
 
 		// The default path is the class file folder/rules
-		$valid = JPATH_PLATFORM . '/joomla/form/rules';
+		// use of realpath to ensure test works for on all platforms
+		$valid = realpath(JPATH_PLATFORM . '/joomla/form') . '/rules';
 
 		$this->assertThat(
 			in_array($valid, $paths),

--- a/tests/suites/unit/joomla/github/JGithubGistsTest.php
+++ b/tests/suites/unit/joomla/github/JGithubGistsTest.php
@@ -123,7 +123,7 @@ class JGithubGistsTest extends PHPUnit_Framework_TestCase
 		$data = json_encode(
 			array(
 				'files' => array(
-					'gittest' => array('content' => 'GistContent' . "\n")
+					'gittest' => array('content' => 'GistContent' . PHP_EOL)
 				),
 				'public' => true,
 				'description' => 'This is a gist'

--- a/tests/suites/unit/joomla/table/JTableTest.php
+++ b/tests/suites/unit/joomla/table/JTableTest.php
@@ -175,6 +175,7 @@ class JTableTest extends TestCaseDatabase
 
 		$reflection = new ReflectionClass('JTable');
 
+		// use of realpath to ensure test works for on all platforms
 		$this->assertEquals(
 			realpath(dirname($reflection->getFileName())),
 			realpath($result[0]),
@@ -185,7 +186,7 @@ class JTableTest extends TestCaseDatabase
 		$expected = array(
 			'/dummy/',
 			'dir/not/exist',
-			JPATH_PLATFORM . '/joomla/table'
+			realpath(JPATH_PLATFORM . '/joomla/table')
 		);
 
 		// Add dummy paths

--- a/tests/suites/unit/joomla/view/JViewHtmlTest.php
+++ b/tests/suites/unit/joomla/view/JViewHtmlTest.php
@@ -106,14 +106,15 @@ class JViewHtmlTest extends TestCase
 		$paths->insert(__DIR__ . '/layouts1', 1);
 		$paths->insert(__DIR__ . '/layouts2', 2);
 
-		$this->assertEquals(__DIR__ . '/layouts2/olivia.php', $this->_instance->getPath('olivia'));
-		$this->assertEquals(__DIR__ . '/layouts1/peter.php', $this->_instance->getPath('peter'));
-		$this->assertEquals(__DIR__ . '/layouts2/fauxlivia.php', $this->_instance->getPath('fauxlivia'));
-		$this->assertEquals(__DIR__ . '/layouts1/fringe/division.php', $this->_instance->getPath('fringe/division'));
+		// use of realpath to ensure test works for on all platforms
+		$this->assertEquals(realpath(__DIR__ . '/layouts2/olivia.php'), $this->_instance->getPath('olivia'));
+		$this->assertEquals(realpath(__DIR__ . '/layouts1/peter.php'), $this->_instance->getPath('peter'));
+		$this->assertEquals(realpath(__DIR__ . '/layouts2/fauxlivia.php'), $this->_instance->getPath('fauxlivia'));
+		$this->assertEquals(realpath(__DIR__ . '/layouts1/fringe/division.php'), $this->_instance->getPath('fringe/division'));
 		$this->assertFalse($this->_instance->getPath('walter'));
 
 		// Check dirty path.
-		$this->assertEquals(__DIR__ . '/layouts1/fringe/division.php', $this->_instance->getPath('fringe//\\division'));
+		$this->assertEquals(realpath(__DIR__ . '/layouts1/fringe/division.php'), $this->_instance->getPath('fringe//\\division'));
 	}
 
 	/**


### PR DESCRIPTION
This  pull request is not done yet, i am still having some issues with the tester

21) JFormTest::testAddRulePath
Line:142 The libraries rule path should be included by default.
Failed asserting that false is true.

C:\Users\fanno\data\Projects\workspaces\phpstorm\joomla-platform\tests\suites\unit\joomla\form\JFormTest.php:143

now the issue is this ..

$valid = JPATH_PLATFORM . '/joomla/form/rules';

$valid is (C:\Users\fanno\data\Projects\workspaces\phpstorm\joomla-platform\libraries/joomla/form/rules)

and the path inside $paths is

C:\Users\fanno\data\Projects\workspaces\phpstorm\joomla-platform\libraries\joomla\form/rules

this comes from
https://github.com/fanno/joomla-platform/blob/staging/libraries/joomla/form/helper.php#L302

I am well aware that the user of DS is not needed anymore, however it complicates the testing

it could posible be solved by doing something like 

$valid = realpath(JPATH_PLATFORM . '/joomla/form').'/rules';

however i think it is ugly but it it works it works ...

is this how the test should be made to look ? or how do you want to deal with it ?
