### PR TITLE
Check for the onUserAuthenticate function before calling it.

### DIFF
--- a/libraries/joomla/user/authentication.php
+++ b/libraries/joomla/user/authentication.php
@@ -271,16 +271,20 @@ class JAuthentication extends JObject
 		{
 			$className = 'plg' . $plugin->type . $plugin->name;
 
-			if (class_exists($className))
-			{
-				$plugin = new $className($this, (array) $plugin);
-			}
-			else
+			if (!class_exists($className))
 			{
 				// Bail here if the plugin can't be created
 				JLog::add(JText::sprintf('JLIB_USER_ERROR_AUTHENTICATION_FAILED_LOAD_PLUGIN', $className), JLog::WARNING, 'jerror');
 				continue;
 			}
+
+			if (!is_callable(array($className, 'onUserAuthenticate')))
+			{
+				// This plugin does not implement the onUserAuthenticate function.
+				continue;
+			}
+
+			$plugin = new $className($this, (array) $plugin);
 
 			// Try to authenticate
 			$plugin->onUserAuthenticate($credentials, $options, $response);


### PR DESCRIPTION
onUserAuthenticate is not called in the usual way that events get triggered (by the dispatcher) and, as such, it can cause a crash if you have an authentication plugin that doesn't implement the function. This patch fixes that.

You might think, "Why have an authentication plugin that doesn't handle authentication?" and the answer is that you might have one that only needs to handle authorization. As it is, if you write such a plugin, you would need to throw in an empty 'onUserAuthenticate' function in order to avoid a crash. 
