### PR TITLE
Fixed issue with open basedir on windows

### DIFF
--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -246,7 +246,7 @@ abstract class JFolder
 				{
 					$test = JPath::clean($test);
 
-					if (strpos($path, $test) === 0)
+					if (strpos(strtolower($path), strtolower($test)) === 0)
 					{
 						$inBaseDir = true;
 						break;


### PR DESCRIPTION
When Joomla tries to create a directory or file, it checks whether the path is in the "open basedir" of PHP when this is active.
The path checking is done in a case sensitive way. However on Windows, paths are NOT case sensitive.

Thus lets say my open basedir is:

E:\sample\DIR\

and Joomla thinks my directory is

E:\sample\dir\

The check will fail (even though the directory is perfectly writeable).

Not to mention that this check seems quite overkill since any subdirectory of the website is always within the open basedir path. Also this can be handled on file creation instead of checking this manually.

This error prevents users from saving their settings so it is best fixed as soon as possible.
Attached code makes the checking case insensitive
