### PR TITLE
Fix unit tests for PHP 5.4

### DIFF
--- a/tests/suites/unit/joomla/google/JGoogleDataAdsenseTest.php
+++ b/tests/suites/unit/joomla/google/JGoogleDataAdsenseTest.php
@@ -380,6 +380,8 @@ class JGoogleDataAdsenseTest extends TestCase
  */
 function jsonAdsenseCallback($url, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/json');
 	$response->body = '{"items":{"1":1,"2":2},"nextPageToken":"1234"}';
@@ -400,6 +402,8 @@ function jsonAdsenseCallback($url, array $headers = null, $timeout = null)
  */
 function jsonAdsenseReportCallback($url, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/json');
 	$response->body = '{"rows":{"0":1,"1":2},"totalMatchedRows":1}';
@@ -420,6 +424,8 @@ function jsonAdsenseReportCallback($url, array $headers = null, $timeout = null)
  */
 function adsenseExceptionCallback($url, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/json');
 	$response->body = 'BADDATA';

--- a/tests/suites/unit/joomla/google/JGoogleDataCalendarTest.php
+++ b/tests/suites/unit/joomla/google/JGoogleDataCalendarTest.php
@@ -489,6 +489,8 @@ class JGoogleDataCalendarTest extends TestCase
  */
 function jsonDataCalendarCallback($url, $data, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/json');
 	$response->body = '{"items":{"1":1,"2":2}}';
@@ -510,6 +512,8 @@ function jsonDataCalendarCallback($url, $data, array $headers = null, $timeout =
  */
 function emptyDataCalendarCallback($url, $data, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'text/html');
 	$response->body = '';
@@ -530,6 +534,8 @@ function emptyDataCalendarCallback($url, $data, array $headers = null, $timeout 
  */
 function jsonCalendarCallback($url, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/json');
 	$response->body = '{"items":{"1":1,"2":2}}';
@@ -550,6 +556,8 @@ function jsonCalendarCallback($url, array $headers = null, $timeout = null)
  */
 function emptyCalendarCallback($url, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'text/html');
 	$response->body = '';
@@ -570,6 +578,8 @@ function emptyCalendarCallback($url, array $headers = null, $timeout = null)
  */
 function calendarExceptionCallback($url, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/json');
 	$response->body = 'BADDATA';
@@ -591,6 +601,8 @@ function calendarExceptionCallback($url, array $headers = null, $timeout = null)
  */
 function calendarDataExceptionCallback($url, $data, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/json');
 	$response->body = 'BADDATA';

--- a/tests/suites/unit/joomla/google/JGoogleDataPicasaAlbumTest.php
+++ b/tests/suites/unit/joomla/google/JGoogleDataPicasaAlbumTest.php
@@ -477,6 +477,8 @@ class JGoogleDataPicasaAlbumTest extends TestCase
  */
 function emptyPicasaCallback($url, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/atom+xml');
 	$response->body = '';
@@ -497,6 +499,8 @@ function emptyPicasaCallback($url, array $headers = null, $timeout = null)
  */
 function picasaPhotolistCallback($url, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/atom+xml');
 	$response->body = JFile::read(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'photolist.txt');
@@ -518,6 +522,8 @@ function picasaPhotolistCallback($url, array $headers = null, $timeout = null)
  */
 function dataPicasaUploadCallback($url, $data, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/atom+xml');
 	$response->body = JFile::read(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'photo.txt');

--- a/tests/suites/unit/joomla/google/JGoogleDataPicasaPhotoTest.php
+++ b/tests/suites/unit/joomla/google/JGoogleDataPicasaPhotoTest.php
@@ -422,6 +422,8 @@ class JGoogleDataPicasaPhotoTest extends TestCase
  */
 function picasaPhotoCallback($url, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/atom+xml');
 	$response->body = JFile::read(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'photo.txt');
@@ -444,6 +446,8 @@ function picasaPhotoCallback($url, array $headers = null, $timeout = null)
 function dataPicasaPhotoCallback($url, $data, array $headers = null, $timeout = null)
 {
 	PHPUnit_Framework_TestCase::assertContains('<title>New Title</title>', $data);
+
+	$response = new stdClass;
 
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/atom+xml');

--- a/tests/suites/unit/joomla/google/JGoogleDataPicasaTest.php
+++ b/tests/suites/unit/joomla/google/JGoogleDataPicasaTest.php
@@ -262,6 +262,8 @@ class JGoogleDataPicasaTest extends TestCase
  */
 function picasaAlbumCallback($url, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'text/html');
 	$response->body = JFile::read(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'album.txt');
@@ -285,6 +287,8 @@ function dataPicasaAlbumCallback($url, $data, array $headers = null, $timeout = 
 {
 	PHPUnit_Framework_TestCase::assertContains('<title>New Title</title>', $data);
 
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/atom+xml');
 	$response->body = $data;
@@ -305,6 +309,8 @@ function dataPicasaAlbumCallback($url, $data, array $headers = null, $timeout = 
  */
 function picasaAlbumlistCallback($url, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/atom+xml');
 	$response->body = JFile::read(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'albumlist.txt');
@@ -325,6 +331,8 @@ function picasaAlbumlistCallback($url, array $headers = null, $timeout = null)
  */
 function picasaExceptionCallback($url, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/atom+xml');
 	$response->body = 'BADDATA';
@@ -346,6 +354,8 @@ function picasaExceptionCallback($url, array $headers = null, $timeout = null)
  */
 function picasaDataExceptionCallback($url, $data, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/atom+xml');
 	$response->body = 'BADDATA';
@@ -366,6 +376,8 @@ function picasaDataExceptionCallback($url, $data, array $headers = null, $timeou
  */
 function picasaBadXmlCallback($url, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/atom+xml');
 	$response->body = '<feed />';

--- a/tests/suites/unit/joomla/google/JGoogleEmbedMapsTest.php
+++ b/tests/suites/unit/joomla/google/JGoogleEmbedMapsTest.php
@@ -759,6 +759,8 @@ function mapsGeocodeCallback($url, array $headers = null, $timeout = null)
 		$data = "{\n   \"results\" : [],\n   \"status\" : \"ZERO_RESULTS\"\n}\n";
 	}
 
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/json');
 	$response->body = $data;
@@ -779,6 +781,8 @@ function mapsGeocodeCallback($url, array $headers = null, $timeout = null)
  */
 function mapsGeocode400Callback($url, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 400;
 	$response->headers = array('Content-Type' => 'application/json');
 	$response->body = '';
@@ -799,6 +803,8 @@ function mapsGeocode400Callback($url, array $headers = null, $timeout = null)
  */
 function mapsGeocodeBadJsonCallback($url, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/json');
 	$response->body = 'BADDATA';

--- a/tests/suites/unit/joomla/oauth2/JOauth2ClientTest.php
+++ b/tests/suites/unit/joomla/oauth2/JOauth2ClientTest.php
@@ -347,6 +347,7 @@ class JOAuth2ClientTest extends TestCase
  */
 function encodedGrantOauthCallback($url, $data, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
 
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'x-www-form-urlencoded');
@@ -370,6 +371,8 @@ function encodedGrantOauthCallback($url, $data, array $headers = null, $timeout 
 function jsonGrantOauthCallback($url, $data, array $headers = null, $timeout = null)
 {
 
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'application/json');
 	$response->body = '{"access_token":"accessvalue","refresh_token":"refreshvalue","expires_in":3600}';
@@ -391,6 +394,8 @@ function jsonGrantOauthCallback($url, $data, array $headers = null, $timeout = n
  */
 function queryOauthCallback($url, $data, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'text/html');
 	$response->body = 'Lorem ipsum dolor sit amet.';
@@ -411,6 +416,8 @@ function queryOauthCallback($url, $data, array $headers = null, $timeout = null)
  */
 function getOauthCallback($url, array $headers = null, $timeout = null)
 {
+	$response = new stdClass;
+
 	$response->code = 200;
 	$response->headers = array('Content-Type' => 'text/html');
 	$response->body = 'Lorem ipsum dolor sit amet.';


### PR DESCRIPTION
Currently the unit tests are failing when run in PHP 5.4 with it's standard options trying to teach us how to write better code: `PHPUnit_Framework_Error_Warning : Creating default object from empty value`
This fixes those nasty messages.
