### PR TITLE
Fixed an issue with JApplication redirecting to invalid URLs 

### DIFF
--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -390,7 +390,7 @@ class JApplication extends JApplicationBase
 		// so we will output a javascript redirect statement.
 		if (headers_sent())
 		{
-			echo "<script>document.location.href='" . htmlspecialchars($url) . "';</script>\n";
+			echo "<script>document.location.href='" . $url . "';</script>\n";
 		}
 		else
 		{

--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -390,7 +390,7 @@ class JApplication extends JApplicationBase
 		// so we will output a javascript redirect statement.
 		if (headers_sent())
 		{
-			echo "<script>document.location.href='" . $url . "';</script>\n";
+			echo "<script>document.location.href='" . str_replace("'","&apos;",$url) . "';</script>\n";
 		}
 		else
 		{
@@ -402,7 +402,7 @@ class JApplication extends JApplicationBase
 			{
 				// MSIE type browser and/or server cause issues when url contains utf8 character,so use a javascript redirect method
 				echo '<html><head><meta http-equiv="content-type" content="text/html; charset=' . $document->getCharset() . '" />'
-					. '<script>document.location.href=\'' . htmlspecialchars($url) . '\';</script></head></html>';
+					. '<script>document.location.href=\'' . str_replace("'","&apos;",$url) . '\';</script></head></html>';
 			}
 			else
 			{


### PR DESCRIPTION
When HTTP headers have already been sent, JApplication::redirect() falls back on a javascript redirect. However it's passing the URL through htmlspecialchars so any URL with and ampersand in the URI will be invalid.
