### PR TITLE
Fixing joomla/joomla-platform#1279

### DIFF
--- a/libraries/joomla/registry/registry.php
+++ b/libraries/joomla/registry/registry.php
@@ -335,8 +335,14 @@ class JRegistry implements JsonSerializable
 	{
 		$result = null;
 
-		// Explode the registry path into an array
-		if ($nodes = explode('.', $path))
+		/**
+		 * Explode the registry path into an array and remove empty
+		 * nodes caused by passing in double dotted strings. ex: joomla..test.
+		 * Finally, re-key the array so it is sequential.
+		 */
+		$nodes = array_values(array_filter(explode('.', $path), 'strlen'));
+
+		if ($nodes)
 		{
 			// Initialize the current node to be the registry root.
 			$node = $this->data;


### PR DESCRIPTION
This fixes the fatal error that would occur when passing in a double dotted string to `JRegistry::set($path, $value)` by filtering the nodes, removing empty ones, and they re-keying the array. 

This has already been applied to the Framework.
