### PR TITLE
Move JApplication**::getInstance methods to JApplicationBase

### DIFF
--- a/libraries/joomla/application/base.php
+++ b/libraries/joomla/application/base.php
@@ -43,6 +43,12 @@ abstract class JApplicationBase
 	public $input = null;
 
 	/**
+	 * @var    JApplicationBase  The application instance.
+	 * @since  13.1
+	 */
+	protected static $instance;
+
+	/**
 	 * Method to close the application.
 	 *
 	 * @param   integer  $code  The exit code (optional; default is 0).
@@ -67,6 +73,36 @@ abstract class JApplicationBase
 	public function getIdentity()
 	{
 		return $this->identity;
+	}
+
+	/**
+	 * Returns a reference to the global JApplicationBase object, only creating it if it doesn't already exist.
+	 *
+	 * This method must be invoked as: $app = JApplicationBase::getInstance();
+	 *
+	 * @param   string  $name  The name (optional) of the JApplicationBase class to instantiate.
+	 *
+	 * @return  JApplicationBase  Application instance
+	 *
+	 * @since   13.1
+	 * @throws  RuntimeException
+	 */
+	public static function getInstance($name = null)
+	{
+		// Only create the object if it doesn't exist.
+		if (empty(static::$instance))
+		{
+			if (class_exists($name) && (is_subclass_of($name, 'JApplicationBase')))
+			{
+				static::$instance = new $name;
+			}
+			else
+			{
+				throw new RuntimeException('Could not instantiate application: ' . $name);
+			}
+		}
+
+		return static::$instance;
 	}
 
 	/**

--- a/libraries/joomla/application/cli.php
+++ b/libraries/joomla/application/cli.php
@@ -25,12 +25,6 @@ class JApplicationCli extends JApplicationBase
 	protected $config;
 
 	/**
-	 * @var    JApplicationCli  The application instance.
-	 * @since  11.1
-	 */
-	protected static $instance;
-
-	/**
 	 * Class constructor.
 	 *
 	 * @param   mixed  $input       An optional argument to provide dependency injection for the application's
@@ -120,23 +114,13 @@ class JApplicationCli extends JApplicationBase
 	 * @return  JApplicationCli
 	 *
 	 * @since   11.1
+	 * @deprecated  14.1  Use JApplicationBase::getInstance() instead.
 	 */
 	public static function getInstance($name = null)
 	{
-		// Only create the object if it doesn't exist.
-		if (empty(self::$instance))
-		{
-			if (class_exists($name) && (is_subclass_of($name, 'JApplicationCli')))
-			{
-				self::$instance = new $name;
-			}
-			else
-			{
-				self::$instance = new JApplicationCli;
-			}
-		}
+		JLog::add(sprintf('%s is deprecated, use JApplicationBase::getInstance() instead.', __METHOD__), JLog::WARNING, 'deprecated');
 
-		return self::$instance;
+		return parent::getInstance($name);
 	}
 
 	/**

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -73,12 +73,6 @@ class JApplicationWeb extends JApplicationBase
 	protected $response;
 
 	/**
-	 * @var    JApplicationWeb  The application instance.
-	 * @since  11.3
-	 */
-	protected static $instance;
-
-	/**
 	 * Class constructor.
 	 *
 	 * @param   mixed  $input   An optional argument to provide dependency injection for the application's
@@ -155,23 +149,13 @@ class JApplicationWeb extends JApplicationBase
 	 * @return  JApplicationWeb
 	 *
 	 * @since   11.3
+	 * @deprecated  14.1  Use JApplicationBase::getInstance() instead.
 	 */
 	public static function getInstance($name = null)
 	{
-		// Only create the object if it doesn't exist.
-		if (empty(self::$instance))
-		{
-			if (class_exists($name) && (is_subclass_of($name, 'JApplicationWeb')))
-			{
-				self::$instance = new $name;
-			}
-			else
-			{
-				self::$instance = new JApplicationWeb;
-			}
-		}
+		JLog::add(sprintf('%s is deprecated, use JApplicationBase::getInstance() instead.', __METHOD__), JLog::WARNING, 'deprecated');
 
-		return self::$instance;
+		return parent::getInstance($name);
 	}
 
 	/**

--- a/tests/suites/unit/joomla/application/JApplicationBaseTest.php
+++ b/tests/suites/unit/joomla/application/JApplicationBaseTest.php
@@ -58,6 +58,41 @@ class JApplicationBaseTest extends TestCase
 	}
 
 	/**
+	 * Tests the JApplicationBase::getInstance method.
+	 *
+	 * @return  void
+	 *
+	 * @since   13.1
+	 */
+	public function testGetInstance()
+	{
+		$this->assertInstanceOf(
+			'JApplicationBaseInspector',
+			JApplicationBase::getInstance('JApplicationBaseInspector'),
+			'Tests that getInstance will instantiate a valid child class of JApplicationBase.'
+		);
+
+		TestReflection::setValue('JApplicationBase', 'instance', 'foo');
+
+		$this->assertEquals('foo', JApplicationBase::getInstance('JApplicationBaseInspector'), 'Tests that singleton value is returned.');
+	}
+
+	/**
+	 * Tests the JApplicationBase::getInstance method for a thrown RuntimeException.
+	 *
+	 * @return  void
+	 *
+	 * @since   13.1
+	 * @expectedException  RuntimeException
+	 */
+	public function testGetInstanceException()
+	{
+		TestReflection::setValue('JApplicationBase', 'instance', null);
+
+		JApplicationBase::getInstance('NonExistingClass');
+	}
+
+	/**
 	 * Tests the JApplicationBase::loadDispatcher method.
 	 *
 	 * @return  void

--- a/tests/suites/unit/joomla/application/JApplicationCliTest.php
+++ b/tests/suites/unit/joomla/application/JApplicationCliTest.php
@@ -284,14 +284,6 @@ class JApplicationCliTest extends TestCase
 		TestReflection::setValue('JApplicationCli', 'instance', 'foo');
 
 		$this->assertEquals('foo', JApplicationCli::getInstance('JApplicationCliInspector'), 'Tests that singleton value is returned.');
-
-		TestReflection::setValue('JApplicationCli', 'instance', null);
-
-		$this->assertInstanceOf(
-			'JApplicationCli',
-			JApplicationCli::getInstance('Foo'),
-			'Tests that getInstance will instantiate a valid child class of JApplicationCli given a non-existent type.'
-		);
 	}
 
 	/**

--- a/tests/suites/unit/joomla/application/JApplicationWebTest.php
+++ b/tests/suites/unit/joomla/application/JApplicationWebTest.php
@@ -949,14 +949,6 @@ class JApplicationWebTest extends TestCase
 			$this->equalTo('foo'),
 			'Tests that singleton value is returned.'
 		);
-
-		TestReflection::setValue('JApplicationWeb', 'instance', null);
-
-		$this->assertInstanceOf(
-			'JApplicationWeb',
-			JApplicationWeb::getInstance('Foo'),
-			'Tests that getInstance will instantiate a valid child class of JApplicationWeb given a non-existent type.'
-		);
 	}
 
 	/**


### PR DESCRIPTION
This will probably best work with #1769 if it is merged, FYI.

This pull deprecates the getInstance methods of JApplicationCli and JApplicationWeb in favor of having the getInstance method in JApplicationBase.  Generally, only one application can be running properly within a workspace, so this is IMO a logical move to support that theory.  If accepted, this method could theoretically replace JFactory::getApplication (another idea discussed in #1729).
