### PR TITLE
Allow Web application router to return controller output.

### DIFF
--- a/libraries/joomla/application/web/router.php
+++ b/libraries/joomla/application/web/router.php
@@ -62,7 +62,7 @@ abstract class JApplicationWebRouter
 	 *
 	 * @param   string  $route  The route string for which to find and execute a controller.
 	 *
-	 * @return  mixed   Controller output
+	 * @return  mixed   The return value of the controller executed
 	 *
 	 * @since   12.2
 	 * @throws  InvalidArgumentException

--- a/libraries/joomla/application/web/router.php
+++ b/libraries/joomla/application/web/router.php
@@ -62,7 +62,7 @@ abstract class JApplicationWebRouter
 	 *
 	 * @param   string  $route  The route string for which to find and execute a controller.
 	 *
-	 * @return  void
+	 * @return  mixed   Controller output
 	 *
 	 * @since   12.2
 	 * @throws  InvalidArgumentException
@@ -77,7 +77,7 @@ abstract class JApplicationWebRouter
 		$controller = $this->fetchController($name);
 
 		// Execute the controller.
-		$controller->execute();
+		return $controller->execute();
 	}
 
 	/**


### PR DESCRIPTION
Since [new generic Router](https://github.com/joomla/joomla-platform/pull/1259) has a functionality of a dispatcher (executing controllers), it's handy to pass controller output further to caller (Application), especially when it's JApplicationWeb. It's easy to to override this method in own JApplication instance, but IMHO this gives a hint how to use new MVC.
