### PR TITLE
Fix warning `sprintf(): Too few arguments` (JMail)

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -82,7 +82,7 @@ class JMail extends PHPMailer
 			}
 			else
 			{
-				throw new RuntimeException(sprintf('%s::Send mail not enabled.'), get_class($this));
+				throw new RuntimeException(sprintf('%s::Send mail not enabled.', get_class($this)));
 			}
 		}
 
@@ -96,7 +96,7 @@ class JMail extends PHPMailer
 			}
 			else
 			{
-				throw new RuntimeException(sprintf('%s::Send failed: "%s".'), get_class($this), $this->ErrorInfo);
+				throw new RuntimeException(sprintf('%s::Send failed: "%s".', get_class($this), $this->ErrorInfo));
 			}
 		}
 


### PR DESCRIPTION
Arguments are assigned to RuntimeException constructor instead of sprintf

``` HTML
<br />
<b>Warning</b>:  sprintf() [<a href='function.sprintf'>function.sprintf</a>]: Too few arguments in <b>*\libraries\joomla\mail\mail.php</b> on line <b>99</b><br />
<br />
<b>Fatal error</b>:  Wrong parameters for Exception([string $exception [, long $code [, Exception $previous = NULL]]]) in <b>*\libraries\joomla\mail\mail.php</b> on line <b>99</b><br />
```
