### PR TITLE
Fix to use sessions using file (default behaviour)

### DIFF
--- a/libraries/joomla/session/storage/none.php
+++ b/libraries/joomla/session/storage/none.php
@@ -19,5 +19,15 @@ defined('JPATH_PLATFORM') or die;
  */
 class JSessionStorageNone extends JSessionStorage
 {
-
+  /**
+   * Register the functions of this class with PHP's session handler
+	 *
+	 * @return  void
+	 *
+	 * @since   11.1
+	 */
+	public function register()
+	{
+		
+	}
 }


### PR DESCRIPTION
Removing the register() function makes file-mode for sessions not working, because the class falls back to JSessionStorage for the register() function, without providing read, write etc. methods.
If you want to use files to save session data, register() needs to exist so that default PHP session-to-file mechanism doesn't stop working.
