### PR TITLE
Fix several bugs in parseArguments and add test suite

### DIFF
--- a/libraries/joomla/input/cli.php
+++ b/libraries/joomla/input/cli.php
@@ -110,6 +110,8 @@ class JInputCLI extends JInput
 	/**
 	 * Initialise the options and arguments
 	 *
+	 * Not supported: -abc c-value
+	 *
 	 * @return  void
 	 *
 	 * @since   11.1
@@ -118,7 +120,9 @@ class JInputCLI extends JInput
     {
         $argv                           = $_SERVER['argv'];
 
-		$this->executable = array_shift($argv);
+        $this->executable = array_shift($argv);
+
+        $out                            = array();
 
         for ($i = 0, $j = count($argv); $i < $j; $i++)
         {
@@ -177,8 +181,8 @@ class JInputCLI extends JInput
                         $out[$key]      = $value;
                     }
 
-                    // -a value1 -abc value2
-                    if ($i + 1 < $j && $argv[$i + 1][0] !== '-')
+                    // -a a-value
+                    if ((count($chars) === 1) && ($i + 1 < $j) && ($argv[$i + 1][0] !== '-'))
                     {
                         $out[$key]      = $argv[$i + 1];
                         $i++;
@@ -189,8 +193,7 @@ class JInputCLI extends JInput
             // plain-arg
             else
             {
-                $value                  = $arg;
-                $out[]                  = $value;
+                $this->args[]           = $arg;
             }
         }
 

--- a/libraries/joomla/input/cli.php
+++ b/libraries/joomla/input/cli.php
@@ -114,78 +114,86 @@ class JInputCLI extends JInput
 	 *
 	 * @since   11.1
 	 */
-	protected function parseArguments()
-	{
-		// Get the list of argument values from the environment.
-		$args = $_SERVER['argv'];
+    protected function parseArguments()
+    {
+        $argv                           = $_SERVER['argv'];
 
-		// Set the path used for program execution and remove it form the program arguments.
-		$this->executable = array_shift($args);
+		$this->executable = array_shift($argv);
 
-		// We use a for loop because in some cases we need to look ahead.
-		for ($i = 0; $i < count($args); $i++)
-		{
-			// Get the current argument to analyze.
-			$arg = $args[$i];
+        for ($i = 0, $j = count($argv); $i < $j; $i++)
+        {
+            $arg                        = $argv[$i];
 
-			// First let's tackle the long argument case.  eg. --foo
-			if (strlen($arg) > 2 && substr($arg, 0, 2) == '--')
-			{
+            // --foo --bar=baz
+            if (substr($arg, 0, 2) === '--')
+            {
+                $eqPos                  = strpos($arg, '=');
 
-				// Attempt to split the thing over equals so we can get the key/value pair if an = was used.
-				$arg = substr($arg, 2);
-				$parts = explode('=', $arg);
-				$this->data[$parts[0]] = true;
+                // --foo
+                if ($eqPos === false)
+                {
+                    $key                = substr($arg, 2);
 
-				// Does not have an =, so let's look ahead to the next argument for the value.
-				if (count($parts) == 1 && isset($args[$i + 1]) && preg_match('/^--?.+/', $args[$i + 1]) == 0)
-				{
-					$this->data[$parts[0]] = $args[$i + 1];
+                    // --foo value
+                    if ($i + 1 < $j && $argv[$i + 1][0] !== '-')
+                    {
+                        $value          = $argv[$i + 1];
+                        $i++;
+                    }
+                    else
+                    {
+                        $value          = isset($out[$key]) ? $out[$key] : true;
+                    }
+                    $out[$key]          = $value;
+                }
 
-					// Since we used the next argument, increment the counter so we don't use it again.
-					$i++;
-				}
-				// We have an equals sign so take the second "part" of the argument as the value.
-				elseif (count($parts) == 2)
-				{
-					$this->data[$parts[0]] = $parts[1];
-				}
-			}
+                // --bar=baz
+                else
+                {
+                    $key                = substr($arg, 2, $eqPos - 2);
+                    $value              = substr($arg, $eqPos + 1);
+                    $out[$key]          = $value;
+                }
+            }
 
-			// Next let's see if we are dealing with a "bunch" of short arguments.  eg. -abc
-			elseif (strlen($arg) > 2 && $arg[0] == '-')
-			{
+            // -k=value -abc
+            else if (substr($arg, 0, 1) === '-')
+            {
+                // -k=value
+                if (substr($arg, 2, 1) === '=')
+                {
+                    $key                = substr($arg, 1, 1);
+                    $value              = substr($arg, 3);
+                    $out[$key]          = $value;
+                }
+                // -abc
+                else
+                {
+                    $chars              = str_split(substr($arg, 1));
+                    foreach ($chars as $char)
+                    {
+                        $key            = $char;
+                        $value          = isset($out[$key]) ? $out[$key] : true;
+                        $out[$key]      = $value;
+                    }
 
-				// For each of these arguments set the value to TRUE since the flag has been set.
-				for ($j = 1; $j < strlen($arg); $j++)
-				{
-					$this->data[$arg[$j]] = true;
-				}
-			}
+                    // -a value1 -abc value2
+                    if ($i + 1 < $j && $argv[$i + 1][0] !== '-')
+                    {
+                        $out[$key]      = $argv[$i + 1];
+                        $i++;
+                    }
+                }
+            }
 
-			// OK, so it isn't a long argument or bunch of short ones, so let's look and see if it is a single
-			// short argument.  eg. -h
-			elseif (strlen($arg) == 2 && $arg[0] == '-')
-			{
+            // plain-arg
+            else
+            {
+                $value                  = $arg;
+                $out[]                  = $value;
+            }
+        }
 
-				// Go ahead and set the value to TRUE and if we find a value later we'll overwrite it.
-				$this->data[$arg[1]] = true;
-
-				// Let's look ahead to see if the next argument is a "value".  If it is, use it for this value.
-				if (isset($args[$i + 1]) && preg_match('/^--?.+/', $args[$i + 1]) == 0)
-				{
-					$this->data[$arg[1]] = $args[$i + 1];
-
-					// Since we used the next argument, increment the counter so we don't use it again.
-					$i++;
-				}
-			}
-
-			// Last but not least, we don't have a key/value based argument so just add it to the arguments list.
-			else
-			{
-				$this->args[] = $arg;
-			}
-		}
-	}
+        $this->data                     = $out;
+    }
 }

--- a/tests/suites/unit/joomla/input/JInputCLITest.php
+++ b/tests/suites/unit/joomla/input/JInputCLITest.php
@@ -34,6 +34,128 @@ class JInputCLITest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Test the JInput::parseArguments method.
+	 *
+	 * @dataProvider provider_parseArguments
+	 */
+	public function test_parseArguments($inputArgv, $expectedData, $expectedArgs)
+	{
+		$_SERVER['argv'] = $inputArgv;
+		$this->inspector = new JInputCLIInspector(null, array('filter' => new JFilterInputMock));
+
+		$this->assertThat(
+			$this->inspector->data,
+			$this->identicalTo($expectedData)
+		);
+
+		$this->assertThat(
+			$this->inspector->args,
+			$this->identicalTo($expectedArgs)
+		);
+	}
+
+	/**
+	 * Test inputs:
+	 *
+	 * php test.php --foo --bar=baz
+	 * php test.php -abc
+	 * php test.php arg1 arg2 arg3
+	 * php test.php plain-arg --foo --bar=baz --funny="spam=eggs" --also-funny=spam=eggs \
+	 *     'plain arg 2' -abc -k=value "plain arg 3" --s="original" --s='overwrite' --s
+	 * php test.php --key value -abc not-c-value
+	 * php test.php --key1 value1 -a --key2 -b b-value --c
+	 *
+	 * Note that this pattern is not supported: -abc c-value
+	 */
+	public function provider_parseArguments()
+	{
+		return array(
+
+			// php test.php --foo --bar=baz
+			array(
+				array('test.php', '--foo', '--bar=baz'),
+				array(
+					'foo' => true,
+					'bar' => 'baz'
+				),
+				array()
+			),
+
+			// php test.php -abc
+			array(
+				array('test.php', '-abc'),
+				array(
+					'a' => true,
+					'b' => true,
+					'c' => true
+				),
+				array()
+			),
+
+			// php test.php arg1 arg2 arg3
+			array(
+				array('test.php', 'arg1', 'arg2', 'arg3'),
+				array(),
+				array(
+					'arg1',
+					'arg2',
+					'arg3'
+				)
+			),
+
+			// php test.php plain-arg --foo --bar=baz --funny="spam=eggs" --also-funny=spam=eggs \
+			//      'plain arg 2' -abc -k=value "plain arg 3" --s="original" --s='overwrite' --s
+			array(
+				array('test.php', 'plain-arg', '--foo', '--bar=baz', '--funny=spam=eggs', '--also-funny=spam=eggs',
+					'plain arg 2', '-abc', '-k=value', 'plain arg 3', '--s=original', '--s=overwrite', '--s'),
+				array(
+					'foo' => true,
+					'bar' => 'baz',
+					'funny' => 'spam=eggs',
+					'also-funny' => 'spam=eggs',
+					'a' => true,
+					'b' => true,
+					'c' => true,
+					'k' => 'value',
+					's' => 'overwrite'
+				),
+				array(
+					'plain-arg',
+					'plain arg 2',
+					'plain arg 3'
+				)
+			),
+
+			// php test.php --key value -abc not-c-value
+			array(
+				array('test.php', '--key', 'value', '-abc', 'not-c-value'),
+				array(
+					'key' => 'value',
+					'a' => true,
+					'b' => true,
+					'c' => true
+				),
+				array(
+					'not-c-value'
+				)
+			),
+
+			// php test.php --key1 value1 -a --key2 -b b-value --c
+			array(
+				array('test.php', '--key1', 'value1', '-a', '--key2', '-b', 'b-value', '--c'),
+				array(
+					'key1' => 'value1',
+					'a' => true,
+					'key2' => true,
+					'b' => 'b-value',
+					'c' => true
+				),
+				array()
+			)
+		);
+	}
+
+	/**
 	 * Test the JInput::get method.
 	 *
 	 * @return void


### PR DESCRIPTION
The old code will fail these tests:

Expected: $data["funny"] === "spam=eggs"
Old result: isset($data["funny"]) === false

Expected: $data["s"] === "override"
Old result: $data["s"] === true

Expected: $data["key2"] === true && $data["b"] === true
Old result: $data["key2"] === "-b" && isset($data["b"]) === false
