### PR TITLE
Add missing argument to JAccess::checkGroup in rules.php

### DIFF
--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -205,7 +205,7 @@ class JFormFieldRules extends JFormField
 					// This is where we show the current effective settings considering currrent group, path and cascade.
 					// Check whether this is a component or global. Change the text slightly.
 
-					if (JAccess::checkGroup($group->value, 'core.admin') !== true)
+					if (JAccess::checkGroup($group->value, 'core.admin', $assetId) !== true)
 					{
 						if ($inheritedRule === null)
 						{


### PR DESCRIPTION
There are major performance issues when the number of user groups is high, particularly in load and save.
Some investigation revealed that the getRootId()  queries were running a high number of times, approximately 2_n of groups_n of permissions and this obviously grows geometrically with the number of  groups.  Drilling down a big further reveals that this query was being run so often because there was no asset information being passed to the JAccess::checkGroup() method in the rules field.  Adding in that argument eliminates those queries and substantially improves performance.  In one case for me the change was from 145 queries (115 the same) taking 1.694 seconds to 27 queries taking 1.472 seconds.

See also:
http://code.joomla.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=27709
