### PR TITLE
Accessibility: add aria-required attribute to JFormField

### DIFF
--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -345,6 +345,7 @@ abstract class JFormField
 		$multiple = (string) $element['multiple'];
 		$name = (string) $element['name'];
 		$required = (string) $element['required'];
+		$ariaRequired = (string) $element['aria-required'];
 		$disabled = (string) $element['disabled'];
 		$readonly = (string) $element['readonly'];
 
@@ -367,6 +368,10 @@ abstract class JFormField
 			else
 			{
 				$this->element->addAttribute('class', 'required');
+			}
+
+			if(!$ariaRequired) {
+				$this->element->addAttribute('aria-required', 'true');
 			}
 		}
 

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -345,7 +345,6 @@ abstract class JFormField
 		$multiple = (string) $element['multiple'];
 		$name = (string) $element['name'];
 		$required = (string) $element['required'];
-		$ariaRequired = (string) $element['aria-required'];
 		$disabled = (string) $element['disabled'];
 		$readonly = (string) $element['readonly'];
 
@@ -368,10 +367,6 @@ abstract class JFormField
 			else
 			{
 				$this->element->addAttribute('class', 'required');
-			}
-
-			if(!$ariaRequired) {
-				$this->element->addAttribute('aria-required', 'true');
 			}
 		}
 

--- a/libraries/joomla/form/fields/accesslevel.php
+++ b/libraries/joomla/form/fields/accesslevel.php
@@ -47,6 +47,7 @@ class JFormFieldAccessLevel extends JFormFieldList
 		$attr .= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
 		$attr .= $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
 		$attr .= $this->multiple ? ' multiple="multiple"' : '';
+		$attr .= $this->required ? ' required="required" aria-required="true"' : '';
 
 		// Initialize JavaScript field attributes.
 		$attr .= $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';

--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -69,6 +69,11 @@ class JFormFieldCalendar extends JFormField
 		{
 			$attributes['onchange'] = (string) $this->element['onchange'];
 		}
+		if ($this->required)
+		{
+			$attributes['required'] = 'required';
+			$attributes['aria-required'] = 'true';
+		}
 
 		// Handle the special case for "now".
 		if (strtoupper($this->value) == 'NOW')

--- a/libraries/joomla/form/fields/checkbox.php
+++ b/libraries/joomla/form/fields/checkbox.php
@@ -44,6 +44,7 @@ class JFormFieldCheckbox extends JFormField
 		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
 		$disabled = ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
 		$value = $this->element['value'] ? (string) $this->element['value'] : '1';
+		$required = $this->required ? ' required="required" aria-required="true"' : '';
 
 		if (empty($this->value))
 		{
@@ -58,6 +59,6 @@ class JFormFieldCheckbox extends JFormField
 		$onclick = $this->element['onclick'] ? ' onclick="' . (string) $this->element['onclick'] . '"' : '';
 
 		return '<input type="checkbox" name="' . $this->name . '" id="' . $this->id . '"' . ' value="'
-			. htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"' . $class . $checked . $disabled . $onclick . ' />';
+			. htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"' . $class . $checked . $disabled . $onclick . $required . ' />';
 	}
 }

--- a/libraries/joomla/form/fields/checkboxes.php
+++ b/libraries/joomla/form/fields/checkboxes.php
@@ -74,6 +74,7 @@ class JFormFieldCheckboxes extends JFormField
 				$checked = (in_array((string) $option->value, $value) ? ' checked="checked"' : '');
 			}
 			$class = !empty($option->class) ? ' class="' . $option->class . '"' : '';
+			$required = !empty($option->required) ? ' required="required" aria-required="true"' : '';
 			$disabled = !empty($option->disable) ? ' disabled="disabled"' : '';
 
 			// Initialize some JavaScript option attributes.
@@ -81,7 +82,7 @@ class JFormFieldCheckboxes extends JFormField
 
 			$html[] = '<li>';
 			$html[] = '<input type="checkbox" id="' . $this->id . $i . '" name="' . $this->name . '"' . ' value="'
-				. htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8') . '"' . $checked . $class . $onclick . $disabled . '/>';
+				. htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8') . '"' . $checked . $class . $onclick . $disabled . $required . '/>';
 
 			$html[] = '<label for="' . $this->id . $i . '"' . $class . '>' . JText::_($option->text) . '</label>';
 			$html[] = '</li>';

--- a/libraries/joomla/form/fields/color.php
+++ b/libraries/joomla/form/fields/color.php
@@ -41,6 +41,7 @@ class JFormFieldColor extends JFormField
 		$size = $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
 		$classes = (string) $this->element['class'];
 		$disabled = ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
+		$required = $this->required ? ' required="required" aria-required="true"' : '';
 
 		if (!$disabled)
 		{
@@ -60,6 +61,6 @@ class JFormFieldColor extends JFormField
 		$class = $classes ? ' class="' . trim($classes) . '"' : '';
 
 		return '<input type="text" name="' . $this->name . '" id="' . $this->id . '"' . ' value="'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $class . $size . $disabled . $onchange . '/>';
+			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $class . $size . $disabled . $onchange . $required . '/>';
 	}
 }

--- a/libraries/joomla/form/fields/combo.php
+++ b/libraries/joomla/form/fields/combo.php
@@ -46,6 +46,7 @@ class JFormFieldCombo extends JFormFieldList
 		$attr .= ((string) $this->element['readonly'] == 'true') ? ' readonly="readonly"' : '';
 		$attr .= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
 		$attr .= $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
+		$attr .= $this->required ? ' required="required" aria-required="true"' : '';
 
 		// Initialize JavaScript field attributes.
 		$attr .= $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';

--- a/libraries/joomla/form/fields/email.php
+++ b/libraries/joomla/form/fields/email.php
@@ -44,11 +44,12 @@ class JFormFieldEMail extends JFormField
 		$class = $this->element['class'] ? ' ' . (string) $this->element['class'] : '';
 		$readonly = ((string) $this->element['readonly'] == 'true') ? ' readonly="readonly"' : '';
 		$disabled = ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
+		$required = $this->required ? ' required="required" aria-required="true"' : '';
 
 		// Initialize JavaScript field attributes.
 		$onchange = $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
 
 		return '<input type="text" name="' . $this->name . '" class="validate-email' . $class . '" id="' . $this->id . '"' . ' value="'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $size . $disabled . $readonly . $onchange . $maxLength . '/>';
+			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $size . $disabled . $readonly . $onchange . $maxLength . $required . '/>';
 	}
 }

--- a/libraries/joomla/form/fields/file.php
+++ b/libraries/joomla/form/fields/file.php
@@ -47,11 +47,12 @@ class JFormFieldFile extends JFormField
 		$size = $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
 		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
 		$disabled = ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
+		$required = $this->required ? ' required="required" aria-required="true"' : '';
 
 		// Initialize JavaScript field attributes.
 		$onchange = $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
 
 		return '<input type="file" name="' . $this->name . '" id="' . $this->id . '"' . ' value=""' . $accept . $disabled . $class . $size
-			. $onchange . ' />';
+			. $onchange . $required . ' />';
 	}
 }

--- a/libraries/joomla/form/fields/groupedlist.php
+++ b/libraries/joomla/form/fields/groupedlist.php
@@ -145,7 +145,6 @@ class JFormFieldGroupedList extends JFormField
 		$attr .= $this->multiple ? ' multiple="multiple"' : '';
 		$attr .= $this->required ? ' required="required" aria-required="true"' : '';
 
-
 		// Initialize JavaScript field attributes.
 		$attr .= $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
 

--- a/libraries/joomla/form/fields/groupedlist.php
+++ b/libraries/joomla/form/fields/groupedlist.php
@@ -143,6 +143,8 @@ class JFormFieldGroupedList extends JFormField
 		$attr .= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
 		$attr .= $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
 		$attr .= $this->multiple ? ' multiple="multiple"' : '';
+		$attr .= $this->required ? ' required="required" aria-required="true"' : '';
+
 
 		// Initialize JavaScript field attributes.
 		$attr .= $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';

--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -51,6 +51,7 @@ class JFormFieldList extends JFormField
 
 		$attr .= $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
 		$attr .= $this->multiple ? ' multiple="multiple"' : '';
+		$attr .= $this->required ? ' required="required" aria-required="true"' : '';
 
 		// Initialize JavaScript field attributes.
 		$attr .= $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';

--- a/libraries/joomla/form/fields/password.php
+++ b/libraries/joomla/form/fields/password.php
@@ -47,6 +47,7 @@ class JFormFieldPassword extends JFormField
 		$disabled	= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
 		$meter		= ((string) $this->element['strengthmeter'] == 'true');
 		$threshold	= $this->element['threshold'] ? (int) $this->element['threshold'] : 66;
+		$required   = $this->required ? ' required="required" aria-required="true"' : '';
 
 		$script = '';
 
@@ -65,6 +66,6 @@ class JFormFieldPassword extends JFormField
 
 		return '<input type="password" name="' . $this->name . '" id="' . $this->id . '"' .
 			' value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' .
-			$auto . $class . $readonly . $disabled . $size . $maxLength . '/>' . $script;
+			$auto . $class . $readonly . $disabled . $size . $maxLength . $required . '/>' . $script;
 	}
 }

--- a/libraries/joomla/form/fields/radio.php
+++ b/libraries/joomla/form/fields/radio.php
@@ -58,7 +58,6 @@ class JFormFieldRadio extends JFormField
 			$disabled = !empty($option->disable) ? ' disabled="disabled"' : '';
 			$required = !empty($option->required) ? ' required="required" aria-required="true"' : '';
 
-
 			// Initialize some JavaScript option attributes.
 			$onclick = !empty($option->onclick) ? ' onclick="' . $option->onclick . '"' : '';
 

--- a/libraries/joomla/form/fields/radio.php
+++ b/libraries/joomla/form/fields/radio.php
@@ -56,12 +56,14 @@ class JFormFieldRadio extends JFormField
 			$checked = ((string) $option->value == (string) $this->value) ? ' checked="checked"' : '';
 			$class = !empty($option->class) ? ' class="' . $option->class . '"' : '';
 			$disabled = !empty($option->disable) ? ' disabled="disabled"' : '';
+			$required = !empty($option->required) ? ' required="required" aria-required="true"' : '';
+
 
 			// Initialize some JavaScript option attributes.
 			$onclick = !empty($option->onclick) ? ' onclick="' . $option->onclick . '"' : '';
 
 			$html[] = '<input type="radio" id="' . $this->id . $i . '" name="' . $this->name . '"' . ' value="'
-				. htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8') . '"' . $checked . $class . $onclick . $disabled . '/>';
+				. htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8') . '"' . $checked . $class . $onclick . $disabled . $required . '/>';
 
 			$html[] = '<label for="' . $this->id . $i . '"' . $class . '>'
 				. JText::alt($option->text, preg_replace('/[^a-zA-Z0-9_\-]/', '_', $this->fieldname)) . '</label>';

--- a/libraries/joomla/form/fields/text.php
+++ b/libraries/joomla/form/fields/text.php
@@ -44,11 +44,12 @@ class JFormFieldText extends JFormField
 		$class = $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
 		$readonly = ((string) $this->element['readonly'] == 'true') ? ' readonly="readonly"' : '';
 		$disabled = ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
+		$required = $this->required ? ' required="required" aria-required="true"' : '';
 
 		// Initialize JavaScript field attributes.
 		$onchange = $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
 
 		return '<input type="text" name="' . $this->name . '" id="' . $this->id . '"' . ' value="'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $class . $size . $disabled . $readonly . $onchange . $maxLength . '/>';
+			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $class . $size . $disabled . $readonly . $onchange . $maxLength . $required . '/>';
 	}
 }

--- a/libraries/joomla/form/fields/textarea.php
+++ b/libraries/joomla/form/fields/textarea.php
@@ -43,11 +43,12 @@ class JFormFieldTextarea extends JFormField
 		$disabled = ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
 		$columns = $this->element['cols'] ? ' cols="' . (int) $this->element['cols'] . '"' : '';
 		$rows = $this->element['rows'] ? ' rows="' . (int) $this->element['rows'] . '"' : '';
+		$required = $this->required ? ' required="required" aria-required="true"' : '';
 
 		// Initialize JavaScript field attributes.
 		$onchange = $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';
 
-		return '<textarea name="' . $this->name . '" id="' . $this->id . '"' . $columns . $rows . $class . $disabled . $onchange . '>'
+		return '<textarea name="' . $this->name . '" id="' . $this->id . '"' . $columns . $rows . $class . $disabled . $onchange . $required . '>'
 			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '</textarea>';
 	}
 }

--- a/libraries/joomla/form/fields/usergroup.php
+++ b/libraries/joomla/form/fields/usergroup.php
@@ -45,6 +45,7 @@ class JFormFieldUsergroup extends JFormField
 		$attr .= ((string) $this->element['disabled'] == 'true') ? ' disabled="disabled"' : '';
 		$attr .= $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
 		$attr .= $this->multiple ? ' multiple="multiple"' : '';
+		$attr .= $this->required ? ' required="required" aria-required="true"' : '';
 
 		// Initialize JavaScript field attributes.
 		$attr .= $this->element['onchange'] ? ' onchange="' . (string) $this->element['onchange'] . '"' : '';

--- a/tests/suites/unit/joomla/form/JFormTest.php
+++ b/tests/suites/unit/joomla/form/JFormTest.php
@@ -1050,7 +1050,7 @@ class JFormTest extends TestCase
 
 		$this->assertThat(
 			$form->getInput('title', null, 'The Title'),
-			$this->equalTo('<input type="text" name="title" id="title_id" value="The Title" class="inputbox required"/>'),
+			$this->equalTo('<input type="text" name="title" id="title_id" value="The Title" class="inputbox required" required="required" aria-required="true"/>'),
 			'Line:' . __LINE__ . ' The method should return a simple input text field.'
 		);
 


### PR DESCRIPTION
The aria-required attribute should be added to any required fields that are generated via JFormField.
