### PR TITLE
Revert "Small array merging optimization"

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -762,19 +762,19 @@ class JLanguage
 
 		if (file_exists($filename))
 		{
-			$strings = ksort($this->parse($filename),SORT_STRING);
+			$strings = $this->parse($filename);
 		}
 
 		if ($strings)
 		{
 			if (is_array($strings))
 			{
-				$this->strings = ksort(array_merge($this->strings, $strings),SORT_STRING);
+				$this->strings = array_merge($this->strings, $strings);
 			}
 
 			if (is_array($strings) && count($strings))
 			{
-				$this->strings = ksort(array_merge($this->strings, $this->override),SORT_STRING);
+				$this->strings = array_merge($this->strings, $this->override);
 				$result = true;
 			}
 		}


### PR DESCRIPTION
This reverts commit bc57b93e3f7ae274721df01d2e886111b9752a32 which was causing a number of tests to fail.
