### PR TITLE
[fix] findmanifest should prioritize main folder manifests

### DIFF
--- a/libraries/legacy/installer/installer.php
+++ b/libraries/legacy/installer/installer.php
@@ -1836,8 +1836,14 @@ class JInstaller extends JAdapter
 	 */
 	public function findManifest()
 	{
-		// Get an array of all the XML files from the installation directory
-		$xmlfiles = JFolder::files($this->getPath('source'), '.xml$', 1, true);
+		// Main folder manifests (higher priority)
+		$parentXmlfiles = JFolder::files($this->getPath('source'), '.xml$', false, true);
+
+		// Search for children manifests (lower priority)
+		$allXmlFiles    = JFolder::files($this->getPath('source'), '.xml$', 1, true);
+
+		// Create an unique array of files ordered by priority
+		$xmlfiles = array_unique(array_merge($parentXmlfiles, $allXmlFiles));
 
 		// If at least one XML file exists
 		if (!empty($xmlfiles))


### PR DESCRIPTION
Actually the findManifest function looks for manifests in the parent folder and in first level subfolders. 

This example structure:

->fof
--->fof.xml
-libraries
-manifies.xml

Will return the fof.xml manifiest.

This fix ensures that the function prioritises the main folder manifiests. I would like to remove the subfolder check but kept it for B/C reasons.
