### PR TITLE
[fix] package uninstaller cannot access the manifest

### DIFF
--- a/libraries/legacy/installer/adapters/package.php
+++ b/libraries/legacy/installer/adapters/package.php
@@ -416,17 +416,10 @@ class JInstallerPackage extends JAdapterInstance
 		// Set the package root path
 		$this->parent->setPath('extension_root', JPATH_MANIFESTS . '/packages/' . $manifest->packagename);
 
-		// Because packages may not have their own folders we cannot use the standard method of finding an installation manifest
-		if (!file_exists($manifestFile))
-		{
-			// TODO: Fail?
-			JLog::add(JText::_('JLIB_INSTALLER_ERROR_PACK_UNINSTALL_MISSINGMANIFEST'), JLog::WARNING, 'jerror');
+		$this->parent->setPath('source', JPATH_MANIFESTS . '/packages');
 
-			return false;
-
-		}
-
-		$this->manifest = simplexml_load_file($manifestFile);
+		$this->parent->findManifest();
+		$this->manifest = $this->parent->getManifest();
 
 		// If we cannot load the XML file return false
 		if (!$this->manifest)

--- a/libraries/legacy/installer/adapters/package.php
+++ b/libraries/legacy/installer/adapters/package.php
@@ -426,10 +426,10 @@ class JInstallerPackage extends JAdapterInstance
 
 		}
 
-		$xml = simplexml_load_file($manifestFile);
+		$this->manifest = simplexml_load_file($manifestFile);
 
 		// If we cannot load the XML file return false
-		if (!$xml)
+		if (!$this->manifest)
 		{
 			JLog::add(JText::_('JLIB_INSTALLER_ERROR_PACK_UNINSTALL_LOAD_MANIFEST'), JLog::WARNING, 'jerror');
 
@@ -437,7 +437,7 @@ class JInstallerPackage extends JAdapterInstance
 		}
 
 		// Check for a valid XML root tag.
-		if ($xml->getName() != 'extension')
+		if ($this->manifest->getName() != 'extension')
 		{
 			JLog::add(JText::_('JLIB_INSTALLER_ERROR_PACK_UNINSTALL_INVALID_MANIFEST'), JLog::WARNING, 'jerror');
 


### PR DESCRIPTION
Currently package installer scripts cannot access to the manifest to process it.

For components in the installer script you can get the manifest with something like:

```
function uninstall($parent)
{
    $manifest  = $parent->get('manifest');
}
```

Actually that will not work for packages. Neither:

```
$manifest = $parent->getParent()->manifest;
```
