### PR TITLE
Adding JImage::cropResize

### DIFF
--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -43,6 +43,12 @@ class JImage
 	const CROP = 4;
 
 	/**
+	 * @const  integer
+	 * @since  12.3
+	 */
+	const CROP_RESIZE = 5;
+
+	/**
 	 * @var    resource  The image resource handle.
 	 * @since  11.3
 	 */
@@ -148,11 +154,11 @@ class JImage
 	}
 
 	/**
-	 * Method to generate thumbnails from the current image. It allows creation by resizing
-	 * or croppping the original image.
+	 * Method to generate thumbnails from the current image. It allows
+	 * creation by resizing or cropping the original image.
 	 *
-	 * @param   mixed    $thumbSizes      string or array of strings. Example: $thumbSizes = array('150x75','250x150');
-	 * @param   integer  $creationMethod  1-3 resize $scaleMethod | 4 create croppping
+	 * @param   mixed    $thumbSizes      String or array of strings. Example: $thumbSizes = array('150x75','250x150');
+	 * @param   integer  $creationMethod  1-3 resize $scaleMethod | 4 create croppping | 5 resize then crop
 	 *
 	 * @return array
 	 *
@@ -192,21 +198,28 @@ class JImage
 				$thumbWidth 	= $size[0];
 				$thumbHeight	= $size[1];
 
-				// Generate thumb cropping image
-				if ($creationMethod == 4)
+				switch ($creationMethod)
 				{
-					$thumb = $this->crop($thumbWidth, $thumbHeight, null, null, true);
-				}
-				// Generate thumb resizing image
-				else
-				{
-					$thumb = $this->resize($thumbWidth, $thumbHeight, true, $creationMethod);
+					// Case for self::CROP
+					case 4:
+						$thumb = $this->crop($thumbWidth, $thumbHeight, null, null, true);
+						break;
+
+					// Case for self::CROP_RESIZE
+					case 5:
+						$thumb = $this->cropResize($thumbWidth, $thumbHeight, true);
+						break;
+
+					default:
+						$thumb = $this->resize($thumbWidth, $thumbHeight, true, $creationMethod);
+						break;
 				}
 
 				// Store the thumb in the results array
 				$generated[] = $thumb;
 			}
 		}
+
 		return $generated;
 	}
 
@@ -674,6 +687,35 @@ class JImage
 	}
 
 	/**
+	 * Method to crop an image after resizing it to maintain
+	 * proportions without having to do all the set up work.
+	 *
+	 * @param   integer  $width      The desired width of the image in pixels or a percentage.
+	 * @param   integer  $height     The desired height of the image in pixels or a percentage.
+	 * @param   integer  $createNew  If true the current image will be cloned, resized, cropped and returned.
+	 *
+	 * @return  object  JImage Object for chaining.
+	 *
+	 * @since   12.3
+	 */
+	public function cropResize($width, $height, $createNew = true)
+	{
+		$width   = $this->sanitizeWidth($width, $height);
+		$height  = $this->sanitizeHeight($height, $width);
+
+		if (($this->getWidth() / $width) < ($this->getHeight() / $height))
+		{
+			$this->resize($width, 0, false);
+		}
+		else
+		{
+			$this->resize(0, $height, false);
+		}
+
+		return $this->crop($width, $height, null, null, $createNew);
+	}
+
+	/**
 	 * Method to rotate the current image.
 	 *
 	 * @param   mixed    $angle       The angle of rotation for the image
@@ -835,19 +877,8 @@ class JImage
 
 			case self::SCALE_INSIDE:
 			case self::SCALE_OUTSIDE:
-
-				// Both $height or $width cannot be zero
-				if ($width == 0 || $height == 0)
-				{
-					throw new InvalidArgumentException(' Width or height cannot be zero with this scale method ');
-				}
-
-				// If both $width and $height are not equals to zero
-				else
-				{
-					$rx = $this->getWidth() / $width;
-					$ry = $this->getHeight() / $height;
-				}
+				$rx = ($width > 0) ? ($this->getWidth() / $width) : 0;
+				$ry = ($height > 0) ? ($this->getHeight() / $height) : 0;
 
 				if ($scaleMethod == self::SCALE_INSIDE)
 				{


### PR DESCRIPTION
A lot of setup is required if you would like to both resize an image down to something more manageable, and then crop that created image from the center. This is very useful for creating thumbnails that are both cropped and resized.

You can achieve a similar result using `createThumbs($sizes, JImage::SCALE_FILL)`, but it squashes the image to fit, resulting in a skewed image. See attached imageFill.png for what this looks like.
![imageFill](https://f.cloud.github.com/assets/718028/7057/75c4445a-43e6-11e2-8539-8e6c08536c8e.png)

This method gives a clean resize and crop from center. See attached cropResize.png.
![cropResize](https://f.cloud.github.com/assets/718028/7060/87f910ec-43e6-11e2-868b-a864381bf94f.png)
