### PR TITLE
Add Union All to JDatabaseQuery

### DIFF
--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -270,6 +270,12 @@ abstract class JDatabaseQuery
 	protected $union = null;
 
 	/**
+	 * @var    JDatabaseQueryElement  The unionAll element.
+	 * @since  13.1
+	 */
+	protected $unionAll = null;
+
+	/**
 	 * Magic method to provide method alias support for quote() and quoteName().
 	 *
 	 * @param   string  $method  The called method.
@@ -374,6 +380,10 @@ abstract class JDatabaseQuery
 			case 'union':
 				$query .= (string) $this->union;
 				break;
+
+			case 'unionAll':
+					$query .= (string) $this->unionAll;
+					break;
 
 			case 'delete':
 				$query .= (string) $this->delete;
@@ -638,6 +648,10 @@ abstract class JDatabaseQuery
 				$this->union = null;
 				break;
 
+			case 'unionAll':
+				$this->unionAll = null;
+				break;
+
 			default:
 				$this->type = null;
 				$this->select = null;
@@ -657,6 +671,7 @@ abstract class JDatabaseQuery
 				$this->exec = null;
 				$this->call = null;
 				$this->union = null;
+				$this->unionAll = null;
 				$this->offset = 0;
 				$this->limit = 0;
 				break;
@@ -1777,5 +1792,43 @@ abstract class JDatabaseQuery
 	public function dateAdd($date, $interval, $datePart)
 	{
 		return trim("DATE_ADD('" . $date . "', INTERVAL " . $interval . ' ' . $datePart . ')');
+	}
+
+	/**
+	 * Add a query to UNION ALL with the current query.
+	 * Multiple unions each require separate statements and create an array of unions.
+	 *
+	 * Usage:
+	 * $query->union('SELECT name FROM  #__foo')
+	 * $query->union('SELECT name FROM  #__foo','distinct')
+	 * $query->union(array('SELECT name FROM  #__foo','SELECT name FROM  #__bar'))
+	 *
+	 * @param   mixed    $query     The JDatabaseQuery object or string to union.
+	 * @param   boolean  $distinct  True to only return distinct rows from the union.
+	 * @param   string   $glue      The glue by which to join the conditions.
+	 *
+	 * @return  mixed    The JDatabaseQuery object on success or boolean false on failure.
+	 *
+	 * @since   13.1
+	 */
+	public function unionAll($query, $distinct = false, $glue = '')
+	{
+			$glue = ')' . PHP_EOL . 'UNION ALL (';
+			$name = 'UNION ALL ()';
+
+		// Get the JDatabaseQueryElement if it does not exist
+		if (is_null($this->unionAll))
+		{
+			$this->unionAll = new JDatabaseQueryElement($name, $query, "$glue");
+		}
+
+		// Otherwise append the second UNION.
+		else
+		{
+			$glue = '';
+			$this->unionAll->append($query);
+		}
+
+		return $this;
 	}
 }

--- a/tests/suites/unit/joomla/database/JDatabaseQueryTest.php
+++ b/tests/suites/unit/joomla/database/JDatabaseQueryTest.php
@@ -346,6 +346,22 @@ class JDatabaseQueryTest extends TestCase
 	}
 
 	/**
+	 * Tests the unionAll element of __toString.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JDatabaseQuery::__toString
+	 * @since   13.1
+	 */
+	public function test__toStringUnionAll()
+	{
+		$this->markTestIncomplete('This test does not work!');
+		$this->_instance->select('*')
+		->unionAll('SELECT id FROM a');
+
+		$this->assertEquals("UNION ALL (SELECT id FROM a)", trim($this->_instance));
+	}
+	/**
 	 * Tests the JDatabaseQuery::call method.
 	 *
 	 * @return  void
@@ -442,6 +458,7 @@ class JDatabaseQueryTest extends TestCase
 			'columns',
 			'values',
 			'union',
+			'unionAll',
 			'exec',
 			'call',
 		);
@@ -492,6 +509,7 @@ class JDatabaseQueryTest extends TestCase
 			'columns',
 			'values',
 			'union',
+			'unionAll',
 			'exec',
 			'call',
 		);
@@ -547,6 +565,7 @@ class JDatabaseQueryTest extends TestCase
 			'update',
 			'insert',
 			'union',
+			'unionAll',
 		);
 
 		$clauses = array(
@@ -1870,6 +1889,67 @@ class JDatabaseQueryTest extends TestCase
 		$this->assertThat(
 				$this->_instance->dateAdd($date, $interval, $datePart),
 				$this->equalTo($expected)
+		);
+	}
+
+	/*
+	 * Tests the JDatabaseQuery::unionAll method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JDatabaseQuery::unionAll
+	 * @since   13.1
+	 */
+	public function testUnionAllUnion()
+	{
+		$this->_instance->unionAll = null;
+		$this->_instance->unionAll('SELECT name FROM foo');
+		$teststring = (string) $this->_instance->unionAll;
+		$this->assertThat(
+				$teststring,
+				$this->equalTo(PHP_EOL . "UNION ALL (SELECT name FROM foo)"),
+				'Tests rendered query with unionAll.'
+		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::unionAll method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JDatabaseQuery::unionAll
+	 * @since   13.1
+	 */
+	public function testUnionAllArray()
+	{
+		$this->_instance->unionAll = null;
+		$this->_instance->unionAll(array('SELECT name FROM foo', 'SELECT name FROM bar'));
+		$teststring = (string) $this->_instance->unionAll;
+		$this->assertThat(
+				$teststring,
+				$this->equalTo(PHP_EOL . "UNION ALL (SELECT name FROM foo)" . PHP_EOL . "UNION ALL (SELECT name FROM bar)"),
+				'Tests rendered query with two union alls as an array.'
+		);
+	}
+
+	/**
+	 * Tests the JDatabaseQuery::unionAll method.
+	 *
+	 * @return  void
+	 *
+	 * @covers  JDatabaseQuery::unionAll
+	 * @since   13.1
+	 */
+	public function testUnionAllTwo()
+	{
+		$this->_instance->unionAll = null;
+		$this->_instance->unionAll('SELECT name FROM foo');
+		$this->_instance->unionAll('SELECT name FROM bar');
+		$teststring = (string) $this->_instance->unionAll;
+		$this->assertThat(
+				$teststring,
+				$this->equalTo(PHP_EOL . "UNION ALL (SELECT name FROM foo)" . PHP_EOL . "UNION ALL (SELECT name FROM bar)"),
+				'Tests rendered query with two union alls sequentially.'
 		);
 	}
 }


### PR DESCRIPTION
UNION ALL can in the right circumstances have a substantial performance benefit over UNION because it eliminates the sort used to find duplicate rows.. 
