### PR TITLE
Stop JTable from giving up too early

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -218,22 +218,19 @@ abstract class JTable extends JObject
 		if (!class_exists($tableClass))
 		{
 			// Search for the class file in the JTable include paths.
-			$path = JPath::find(self::addIncludePath(), strtolower($type) . '.php');
+			jimport('joomla.filesystem.path');
 
-			if ($path)
+			$paths = JTable::addIncludePath();
+			$pathIndex = 0;
+			while (!class_exists($tableClass) && $pathIndex < count($paths))
 			{
-				// Import the class file.
-				include_once $path;
-
-				// If we were unable to load the proper class, raise a warning and return false.
-				if (!class_exists($tableClass))
+				if ($tryThis = JPath::find($paths[$pathIndex++], strtolower($type) . '.php'))
 				{
-					JLog::add(JText::sprintf('JLIB_DATABASE_ERROR_CLASS_NOT_FOUND_IN_FILE', $tableClass), JLog::WARNING, 'jerror');
-
-					return false;
+					// Import the class file.
+					include_once $tryThis;
 				}
 			}
-			else
+			if (!class_exists($tableClass))
 			{
 				// If we were unable to find the class file in the JTable include paths, raise a warning and return false.
 				JLog::add(JText::sprintf('JLIB_DATABASE_ERROR_NOT_SUPPORTED_FILE_NOT_FOUND', $type), JLog::WARNING, 'jerror');


### PR DESCRIPTION
JTable wasn't finding a class because it was in a file with the same name as a file encountered earlier in the include chain. This change enables JTable to keep looking, instead of giving up after the first matching file.

This one is worth discussing, I think. I can see an argument for keeping it as it was, but this is a case of "scratching my own itch." I have to work with an extension that creates just this situation -- it's in the includePath ahead of a Joomla class with the same file name (not the same class name).

The actual problem originates with JPath::find, but I think fixing it there would have much wider repercussions for b/c than this change will. Perhaps it would be the best idea to start moving towards that solution, putting this one in place to fix existing problems until there is time to smoothly integrate the other change into the system. 

The change moves the loop into JTable, and just uses JPath for the proofing. (Maybe that should be pulled in to here to? I just wanted to minimize what I was changing, not arguing this is the ultimately best way.) Every successful result should be unaffected by this change, but some rare unsuccessful ones will now be successful.

Not sure if this change even causes a b/c issue, because it shouldn't break any successful code, and it's hard for me to understand why the older unsuccessful result should be preferred. It certainly causes a change, very minor but a change, in the behavior of the actual API while not affecting the API description at all.
