### PR TITLE
Form field type checkbox does not work - Proposed Fix

### DIFF
--- a/libraries/joomla/form/fields/checkbox.php
+++ b/libraries/joomla/form/fields/checkbox.php
@@ -58,7 +58,8 @@ class JFormFieldCheckbox extends JFormField
 		// Initialize JavaScript field attributes.
 		$onclick = $this->element['onclick'] ? ' onclick="' . (string) $this->element['onclick'] . '"' : '';
 
-		return '<input type="checkbox" name="' . $this->name . '" id="' . $this->id . '"' . ' value="'
+		return '<input type="hidden" name="' . $this->name . '" value="0" />'
+			. '<input type="checkbox" name="' . $this->name . '" id="' . $this->id . '"' . ' value="'
 			. htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"' . $class . $checked . $disabled . $onclick . $required . ' />';
 	}
 }


### PR DESCRIPTION
I tried to put checkbox form fields into my custom component using xml forms. In my fieldset there is included: 

&lt;field
    name="named_checkbox"
    type="checkbox"
    label="COM_COMPONENT_CHECKBOX_LABEL"
    description="COM_COMPONENT_CHECKBOX_DESC"
    class="inputbox"
    value="1"
    default="0"  
/&gt;

The checkbox saves fine when it is checked. However when I try to uncheck the checkbox, it does not update the database. After this change any checkbox form element should save value 0 when the checkbox is unchecked.
