### PR TITLE
Avoid include_once when we are sure the class doesn't exist

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -266,7 +266,7 @@ abstract class JLoader
 				// Include the file if it exists.
 				if (file_exists($path))
 				{
-					return (bool) include_once $path;
+					return (bool) include $path;
 				}
 			}
 		}
@@ -313,7 +313,7 @@ abstract class JLoader
 				// Include the file if it exists.
 				if (file_exists($path))
 				{
-					return (bool) include_once $path;
+					return (bool) include $path;
 				}
 			}
 		}
@@ -364,7 +364,7 @@ abstract class JLoader
 				// Include the file if it exists.
 				if (file_exists($lowerPath))
 				{
-					return (bool) include_once $lowerPath;
+					return (bool) include $lowerPath;
 				}
 
 				// Create the full natural case path.
@@ -373,7 +373,7 @@ abstract class JLoader
 				// Include the file if it exists.
 				if (file_exists($naturalPath))
 				{
-					return (bool) include_once $naturalPath;
+					return (bool) include $naturalPath;
 				}
 			}
 		}


### PR DESCRIPTION
Since a class_exists call was added in all loadByNamespace methods, include_once is no more needed.

APC also prefers include :
http://php.net/manual/en/apc.configuration.php#ini.apc.include-once-override
