### PR TITLE
Add brackets for database name in sqlsrv driver when selecting 

### DIFF
--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -139,7 +139,8 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		// If auto-select is enabled select the given database.
 		if ($this->options['select'] && !empty($this->options['database']))
 		{
-			$this->select($this->options['database']);
+			// Database name needs to be wrapped in [] to support any valid name.
+			$this->select($this->quoteName($this->options['database']));
 		}
 	}
 


### PR DESCRIPTION
Database names like 0_MyDatabase needs to be wrapped in [...], otherway the driver will throw an exception.
