### PR TITLE
JFactory::getUser()

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -225,6 +225,10 @@ abstract class JFactory
 		{
 			$instance = JUser::getInstance($id);
 		}
+		elseif ($id && !$instance->id)
+		{
+			$instance = JUser::getInstance($id);
+		}
 
 		return $instance;
 	}

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -242,10 +242,7 @@ class JUser extends JObject
 		{
 			if (!$id = JUserHelper::getUserId($identifier))
 			{
-				JLog::add(JText::sprintf('JLIB_USER_ERROR_ID_NOT_EXISTS', $identifier), JLog::WARNING, 'jerror');
-				$retval = false;
-
-				return $retval;
+				return new JUser;
 			}
 		}
 		else

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -242,6 +242,8 @@ class JUser extends JObject
 		{
 			if (!$id = JUserHelper::getUserId($identifier))
 			{
+				// If the $identifier is zero, just return an empty JUser.
+				// Note: don't cache this user because it'll have a new ID on save!
 				return new JUser;
 			}
 		}


### PR DESCRIPTION
I'm following (with a slight tweak of the foreach statement) example 2 of the JFactory::getUser() docs page here (http://docs.joomla.org/JFactory/getUser)

```
$users[0]='admin';    //Some user that exists
$users[1]='joeblogs';  // Some user that doesn't exist
foreach($users as $name) {
        $user =& JFactory::getUser( $name );
    if ($user->id == 0) {
            echo 'There is no user '.$name.' registered on this site.';
    } else {
        echo 'User name: ' . $user->username;
        echo 'Real name: ' . $user->name;
        echo 'User ID : ' . $user->id; 
    }
}
```

Now the docs state when searching for a user that "information about a specific user, with username 'joebloggs', is displayed, regardless of the status of the current user."

So when you run this when logged out you find you get "There is no user admin registered on this site.There is no user joeblogs registered on this site." whereas you actually should see admin does exist as a user. And if you are logged in then you find a JLog (or whatever its called now) is thrown for the joebloggs user of "JUser: :_load: User joeblogs does not exist" and a php warning is also thrown that the line "if ($user->id == 0) {" is "Trying to get property of non-object". And the admin properties display as expected.

This JLog is thrown on line 245 of libraries/joomla/user/user.php : "               JLog::add(JText::sprintf('JLIB_USER_ERROR_ID_NOT_EXISTS', $identifier), JLog::WARNING, 'jerror');" in joomla 3.0 (this may have changed since I guess).

Now this is definitely NOT the behavior documented and this needs to be resolved. Personally I prefer the documented behavior (although i guess that's open to you guys).

I'll try and work some commits into this over the next few days to try and swap the behavior back to that expected in the docs - post if you have any better ideas though.
