### PR TITLE
Joomla CMS [#29922] Detect Chrome for iOS in browser.php

### DIFF
--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -256,6 +256,11 @@ class JBrowser
 				$this->setBrowser('chrome');
 				list ($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
 			}
+			elseif (preg_match('|CriOS[/ ]([0-9.]+)|', $this->agent, $version))
+			{
+				$this->setBrowser('chrome');
+				list ($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
+			}
 			elseif (strpos($this->lowerAgent, 'elaine/') !== false
 				|| strpos($this->lowerAgent, 'palmsource') !== false
 				|| strpos($this->lowerAgent, 'digital paths') !== false)


### PR DESCRIPTION
Fixes tracker item:
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_id=8103&tracker_item_id=29922

Simular (CriOS) to a previous fix for Chrome for Android (CrMo):
http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=28039

An alternative approach is to put Chrome|CrMo|CriOS in the rame regexp... I prefer to keep them apart though - some redundant code, but better readability.
