### PR TITLE
Update to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,5 +7,9 @@
     "license": "GNU Public License",
     "require": {
         "php": ">=5.3.1"
+    },
+    "config": {
+	    "vendor-dir": "libraries",
+	    "bin-dir": "bin"
     }
 }


### PR DESCRIPTION
This PR updates the config directive in composer.json to match the platforms naming convention. Typically, when installing via composer, the files get put in the `vendor` directory. Joomla puts 3rd party libraries in the `libraries` dir. If a package installed via composer has any binary files, this update will place them in the `bin` folder, instead of the default `vendor/bin`.
